### PR TITLE
Add zsh completion

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -422,6 +422,21 @@ case "$1" in
 		$SUDOCOMMAND mv "$COMPLETIONFILE" "$COMPLETIONPATH/" 2> /dev/null
 		echo " Completion has been enabled!"
 	fi
+	if [ -f "$HOME/.zshrc" ] || [ -f "$ZDOTDIR/.zshrc" ]; then
+		if [ -n "$ZDOTDIR" ]; then
+    		ZSHDIR="$ZDOTDIR"
+		else
+   	    	ZSHDIR="$HOME"
+		fi
+		echo '#!/usr/bin/env bash' >> "$ZSHDIR/$COMPLETIONFILE"
+		echo 'complete -W "$(cat '"$AMPATH"'/list 2>/dev/null)" '"$AMCLI"'' >> "$ZSHDIR/$COMPLETIONFILE"
+		chmod a+x "$ZSHDIR/$COMPLETIONFILE"
+		echo "
+autoload bashcompinit
+bashcompinit
+source $ZSHDIR/$COMPLETIONFILE" >> "$ZSHDIR/.zshrc"
+
+	fi
 	;;
 
   '--launcher')

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -428,14 +428,17 @@ case "$1" in
 		else
    	    	ZSHDIR="$HOME"
 		fi
-		echo '#!/usr/bin/env bash' >> "$ZSHDIR/$COMPLETIONFILE"
-		echo 'complete -W "$(cat '"$AMPATH"'/list 2>/dev/null)" '"$AMCLI"'' >> "$ZSHDIR/$COMPLETIONFILE"
-		chmod a+x "$ZSHDIR/$COMPLETIONFILE"
-		echo "
+		if grep -q "source $ZSHDIR/$COMPLETIONFILE" "$ZSHDIR/.zshrc"; then
+			echo "Zsh completion already enabled!"
+		else
+			echo '#!/usr/bin/env bash' >> "$ZSHDIR/$COMPLETIONFILE"
+			echo 'complete -W "$(cat '"$AMPATH"'/list 2>/dev/null)" '"$AMCLI"'' >> "$ZSHDIR/$COMPLETIONFILE"
+			chmod a+x "$ZSHDIR/$COMPLETIONFILE"
+			echo "
 autoload bashcompinit
 bashcompinit
 source $ZSHDIR/$COMPLETIONFILE" >> "$ZSHDIR/.zshrc"
-
+		fi
 	fi
 	;;
 


### PR DESCRIPTION
I don't know if there is a way to fix the lack of space in lines 438, 439, 440, because otherwise the space gets piped into `.zshrc. `

And if I try to individually `echo "" >>` each line to `.zshrc` there is the problem that if the last line in zshrc does not end in an empty line, it will put the text next to the existing text for the first line, breaking it.

Fixes https://github.com/ivan-hc/AM/issues/397