### PR TITLE
Update AM-SAMPLE-AppImage to be POSIX compliant 

### DIFF
--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -18,12 +18,12 @@ chmod a+x "/opt/$APP/remove"
 
 version=$(FUNCTION)
 wget "$version"
-wget "$version.zsync" &>/dev/null
+wget "$version.zsync" >/dev/null 2>&1
 echo "$version" >> /opt/$APP/version
 # Use tar fx ./*tar* for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
-mv ./tmp/*.zsync ./"$APP".zsync &>/dev/null
+mv ./tmp/*.zsync ./"$APP".zsync >/dev/null 2>&1
 chmod a+x "/opt/$APP/$APP"
 rm -R -f ./tmp
 
@@ -41,7 +41,7 @@ version=$(FUNCTION)
 if test -f "/opt/$APP/*.zsync"; then
 	mkdir "/opt/$APP/tmp"
 	cd "/opt/$APP/tmp" || exit 1
-	wget "$version.zsync" &>/dev/null
+	wget "$version.zsync" >/dev/null 2>&1
 	cd ..
 	mv ./tmp/*.zsync ./"$APP".zsync
 	rm -R -f ./tmp
@@ -79,16 +79,16 @@ chmod a+x "/opt/$APP/AM-updater"
 
 # LAUNCHER & ICON
 cd "/opt/$APP" || exit 1
-./"$APP" --appimage-extract .DirIcon &>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon &>/dev/null
-./"$APP" --appimage-extract *.desktop &>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop &>/dev/null
-./"$APP" --appimage-extract share/applications/*.desktop &>/dev/null && mv ./squashfs-root/share/applications/*.desktop ./"$APP".desktop &>/dev/null
-./"$APP" --appimage-extract usr/share/applications/*.desktop &>/dev/null && mv ./squashfs-root/usr/share/applications/*.desktop ./"$APP".desktop &>/dev/null
+./"$APP" --appimage-extract .DirIcon >/dev/null 2>&1 && mv ./squashfs-root/.DirIcon ./DirIcon >/dev/null 2>&1
+./"$APP" --appimage-extract *.desktop >/dev/null 2>&1 && mv ./squashfs-root/*.desktop ./"$APP".desktop >/dev/null 2>&1
+./"$APP" --appimage-extract share/applications/*.desktop >/dev/null 2>&1 && mv ./squashfs-root/share/applications/*.desktop ./"$APP".desktop >/dev/null 2>&1
+./"$APP" --appimage-extract usr/share/applications/*.desktop >/dev/null 2>&1 && mv ./squashfs-root/usr/share/applications/*.desktop ./"$APP".desktop >/dev/null 2>&1
 if [ -L ./DirIcon ]; then
 	LINKPATH=$(readlink ./DirIcon)
-	./"$APP" --appimage-extract "$LINKPATH" &>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon &>/dev/null
+	./"$APP" --appimage-extract "$LINKPATH" >/dev/null 2>&1 && mv ./squashfs-root/"$LINKPATH" ./DirIcon >/dev/null 2>&1
 fi
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
-mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" &>/dev/null
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" >/dev/null 2>&1
 rm -R -f ./squashfs-root
 
 # CHANGE THE PERMISSIONS


### PR DESCRIPTION
Test

![image](https://github.com/ivan-hc/AM/assets/36420837/7e8a1d8e-11c9-45aa-a46e-af32f298dcd9)

Now it should be fully silent when using the dash shell (which is /bin/sh in debian). 
