### PR TITLE
Changes to AM-SAMPLE-AppImage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Before reporting a problem, be it a bug, design or others, we assume you have ma
 1. [the README.md](https://github.com/ivan-hc/AM/blob/main/README.md) does not cover your problem
 2. the problem has not been reported in the [issue tracker](https://github.com/ivan-hc/AM/issues)
 3. the problem is not related to the installed apps but to the [installation scripts](https://github.com/ivan-hc/AM/tree/main/programs)
+4. the "AM"/"AppMan" command line interface [is updated to the latest version](https://github.com/ivan-hc/AM/releases/latest)
 
 If all apply, then please consider opening a [new issue](https://github.com/ivan-hc/AM/issues).
 

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -75,12 +75,10 @@ chmod a+x /opt/$APP/AM-updater
 # LAUNCHER & ICON
 app=$(echo $APP | cut -c -3)
 cd /opt/$APP
-./$APP --appimage-extract *.desktop 1>/dev/null
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null
-mv squashfs-root/*.desktop ./$APP.desktop
-mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
+./$APP --appimage-extract *.desktop 1>/dev/null && mv squashfs-root/*.desktop ./$APP.desktop
+./$APP --appimage-extract share/applications/*.desktop 1>/dev/null && mv squashfs-root/share/applications/*.desktop ./$APP.desktop
+./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null && mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
+
 if [ ! -e ./$APP.desktop ]; then 
 	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
 	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
@@ -89,13 +87,9 @@ if [ ! -e ./$APP.desktop ]; then
 	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
 	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
 fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep -i $app | head -1)
-sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
-sed -i "s#AppRun#$APP#g" ./$APP.desktop
-sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
-sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
+
+sed -i "s#Exec=[^ ]*#Exec=$APP#g" ./$APP.desktop
+sed -i "s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
 
 mkdir icons
 mv $(./$APP --appimage-extract *.png) ./icons/$APP 2>/dev/null


### PR DESCRIPTION
The first change is combining the `mv` and `--appimage-extract` commands. That way mv will move the .desktop file only if a file was actually extracted with --appimage-extract. 

The second change simplifies the patching in the .desktop file. I created this test demonstration that shows what it does: 

```
#!/bin/sh

APP=TESTDEMO

sed -i "s#Exec=[^ ]*#Exec=$APP#g" ./$APP.desktop
sed -i "s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
```

And ran it the librewolf.desktop file thru, which this is how it looks before changing it: 

```
[Desktop Entry]
Name=LibreWolf
Exec=librewolf %u
Icon=librewolf
Type=Application
MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
StartupWMClass=LibreWolf
Categories=Network;WebBrowser;
StartupNotify=true
Terminal=false
X-MultipleArgs=false
Keywords=Internet;WWW;Browser;Web;Explorer;
Actions=new-window;new-private-window;profilemanager;
X-AppImage-Version=177

[Desktop Action new-window]
Name=Open a New Window
Exec=librewolf %u

[Desktop Action new-private-window]
Name=Open a New Private Window
Exec=librewolf --private-window %u

[Desktop Action profilemanager]
Name=Open the Profile Manager
Exec=librewolf --ProfileManager %u
```

And this is after running the change: 

```
[Desktop Entry]
Name=LibreWolf
Exec=TESTDEMO %u
Icon=/opt/TESTDEMO/icons/TESTDEMO
Type=Application
MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
StartupWMClass=LibreWolf
Categories=Network;WebBrowser;
StartupNotify=true
Terminal=false
X-MultipleArgs=false
Keywords=Internet;WWW;Browser;Web;Explorer;
Actions=new-window;new-private-window;profilemanager;
X-AppImage-Version=177

[Desktop Action new-window]
Name=Open a New Window
Exec=TESTDEMO %u

[Desktop Action new-private-window]
Name=Open a New Private Window
Exec=TESTDEMO --private-window %u

[Desktop Action profilemanager]
Name=Open the Profile Manager
Exec=TESTDEMO --ProfileManager %u

```

And just like that, every instance of Exec= and Icon= was changed to the desired string and it preserved the original launch flags.
