### PR TITLE
Make xdg-user-dirs an optional dependency

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 CLI=$(basename "$0")
 
-if ! command -v xdg-user-dir 1>/dev/null; then echo ' ⚠️ WARNING: "xdg-user-dir" command not found (required by modules)'; exit; fi
+SCRIPTDIR="$(if command -v xdg-user-dir &>/dev/null; then xdg-user-dir DESKTOP; else echo $HOME; fi)"
 
 # Check XDG variables
 if [ -n "$XDG_CONFIG_HOME" ]; then
@@ -221,9 +221,9 @@ function _no_sudo(){
 function _patch_bashrc_and_profile(){
 	# Check if the custom PATH is not already in .bashrc, then append it (fix - exclamation mark negates the entire command substitution)
 	if test -f "$HOME/.bashrc"; then
-		if ! grep -q 'export PATH=$PATH:$(xdg-user-dir USER)/.local/bin' "$HOME/.bashrc"; then
+		if ! grep -q 'export PATH=$PATH:$HOME/.local/bin' "$HOME/.bashrc"; then
 			echo 'export PATH=$(echo $PATH | tr ":" "\n" | grep -v "/.local/bin" | tr "\n" ":" | sed ''s/.$//'')' >> "$HOME/.bashrc"
-			echo -e 'export PATH=$PATH:$(xdg-user-dir USER)/.local/bin\n' >> "$HOME/.bashrc"
+			echo -e 'export PATH=$PATH:$HOME/.local/bin\n' >> "$HOME/.bashrc"
 		fi
 	fi
 	# Correct the order of .local/bin in .profile if necessary

--- a/README.md
+++ b/README.md
@@ -851,6 +851,8 @@ I could disappear at any moment, and I don't want this database to end up in the
 
 I wanted to build something long-lasting, and the application database must be too, and if managing it is a person who can suddenly disappear, then this project will be another of the many lost forever.
 
+# See the full guide at https://github.com/ivan-hc/neodb
+
 </details>
 
 ------------------------------------------------------------------------

--- a/modules/download.am
+++ b/modules/download.am
@@ -44,10 +44,10 @@ while [ -n "$1" ]; do
 
 				if curl --output /dev/null --silent --head --fail $APPSDB/$arg  1>/dev/null; then
 					echo ' ◆ "'$arg'" installation script downloaded! ' | tr a-z A-Z
-					cd "$(xdg-user-dir DESKTOP)" || return; wget -q $APPSDB/$arg;  _convert_to_appman_compatible_script; echo " --------------------------------------------------"
+					cd "$SCRIPTDIR" || return; wget -q $APPSDB/$arg;  _convert_to_appman_compatible_script; echo " --------------------------------------------------"
 				elif curl --output /dev/null --silent --head --fail $AMREPO/testing/$arch/$arg  1>/dev/null; then
 					echo ' ⚠️ "'$arg'" downloaded from "testing", the unstable branch ' | tr a-z A-Z; echo ""; echo ' WARNING! PROGRAMS COMING FROM "TESTING" ARE BROKEN, USE AT YOUR OWN RISK!'
-					cd "$(xdg-user-dir DESKTOP)" || return; wget -q $AMREPO/testing/$arch/$arg; _convert_to_appman_compatible_script; echo " --------------------------------------------------"
+					cd "$SCRIPTDIR" || return; wget -q $AMREPO/testing/$arch/$arg; _convert_to_appman_compatible_script; echo " --------------------------------------------------"
 				else
 					echo ' 💀 ERROR: "'$arg'" is NOT a valid argument'; echo ""
 				fi

--- a/modules/template.am
+++ b/modules/template.am
@@ -16,7 +16,7 @@ while [ -n "$1" ]; do
 			arg=$(echo "$arg" | tr A-Z a-z)
 			case $arg in
 			*) 
-				cd "$(xdg-user-dir DESKTOP)" || return
+				cd "$SCRIPTDIR" || return
 
 				echo "##############################################################"; echo ""
 				echo ' Create templates for "'$arg'"
@@ -149,7 +149,7 @@ while [ -n "$1" ]; do
 
 					echo "-----------------------------------------------------------------------"
 					# END OF THIS FUNCTION
-					echo -e "\n All files are saved in $(xdg-user-dir DESKTOP)/am-scripts\n";;
+					echo -e "\n All files are saved in $SCRIPTDIR/am-scripts\n";;
 
 				1) # CREATE AN APPIMAGE ON-THE-FLY
 
@@ -212,7 +212,7 @@ while [ -n "$1" ]; do
 					# CREATE A NEW LINE FOR THE APPLICATION'S LIST
 					echo '◆ '$arg' : '$COMMENT'' >> ./am-scripts/list; echo ""
 					# END OF THIS FUNCTION
-					echo -e "\n All files are saved in $(xdg-user-dir DESKTOP)/am-scripts\n";;
+					echo -e "\n All files are saved in $SCRIPTDIR/am-scripts\n";;
 
 				2) # DOWNLOAD ANY ARCHIVE
 
@@ -411,7 +411,7 @@ while [ -n "$1" ]; do
 
 					echo "-----------------------------------------------------------------------"
 					# END OF THIS FUNCTION
-					echo -e "\n All files are saved in $(xdg-user-dir DESKTOP)/am-scripts\n";;
+					echo -e "\n All files are saved in $SCRIPTDIR/am-scripts\n";;
 
 				3) # CREATE A CUSTOM FIREFOX PROFILE ("firefox" MUST BE IN "$PATH" TO MADE IT WORK)
 
@@ -472,7 +472,7 @@ while [ -n "$1" ]; do
 
 					echo "-----------------------------------------------------------------------"
 					# END OF THIS FUNCTION
-					echo -e "\n All files are saved in $(xdg-user-dir DESKTOP)/am-scripts\n";;
+					echo -e "\n All files are saved in $SCRIPTDIR/am-scripts\n";;
 
 				# NOTHING SELECTED
 				*) 


### PR DESCRIPTION
This changes make xdg-user-dirs an optional dependency. Tested it with the template module with and without `xdg-user-dir` and it worked like it should.

Introduces a new variable named `SCRIPTDIR` which if `xdg-user-dir` is present it gets set as `xdg-user-dir DESKTOP` and everything works like it used to.

If `xdg-user-dir` is not present then the variable gets defined as `$HOME` and the `template.am` module puts the am-scripts dir in `$HOME` instead for example.

(Sorry about the readme.md changing in this pr lol). 



