### PR TITLE
Fix small issue

### DIFF
--- a/modules/nolibfuse.am
+++ b/modules/nolibfuse.am
@@ -20,6 +20,7 @@ while [ -n "$1" ]; do
 					echo -ne " ...extracting the AppImage\r"
 					./$2 --appimage-extract 2> /dev/null | grep -v "squashfs-root"
 					echo -ne " ...trying to convert in Type3 AppImage\r"
+					chmod 0755 ./squashfs-root
 					ARCH="$(uname -m)" VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./squashfs-root > /dev/null 2> /dev/null
 					if test -f ./*.AppImage; then
 						mv ./"$2" ./"$2".old


### PR DESCRIPTION
This fixes an issue that nolibfuse can't convert the freetube appimage to type 3 because appimagetool complains `Wrong permissions on AppDir, please set it to 0755 and try again`. Works with this patch.

Also tested converting again an appimage that doesn't need the permissions change (librewolf) just in case and had no issues.

