### PR TITLE
Add Naruto-Arena and Soul-Arena games to the installation scripts list

### DIFF
--- a/programs/x86_64/naruto-arena
+++ b/programs/x86_64/naruto-arena
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+APP=naruto-arena
+SITE="https://naruto-arena.app/"
+
+# CREATE THE FOLDER
+mkdir /opt/$APP
+cd /opt/$APP
+
+# ADD THE REMOVER
+echo '#!/bin/sh' >> /opt/$APP/remove
+echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+chmod a+x /opt/$APP/remove
+
+# DOWNLOAD THE ARCHIVE
+mkdir tmp
+cd ./tmp
+
+version=$(echo https://get.arena-game.app/lin64_na)
+wget $version
+echo "$version" >> /opt/$APP/version
+chmod a+x ./*
+cd ..
+mv --backup=t ./tmp/lin64_na ./naruto-arena
+rm -R -f ./tmp
+
+# LINK
+ln -s /opt/$APP/$APP /usr/local/bin/$APP
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> /opt/$APP/AM-updater << 'EOF'
+#!/usr/bin/env bash
+APP=naruto-arena
+version0=$(cat /opt/$APP/version)
+version=$(echo https://get.arena-game.app/lin64_na)
+if [ $version = $version0 ]; then
+	echo "Update not needed!"
+else
+	notify-send "A new version of $APP is available, please wait"
+	mkdir /opt/$APP/tmp
+	cd /opt/$APP/tmp
+	wget $version
+	chmod a+x ./*
+	cd ..
+	mv --backup=t ./tmp/lin64_na ./naruto-arena
+	rm ./version
+	echo $version >> ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+fi
+EOF
+chmod a+x /opt/$APP/AM-updater
+
+# ICON
+mkdir icons
+wget https://naruto-arena.app/assets/logo.png -O ./icons/$APP 2> /dev/null
+
+# LAUNCHER
+rm -f /usr/share/applications/AM-$APP.desktop
+echo "[Desktop Entry]
+Name=Naruto-Arena Next Generations
+Exec=$APP
+Icon=/opt/$APP/icons/$APP
+Type=Application
+Terminal=false
+Categories=Game;" >> /usr/share/applications/AM-$APP.desktop
+
+# CHANGE THE PERMISSIONS
+currentuser=$(who | awk '{print $1}')
+chown -R $currentuser /opt/$APP

--- a/programs/x86_64/soul-arena
+++ b/programs/x86_64/soul-arena
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+APP=soul-arena
+SITE="https://soul.arena-game.app/"
+
+# CREATE THE FOLDER
+mkdir /opt/$APP
+cd /opt/$APP
+
+# ADD THE REMOVER
+echo '#!/bin/sh' >> /opt/$APP/remove
+echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+chmod a+x /opt/$APP/remove
+
+# DOWNLOAD THE ARCHIVE
+mkdir tmp
+cd ./tmp
+
+version=$(echo https://get.arena-game.app/lin64_sa)
+wget $version
+echo "$version" >> /opt/$APP/version
+chmod a+x ./*
+cd ..
+mv --backup=t ./tmp/lin64_sa ./soul-arena
+rm -R -f ./tmp
+
+# LINK
+ln -s /opt/$APP/$APP /usr/local/bin/$APP
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> /opt/$APP/AM-updater << 'EOF'
+#!/usr/bin/env bash
+APP=soul-arena
+version0=$(cat /opt/$APP/version)
+version=$(echo https://get.arena-game.app/lin64_sa)
+if [ $version = $version0 ]; then
+	echo "Update not needed!"
+else
+	notify-send "A new version of $APP is available, please wait"
+	mkdir /opt/$APP/tmp
+	cd /opt/$APP/tmp
+	wget $version
+	chmod a+x ./*
+	cd ..
+	mv --backup=t ./tmp/lin64_sa ./soul-arena
+	rm ./version
+	echo $version >> ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+fi
+EOF
+chmod a+x /opt/$APP/AM-updater
+
+# ICON
+mkdir icons
+wget https://soul.arena-game.app/assets/logo.png -O ./icons/$APP 2> /dev/null
+
+# LAUNCHER
+rm -f /usr/share/applications/AM-$APP.desktop
+echo "[Desktop Entry]
+Name=Soul-Arena Next Generations
+Exec=$APP
+Icon=/opt/$APP/icons/$APP
+Type=Application
+Terminal=false
+Categories=Game;" >> /usr/share/applications/AM-$APP.desktop
+
+# CHANGE THE PERMISSIONS
+currentuser=$(who | awk '{print $1}')
+chown -R $currentuser /opt/$APP


### PR DESCRIPTION
# FEATURE: Addition of new installation script(s)

## Description

Add two new generic binary games - developed with [godot](https://godotengine.org/) engine - to the list of `am`/`appman` scripts. Below are the description of both, with reference to their respective proprietary website.

**[Naruto-Arena](https://naruto-arena.app/)** -  Naruto-based online multiplayer strategy game.

**[Soul-Arena](https://soul.arena-game.app/)** -  Bleach-based online multiplayer strategy game.

## Validation checklist

- [x] Test script(s) installation locally **[required]**
- [x] Check if desktop entry was added, and if it opens the application
- [x] Confirm the application version installed
- [x] Test the application usage

## Issues details

Need adjustments after running the `$ appman -t <game>` command:

- change line 24 of both scripts, in order to rename the binary downloaded to the game package name.

## Environment

> You can run the command: `$ hostnamectl`

- **Operation System**: Arch Linux
- **Kernel**: Linux 6.8.1-arch1-1
- **Architecture**: x86-64
