### PR TITLE
Fix sed causes wrong substitution when local path contains `/opt`

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -103,7 +103,7 @@ while [ -n "$1" ]; do
 
 					function _install_appman_local_patch(){
 						sed -i "s# /opt# $APPSPATH#g" ./$arg
-						sed -i "s#/opt/#$APPSPATH/#g" ./$arg
+						sed -i "s#Icon=/opt/#Icon=$APPSPATH/#g" ./$arg
 						sed -i "s# /usr/local/bin# $(xdg-user-dir USER)/.local/bin#g" ./$arg
 						sed -i "s# /usr/bin# $(xdg-user-dir USER)/.local/bin#g" ./$arg
 						sed -i "s# /usr/local/games# $(xdg-user-dir USER)/.local/bin#g" ./$arg


### PR DESCRIPTION
My use case when local path contains `/opt` (`/home/username/opt/Applications'), it causes this sed command doing wrong.

I think `sed -i -E "s#([^_[:space:]])/opt/#\1$APPSPATH/#g" ./$arg` is more suitable, but I'm not sure 😅️