### PR TITLE
Add safety checks hyperfine

### DIFF
--- a/programs/x86_64/hyperfine
+++ b/programs/x86_64/hyperfine
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 APP=hyperfine
+if [ -z "$APP" ]; then exit 1; fi
 SITE="sharkdp/hyperfine"
 
 # CREATE THE FOLDER
@@ -9,7 +10,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -rf \"/opt/$APP\" \"/usr/local/bin/$APP\"" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE


### PR DESCRIPTION
`if [ -z "$APP" ]; then exit 1; fi` prevents the script from continuing if for whatever reason `$APP` were to be empty (this scenario would be somebody accidentally deleting it while changing the name of the application for example). This is important because later on, you will pipe an `rm -rf /usr/local/bin/$APP` to the `remove` script, if the script allows for an empty variable it will result in a remove script `rm -rf /usr/local/bin/` and that would be very bad. 

The other change: `echo "rm -rf \"/opt/$APP\" \"/usr/local/bin/$APP\"" >> /opt/$APP/remove` adds the quotations to the path for rm -rf, that way an accidental space in the `remove` script rm -rf doesn't result in catastrophic results either.

Btw Ivan get sed ready because I think this is something that needs to be done on every script, specially the check for the empty variable. 