### PR TITLE
More optimizations

### DIFF
--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -50,7 +50,8 @@ if test -f "/opt/$APP/*.zsync"; then
 	chmod a+x "/opt/$APP/$APP"
 else
 	if [ "$version" = "$version0" ]; then
-		echo "Update not needed!" && exit 0
+		rm -f "/opt/$APP/version"
+		echo "$version" >> "/opt/$APP/version"
 	else
 		notify-send "A new version of $APP is available, please wait"
 		mkdir "/opt/$APP/tmp"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -20,7 +20,7 @@ version=$(FUNCTION)
 wget "$version"
 wget "$version.zsync" 2> /dev/null
 echo "$version" >> /opt/$APP/version
-
+# Use tar fx ./*tar* for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
 mv ./tmp/*.zsync ./"$APP".zsync 2> /dev/null

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -3,57 +3,58 @@
 APP=SAMPLE
 SITE="REPLACETHIS"
 
-# CREATE THE FOLDER
+# CREATE DIRECTORIES
 if [ -z "$APP" ]; then exit 1; fi
-mkdir /opt/$APP && cd /opt/$APP
+mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 
 # ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
+echo "#!/bin/sh
+rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
+rm -R -f /opt/$APP" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
-# DOWNLOAD THE ARCHIVE
-mkdir tmp
-cd ./tmp
+# Ivan wants to have version in line 19 so I'm using this space for random info
+# Did you know that we break pasta in half when cooking it?
 
 version=$(FUNCTION)
-wget $version
-wget $version.zsync 2> /dev/null
+wget "$version"
+wget "$version.zsync" 2> /dev/null
 echo "$version" >> /opt/$APP/version
 
 cd ..
-mv ./tmp/*mage ./$APP
-mv ./tmp/*.zsync ./$APP.zsync 2> /dev/null
-chmod a+x /opt/$APP/$APP
+mv ./tmp/*mage ./"$APP"
+mv ./tmp/*.zsync ./"$APP".zsync 2> /dev/null
+chmod a+x "/opt/$APP/$APP"
 rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> /opt/$APP/AM-updater << 'EOF'
 #!/usr/bin/env bash
 APP=SAMPLE
 SITE="REPLACETHIS"
-version0=$(cat /opt/$APP/version)
+if [ -z "$APP" ]; then exit 1; fi
+version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
-if test -f /opt/$APP/*.zsync; then
-	mkdir /opt/$APP/tmp
-	cd /opt/$APP/tmp
-	wget $version.zsync 2> /dev/null
+if test -f "/opt/$APP/*.zsync"; then
+	mkdir "/opt/$APP/tmp"
+	cd "/opt/$APP/tmp" || exit 1
+	wget "$version.zsync" 2> /dev/null
 	cd ..
-	mv ./tmp/*.zsync ./$APP.zsync
+	mv ./tmp/*.zsync ./"$APP".zsync
 	rm -R -f ./tmp
-	zsync /opt/$APP/$APP.zsync
-	rm -R -f /opt/$APP/*zs-old /opt/$APP/*.part
-	chmod a+x /opt/$APP/$APP
+	zsync "/opt/$APP/$APP.zsync"
+	rm -R -f "/opt/$APP/*zs-old" "/opt/$APP/*.part"
+	chmod a+x "/opt/$APP/$APP"
 else
-	if [ $version = $version0 ]; then
-		echo "Update not needed!"
+	if [ "$version" = "$version0" ]; then
+		echo "Update not needed!" && exit 0
 	else
 		notify-send "A new version of $APP is available, please wait"
-		mkdir /opt/$APP/tmp
-		cd /opt/$APP/tmp
+		mkdir "/opt/$APP/tmp"
+		cd "/opt/$APP/tmp" || exit 1
 		wget $version
 		if ls . | grep mage; then
 			
@@ -61,7 +62,7 @@ else
 			
 	  		if test -f ./tmp/*mage; then rm ./version
 	  		fi
-	  		echo $version >> ./version
+	  		echo "$version" >> ./version
 	  		mv --backup=t ./tmp/* ./$APP
 	  		chmod a+x /opt/$APP/$APP
 	  		rm -R -f ./tmp ./*~
@@ -69,57 +70,35 @@ else
 		notify-send "$APP is updated!"
 	fi
 fi
+pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}')
+if [ "$pkgversion" = "continuous" ]; then
+	pkgversion=$(FUNCTION)
+fi
+echo "$pkgversion" >> "/opt/$APP/pkgversion"
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x /opt/"$APP"/AM-updater
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
-cd /opt/$APP
-./$APP --appimage-extract *.desktop 1>/dev/null && mv squashfs-root/*.desktop ./$APP.desktop
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null && mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null && mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
-	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
+cd "/opt/$APP" || exit 1
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract share/applications/*.desktop 1>/dev/null && mv ./squashfs-root/share/applications/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract usr/share/applications/*.desktop 1>/dev/null && mv ./squashfs-root/usr/share/applications/*.desktop ./"$APP".desktop
+if [ -L ./DirIcon ]; then
+	LINKPATH=$(readlink ./DirIcon)
+	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 fi
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
-	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 2>/dev/null
+rm -R -f ./squashfs-root
+
+# PACKAGE VERSION
+pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}')
+if [ "$pkgversion" = "continuous" ]; then
+	pkgversion=$(FUNCTION)
 fi
-
-sed -i "s#Exec=[^ ]*#Exec=$APP#g" ./$APP.desktop
-sed -i "s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
-
-mkdir icons
-mv $(./$APP --appimage-extract *.png) ./icons/$APP 2>/dev/null
-mv $(./$APP --appimage-extract *.svg) ./icons/$APP 2>/dev/null
-./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-mv ./squashfs-root/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-
-rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+echo "$pkgversion" >> ./pkgversion
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')
-chown -R $currentuser /opt/$APP
+chown -R "$currentuser" "/opt/$APP"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -71,11 +71,6 @@ else
 		notify-send "$APP is updated!"
 	fi
 fi
-pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}' | cut -c1-12)
-if [ "$pkgversion" = "continuous" ]; then
-	pkgversion=$(FUNCTION)
-fi
-echo "$pkgversion" >> "/opt/$APP/pkgversion"
 EOF
 chmod a+x "/opt/$APP/AM-updater"
 
@@ -92,13 +87,6 @@ fi
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 2>/dev/null
 rm -R -f ./squashfs-root
-
-# PACKAGE VERSION
-pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}' | cut -c1-12)
-if [ "$pkgversion" = "continuous" ]; then
-	pkgversion=$(FUNCTION)
-fi
-echo "$pkgversion" >> ./pkgversion
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -13,8 +13,8 @@ rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
 rm -R -f /opt/$APP" >> "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
-# Ivan wants to have version in line 19 so I'm using this space for random info
-# Did you know that we break pasta in half when cooking it?
+# DOWNLOAD AND PREPARE THE APP
+# $version is also used for updates
 
 version=$(FUNCTION)
 wget "$version"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -63,8 +63,8 @@ else
 	  		if test -f ./tmp/*mage; then rm ./version
 	  		fi
 	  		echo "$version" >> ./version
-	  		mv --backup=t ./tmp/* ./$APP
-	  		chmod a+x /opt/$APP/$APP
+	  		mv --backup=t ./tmp/* ./"$APP"
+	  		chmod a+x "/opt/$APP/$APP"
 	  		rm -R -f ./tmp ./*~
 		fi
 		notify-send "$APP is updated!"
@@ -76,7 +76,7 @@ if [ "$pkgversion" = "continuous" ]; then
 fi
 echo "$pkgversion" >> "/opt/$APP/pkgversion"
 EOF
-chmod a+x /opt/"$APP"/AM-updater
+chmod a+x "/opt/$APP/AM-updater"
 
 # LAUNCHER & ICON
 cd "/opt/$APP" || exit 1

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -70,7 +70,7 @@ else
 		notify-send "$APP is updated!"
 	fi
 fi
-pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}')
+pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}' | cut -c1-12)
 if [ "$pkgversion" = "continuous" ]; then
 	pkgversion=$(FUNCTION)
 fi
@@ -93,7 +93,7 @@ mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./
 rm -R -f ./squashfs-root
 
 # PACKAGE VERSION
-pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}')
+pkgversion=$(echo "$version" | awk -F / '{print $(NF-1)}' | cut -c1-12)
 if [ "$pkgversion" = "continuous" ]; then
 	pkgversion=$(FUNCTION)
 fi


### PR DESCRIPTION
Ok several things changed here: 

* First change: https://i.redd.it/4ai705yurikb1.jpg

* Use one `mkdir` to make all nested directories. tested and works without problems.

* Made the remover safer since we only need to use `rm -R -f` for the `$APP` directory. tested it and works without issues.

* New way of getting the icon by extracting `.DirIcon`. I also tested when `./DirIcon` is a symlink with the tesseract appimage where this happens, and it worked like it should, it used the path in the symlink to get the right icon with --appimage-extract. 🎉

* Combined the sed commands into one, it works without issues as well. 

* Added quotations to several paths for safety™

* first pkgversion attempt, @zen0bit I also want your input on how pkgversion should be done.

