### PR TITLE
Add deadbeef-devel

### DIFF
--- a/programs/x86_64/deadbeef-devel
+++ b/programs/x86_64/deadbeef-devel
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+APP=deadbeef-devel
+SITE="https://deadbeef.sourceforge.io"
+
+# CREATE THE FOLDER
+mkdir /opt/$APP
+cd /opt/$APP
+
+# ADD THE REMOVER
+echo '#!/bin/sh' >> /opt/$APP/remove
+echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+chmod a+x /opt/$APP/remove
+
+# DOWNLOAD THE ARCHIVE
+mkdir tmp
+cd ./tmp
+
+version=$(wget -q https://sourceforge.net/projects/deadbeef/files/travis/linux/master/ -O - | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | sort -u | grep "x86_64.tar.bz2")
+wget $version -O download.tar.bz2
+echo "$version" >> /opt/$APP/version
+tar fx ./*tar*
+cd ..
+mv --backup=t ./tmp/*/* ./
+rm -R -f ./tmp
+
+# LINK
+ln -s /opt/$APP/deadbeef /usr/local/bin/deadbeef; ln -s /opt/$APP/deadbeef /usr/local/bin/$APP
+chmod a+x /usr/local/bin/$APP
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> /opt/$APP/AM-updater << 'EOF'
+#!/bin/sh
+APP=deadbeef-devel
+version0=$(cat /opt/$APP/version)
+version=$(wget -q https://sourceforge.net/projects/deadbeef/files/travis/linux/master/ -O - | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | sort -u | grep "x86_64.tar.bz2")
+if [ $version = $version0 ]; then
+	echo "deadbeef-devel is up to date!"
+else
+	notify-send "A new version of $APP is available, please wait"
+	mkdir /opt/$APP/tmp
+	cd /opt/$APP/tmp
+	wget $version -O download.tar.bz2
+  tar fx ./*tar*; rm -f -R ./*tar*
+	cd ..
+  mv --backup=t ./tmp/*/* ./
+	rm ./version
+	echo $version >> ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+fi
+EOF
+chmod a+x /opt/$APP/AM-updater
+
+# ICON
+mkdir icons
+ln -s /opt/$APP/deadbeef.png ./icons/$APP
+
+# LAUNCHER
+rm -f /usr/share/applications/AM-$APP.desktop
+echo "[Desktop Entry]
+Type=Application
+Name=DeaDBeeF
+Comment=devel build
+Exec=/opt/$APP/deadbeef %F
+Icon=/opt/$APP/icons/$APP
+GenericName[pt_BR]=Reprodutor de áudio
+GenericName[ru]=Аудио плеер
+GenericName[zh_CN]=音频播放器
+GenericName[zh_TW]=音樂播放器
+Comment=Listen to music
+Comment[pt_BR]=Escute músicas
+Comment[ru]=Слушай музыку
+Comment[zh_CN]=倾听音乐
+Comment[zh_TW]=聆聽音樂
+MimeType=application/ogg;audio/x-vorbis+ogg;application/x-ogg;audio/mp3;audio/prs.sid;audio/x-flac;audio/mpeg;audio/x-mpeg;audio/x-mod;audio/x-it;audio/x-s3m;audio/x-xm;audio/x-mpegurl;audio/x-scpls;application/x-cue;
+Categories=Audio;AudioVideo;Player;GTK;
+Keywords=Sound;Music;Audio;Player;Musicplayer;MP3;
+Terminal=false
+Categories=Audio;AudioVideo;Player;GTK;
+X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Next;Prev;
+X-PulseAudio-Properties=media.role=music
+
+[Desktop Action Play]
+Name=Play
+Name[zh_CN]=播放
+Name[zh_TW]=播放
+Exec=deadbeef --play
+
+[Desktop Action Pause]
+Name=Pause
+Name[zh_CN]=暂停
+Name[zh_TW]=暫停
+Exec=deadbeef --pause
+
+[Desktop Action Toggle-Pause]
+Name=Toggle Pause
+Name[zh_CN]=播放/暂停
+Name[zh_TW]=播放/暫停
+Exec=deadbeef --toggle-pause
+
+[Desktop Action Stop]
+Name=Stop
+Name[zh_TW]=停止
+Exec=deadbeef --stop
+
+[Desktop Action Next]
+Name=Next
+Name[zh_TW]=下一首
+Exec=deadbeef --next
+
+[Desktop Action Prev]
+Name=Prev
+Name[zh_TW]=上一首
+Exec=deadbeef --prev" >> /usr/share/applications/AM-$APP.desktop
+
+# CHANGE THE PERMISSIONS
+currentuser=$(who | awk '{print $1}')
+chown -R $currentuser /opt/$APP

--- a/programs/x86_64/deadbeef-devel
+++ b/programs/x86_64/deadbeef-devel
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/deadbeef" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -25,7 +25,7 @@ mv --backup=t ./tmp/*/* ./
 rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/deadbeef /usr/local/bin/deadbeef; ln -s /opt/$APP/deadbeef /usr/local/bin/$APP
+ln -s /opt/$APP/deadbeef /usr/local/bin/deadbeef; ln -s /opt/$APP/deadbeef /usr/local/bin/deadbeef
 chmod a+x /usr/local/bin/$APP
 
 # SCRIPT TO UPDATE THE PROGRAM

--- a/programs/x86_64/deadbeef-devel
+++ b/programs/x86_64/deadbeef-devel
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/deadbeef" >> /opt/$APP/remove
+echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -25,7 +25,7 @@ mv --backup=t ./tmp/*/* ./
 rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/deadbeef /usr/local/bin/deadbeef; ln -s /opt/$APP/deadbeef /usr/local/bin/deadbeef
+ln -s /opt/$APP/deadbeef /usr/local/bin/$APP
 chmod a+x /usr/local/bin/$APP
 
 # SCRIPT TO UPDATE THE PROGRAM
@@ -62,7 +62,7 @@ echo "[Desktop Entry]
 Type=Application
 Name=DeaDBeeF
 Comment=devel build
-Exec=/opt/$APP/deadbeef %F
+Exec=/opt/$APP/$APP %F
 Icon=/opt/$APP/icons/$APP
 GenericName[pt_BR]=Reprodutor de áudio
 GenericName[ru]=Аудио плеер
@@ -85,34 +85,34 @@ X-PulseAudio-Properties=media.role=music
 Name=Play
 Name[zh_CN]=播放
 Name[zh_TW]=播放
-Exec=deadbeef --play
+Exec=$APP --play
 
 [Desktop Action Pause]
 Name=Pause
 Name[zh_CN]=暂停
 Name[zh_TW]=暫停
-Exec=deadbeef --pause
+Exec=$APP --pause
 
 [Desktop Action Toggle-Pause]
 Name=Toggle Pause
 Name[zh_CN]=播放/暂停
 Name[zh_TW]=播放/暫停
-Exec=deadbeef --toggle-pause
+Exec=$APP --toggle-pause
 
 [Desktop Action Stop]
 Name=Stop
 Name[zh_TW]=停止
-Exec=deadbeef --stop
+Exec=$APP --stop
 
 [Desktop Action Next]
 Name=Next
 Name[zh_TW]=下一首
-Exec=deadbeef --next
+Exec=$APP --next
 
 [Desktop Action Prev]
 Name=Prev
 Name[zh_TW]=上一首
-Exec=deadbeef --prev" >> /usr/share/applications/AM-$APP.desktop
+Exec=$APP --prev" >> /usr/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')


### PR DESCRIPTION
Hey I don't know the rules about devel/nightly packages being here, so I just made a PR with one instead of asking xd. 

This adds the nightly build of deadbeef, it is released on the same package as the stable builds, made it because the stable releases of deadbeef move very slow. 

The way the #LINK is originally done for the stable deadbeef package made no sense to me, so I changed it for symlinks like other packages do, also expanded the desktop entry. 

Also I removed the original way to get the icon from a link since deadbeef already contains the icon in its directory and linked that instead.