### PR TITLE
Update hyperfine and fix hack in android-tools. 

### DIFF
--- a/programs/x86_64/android-tools
+++ b/programs/x86_64/android-tools
@@ -67,7 +67,7 @@ if [ -L ./DirIcon ]; then
 	LINKPATH=$(readlink ./DirIcon)
 	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 fi
-sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+sed -i "s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 2>/dev/null
 rm -R -f ./squashfs-root
 

--- a/programs/x86_64/hyperfine
+++ b/programs/x86_64/hyperfine
@@ -1,36 +1,35 @@
 #!/bin/sh
 
 APP=hyperfine
-if [ -z "$APP" ]; then exit 1; fi
 SITE="sharkdp/hyperfine"
 
-# CREATE THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP
+# CREATE DIRECTORIES
+if [ -z "$APP" ]; then exit 1; fi
+mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 
 # ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -rf \"/opt/$APP\" \"/usr/local/bin/$APP\"" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
+echo "#!/bin/sh
+rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
+rm -R -f /opt/$APP" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
-# DOWNLOAD THE ARCHIVE
-mkdir tmp
-cd ./tmp
+# DOWNLOAD AND PREPARE THE APP
+# $version is also used for updates
 
 version=$(wget -q https://api.github.com/repos/sharkdp/hyperfine/releases -O - | grep browser_download_url | grep -i x86_64-unknown-linux-gnu.tar.gz   | cut -d '"' -f 4 | head -1)
-wget $version
-echo "$version" >> /opt/$APP/version
+wget "$version"
+echo "$version" >> "/opt/$APP/version"
 tar fx ./*tar*; rm -R -f ./*tar*
 cd ..
-mv --backup=t ./tmp/*/$APP ./
+mv --backup=t ./tmp/*/"$APP" ./
 rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP; ln -s /opt/$APP/$APP /usr/local/bin/$APP
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> /opt/$APP/AM-updater << 'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 APP=hyperfine
 version0=$(cat /opt/$APP/version)
 version=$(wget -q https://api.github.com/repos/sharkdp/hyperfine/releases -O - | grep browser_download_url | grep -i x86_64-unknown-linux-gnu.tar.gz  | cut -d '"' -f 4 | head -1)
@@ -38,20 +37,19 @@ if [ $version = $version0 ]; then
 	echo "Update not needed!"
 else
 	notify-send "A new version of $APP is available, please wait"
-	mkdir /opt/$APP/tmp
-	cd /opt/$APP/tmp
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget $version
   tar fx ./*tar*; rm -R -f ./*tar*
 	cd ..
-  mv --backup=t ./tmp/*/$APP ./
+  mv --backup=t ./tmp/*/"$APP" ./
 	rm ./version
-	echo $version >> ./version
+	echo "$version" >> ./version
 	rm -R -f ./tmp ./*~
 	notify-send "$APP is updated!"
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x "/opt/$APP/AM-updater"
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')
-chown -R $currentuser /opt/$APP
+chown -R "$currentuser" "/opt/$APP"


### PR DESCRIPTION
Don't look at how the 'Exec=' is done in the android-tools appimage that I need to prevent sed from touching that 💀 (appimagetool doesn't like `Exec=` with special characters). 

It also means that it will be near impossible to get `--launcher` to correctly work with this appimage lol. 