### PR TITLE
Fix QownNotes installation error

### DIFF
--- a/programs/x86_64/qownnotes
+++ b/programs/x86_64/qownnotes
@@ -15,7 +15,7 @@ chmod a+x /opt/$APP/remove
 mkdir tmp
 cd ./tmp
 
-echo https://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/AppImage/QOwnNotes-latest-x86_64.AppImage
+wget https://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/AppImage/QOwnNotes-latest-x86_64.AppImage
 
 cd ..
 mv ./tmp/*mage ./$APP

--- a/programs/x86_64/qownnotes
+++ b/programs/x86_64/qownnotes
@@ -1,47 +1,62 @@
 #!/bin/sh
 
 APP=qownnotes
+REPO="pbek/QOwnNotes"
 
 # CREATE THE FOLDER
-mkdir /opt/$APP
+mkdir -p /opt/$APP
 cd /opt/$APP
 
 # ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
+echo '#!/bin/sh' > /opt/$APP/remove
 echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
-mkdir tmp
-cd ./tmp
+mkdir -p tmp
+cd tmp
 
-wget https://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/AppImage/QOwnNotes-latest-x86_64.AppImage
-
+version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
+wget $version
+echo "$version" > /opt/$APP/version
 cd ..
 mv ./tmp/*mage ./$APP
 chmod a+x /opt/$APP/$APP
-echo "appimage" >> /opt/$APP/version
-
-cd ./tmp
-wget https://github.com/AppImage/AppImageUpdate/releases/download/continuous/appimageupdatetool-x86_64.AppImage 2> /dev/null
-cd ..
-mv ./tmp/appimageupdatetool-x86_64.AppImage ./updater
-chmod a+x ./updater
+rm -r ./tmp
 
 # LINK
 ln -s /opt/$APP/$APP /usr/local/bin/$APP
 
-# SCRIPT TO UPDATE
-echo '#!/bin/sh
-APP='$APP'
-cd /opt/$APP
-./updater -O ./$APP
-chmod a+x /opt/$APP/$APP
-rm -R -f /opt/$APP/*zs-old && rm -R -f /opt/$APP/*.part' >> /opt/$APP/AM-updater
+# SCRIPT TO UPDATE THE PROGRAM
+cat > /opt/$APP/AM-updater << 'EOF'
+#!/usr/bin/env bash
+APP=qownnotes
+REPO="pbek/QOwnNotes"
+version0=$(cat /opt/$APP/version)
+version=$(wget -q https://api.github.com/repos/$REPO/releases -O - | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
+if [ $version = $version0 ]; then
+  echo "Update not needed!"
+else
+  notify-send "A new version of $APP is available, please wait"
+  mkdir -p /opt/$APP/tmp
+  cd /opt/$APP/tmp
+  wget $version
+  if ls . | grep mage; then
+	cd ..
+  	if test -f ./tmp/*mage; then rm ./version
+  	fi
+  	echo $version > ./version
+  	mv --backup=t ./tmp/*mage ./$APP
+  	chmod a+x /opt/$APP/$APP
+  	rm -R -f ./tmp ./*~
+  fi
+  notify-send "$APP is updated!"
+fi
+EOF
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
+app="QOwnNotes"
 cd /opt/$APP
 ./$APP --appimage-extract *.desktop 1>/dev/null
 ./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
@@ -57,7 +72,7 @@ if [ ! -e ./$APP.desktop ]; then
 	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
 	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
 fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep $app | head -1)
+CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep -i $app | head -1)
 sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
 sed -i "s#AppRun#$APP#g" ./$APP.desktop
 sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
@@ -65,7 +80,7 @@ sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
 CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
 sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
 
-mkdir icons
+mkdir -p icons
 mv $(./$APP --appimage-extract *.png) ./icons/$APP 2>/dev/null
 mv $(./$APP --appimage-extract *.svg) ./icons/$APP 2>/dev/null
 ./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
@@ -92,7 +107,7 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop 2> /dev/null
+mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')
@@ -100,7 +115,6 @@ chown -R $currentuser /opt/$APP
 
 # MESSAGE
 echo "
-
-	$APP is provided by https://www.qownnotes.org
-
+ $APP is provided by https://github.com/$(echo $REPO | sed 's:/[^/]*$::')
+ script Author https://github.com/nazdridoy
 "


### PR DESCRIPTION
Fixes the installation error that occurs when trying to install QownNotes. The error was caused by a broken download command (echo instade of wget). . Fixes #133 