### PR TITLE
Small fixes to deadbeef and deadbeef-devel

### DIFF
--- a/programs/x86_64/deadbeef
+++ b/programs/x86_64/deadbeef
@@ -25,7 +25,8 @@ mv --backup=t ./tmp/*/* ./
 rm -R -f ./tmp
 
 # LINK
-echo -e '#!/usr/bin/sh\n\nAPP='$APP'\n/opt/$APP/$APP "$@" ' >> /usr/local/bin/$APP; chmod a+x /usr/local/bin/$APP
+ln -s /opt/$APP/deadbeef /usr/local/bin/$APP
+chmod a+x /usr/local/bin/$APP
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> /opt/$APP/AM-updater << 'EOF'
@@ -51,19 +52,67 @@ fi
 EOF
 chmod a+x /opt/$APP/AM-updater
 
-# ICON
+# ICON (HIGHER QUALITY ICON)
 mkdir icons
 wget https://raw.githubusercontent.com/DeaDBeeF-Player/deadbeef/master/icons/scalable/deadbeef.svg -O ./icons/$APP 2> /dev/null
 
 # LAUNCHER
 rm -f /usr/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
-Name=DeaDBeeF
-Exec=/opt/$APP/$APP
-Icon=/opt/$APP/icons/$APP
 Type=Application
+Name=DeaDBeeF
+Exec=/opt/$APP/$APP %F
+Icon=/opt/$APP/icons/$APP
+GenericName=Audio Player
+GenericName[pt_BR]=Reprodutor de áudio
+GenericName[ru]=Аудио плеер
+GenericName[zh_CN]=音频播放器
+GenericName[zh_TW]=音樂播放器
+Comment=Listen to music
+Comment[pt_BR]=Escute músicas
+Comment[ru]=Слушай музыку
+Comment[zh_CN]=倾听音乐
+Comment[zh_TW]=聆聽音樂
+MimeType=application/ogg;audio/x-vorbis+ogg;application/x-ogg;audio/mp3;audio/prs.sid;audio/x-flac;audio/mpeg;audio/x-mpeg;audio/x-mod;audio/x-it;audio/x-s3m;audio/x-xm;audio/x-mpegurl;audio/x-scpls;application/x-cue;
+Categories=Audio;AudioVideo;Player;GTK;
+Keywords=Sound;Music;Audio;Player;Musicplayer;MP3;
 Terminal=false
-Categories=Audio;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Audio;AudioVideo;Player;GTK;
+X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Next;Prev;
+X-PulseAudio-Properties=media.role=music
+
+[Desktop Action Play]
+Name=Play
+Name[zh_CN]=播放
+Name[zh_TW]=播放
+Exec=$APP --play
+
+[Desktop Action Pause]
+Name=Pause
+Name[zh_CN]=暂停
+Name[zh_TW]=暫停
+Exec=$APP --pause
+
+[Desktop Action Toggle-Pause]
+Name=Toggle Pause
+Name[zh_CN]=播放/暂停
+Name[zh_TW]=播放/暫停
+Exec=$APP --toggle-pause
+
+[Desktop Action Stop]
+Name=Stop
+Name[zh_TW]=停止
+Exec=$APP --stop
+
+[Desktop Action Next]
+Name=Next
+Name[zh_TW]=下一首
+Exec=$APP --next
+
+[Desktop Action Prev]
+Name=Prev
+Name[zh_TW]=上一首
+Exec=$APP --prev" >> /usr/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/x86_64/deadbeef-devel
+++ b/programs/x86_64/deadbeef-devel
@@ -61,7 +61,6 @@ rm -f /usr/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Type=Application
 Name=DeaDBeeF Nightly
-Comment=devel build
 Exec=/opt/$APP/$APP %F
 Icon=/opt/$APP/icons/$APP
 GenericName=Audio Player

--- a/programs/x86_64/deadbeef-devel
+++ b/programs/x86_64/deadbeef-devel
@@ -52,15 +52,15 @@ fi
 EOF
 chmod a+x /opt/$APP/AM-updater
 
-# ICON
+# ICON (HIGHER QUALITY ICON)
 mkdir icons
-ln -s /opt/$APP/deadbeef.png ./icons/$APP
+wget https://raw.githubusercontent.com/DeaDBeeF-Player/deadbeef/master/icons/scalable/deadbeef.svg -O ./icons/$APP 2> /dev/null
 
 # LAUNCHER
 rm -f /usr/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Type=Application
-Name=DeaDBeeF
+Name=DeaDBeeF Nightly
 Comment=devel build
 Exec=/opt/$APP/$APP %F
 Icon=/opt/$APP/icons/$APP

--- a/programs/x86_64/deadbeef-devel
+++ b/programs/x86_64/deadbeef-devel
@@ -64,6 +64,7 @@ Name=DeaDBeeF
 Comment=devel build
 Exec=/opt/$APP/$APP %F
 Icon=/opt/$APP/icons/$APP
+GenericName=Audio Player
 GenericName[pt_BR]=Reprodutor de áudio
 GenericName[ru]=Аудио плеер
 GenericName[zh_CN]=音频播放器


### PR DESCRIPTION
Alright these changes put the desktop entries of both applications up to date, they also have the `exec=appname %F` which was missing from the original script. Not having the %F prevents deadbeef from opening files thru xdg-open. 

I also reverted that original change to deadbeef-devel to use the built in icon from deadbeef, because turns out that icon has a very low quality lol. 


