### PR TITLE
Update database.am: clean lists and queries

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -29,6 +29,11 @@ function _completion_lists(){
 	cat $AMPATH/options >> $AMPATH/list
 }
 
+function _clean_lists_and_queries(){
+	# Remove references to URLs, "-a" elements and limit message length to a maximum of 80 characters in "-l" and "-q"
+	cut -c -81 | sed 's#http://[^ ]*##g' | sed 's#https://[^ ]*##g' | sed 's#ftp://[^ ]*##g' | sed 's/SITE://g' | sed 's/SOURCE://g'
+}
+
 case "$1" in
 
   '-a'|'about')
@@ -136,7 +141,7 @@ case "$1" in
 				_completion_lists
 			fi
 			MESSAGE=$(echo " YOU HAVE INSTALLED $APPSNUMBER APPLICATIONS OUT OF $(grep -e "$" -c $AMPATH/$arch-apps) AVAILABLE")
-			echo -e "\n$MESSAGE\n\n LIST OF THE $(grep -e "$" -c $AMPATH/$arch-apps) APPLICATIONS AVAILABLE IN THE 'AM' REPOSITORY:\n\n$(cat $AMPATH/$arch-apps | cut -c -81)\n" | less -I
+			echo -e "\n$MESSAGE\n\n LIST OF THE $(grep -e "$" -c $AMPATH/$arch-apps) APPLICATIONS AVAILABLE IN THE 'AM' REPOSITORY:\n\n$(cat $AMPATH/$arch-apps | _clean_lists_and_queries)\n" | less -I
 			echo -e "\n $MESSAGE\n"
 		}
 
@@ -146,7 +151,7 @@ case "$1" in
 				_completion_lists
 			fi
 			MESSAGE=$(echo " YOU HAVE INSTALLED $LIBNUMBER LIBRARIES OUT OF $(grep -e "$" -c $AMPATH/libs-list) AVAILABLE")
-			echo -e "\n$MESSAGE\n\n LIST OF THE $(grep -e "$" -c $AMPATH/libs-list) LIBRARIES AVAILABLE IN THE 'AM' REPOSITORY:\n\n$(cat $AMPATH/libs-list | cut -c -81)\n" | less -I
+			echo -e "\n$MESSAGE\n\n LIST OF THE $(grep -e "$" -c $AMPATH/libs-list) LIBRARIES AVAILABLE IN THE 'AM' REPOSITORY:\n\n$(cat $AMPATH/libs-list | _clean_lists_and_queries)\n" | less -I
 			echo -e "\n $MESSAGE\n"
 		}
 
@@ -171,8 +176,8 @@ case "$1" in
 	echo ""
 	echo ' Search results for "'$ARGS'":' | tr a-z A-Z
 	echo ""
-	grep -i -E "$2" $AMPATH/$arch-apps | grep -i -E "$3" | grep -i -E "$4" | grep -i -E "$5" | grep -i -E "$6" | grep -i -E "$7" | grep -i -E "$8" | grep -i -E "$9" | cut -c -81
-	grep -i -E "$2" $AMPATH/libs-list | grep -i -E "$3" | grep -i -E "$4" | grep -i -E "$5" | grep -i -E "$6" | grep -i -E "$7" | grep -i -E "$8" | grep -i -E "$9" | cut -c -81
+	grep -i -E "$2" "$AMPATH/$arch-apps" | grep -i -E "$3" | grep -i -E "$4" | grep -i -E "$5" | grep -i -E "$6" | grep -i -E "$7" | grep -i -E "$8" | grep -i -E "$9" | _clean_lists_and_queries
+	grep -i -E "$2" "$AMPATH/libs-list" | grep -i -E "$3" | grep -i -E "$4" | grep -i -E "$5" | grep -i -E "$6" | grep -i -E "$7" | grep -i -E "$8" | grep -i -E "$9" | _clean_lists_and_queries
 	echo ""
 	exit
 	;;


### PR DESCRIPTION
New function to remove references to URLs, "-a" elements and limit message length to a maximum of 80 characters in "-l" and "-q"