### PR TITLE
Security: Specified the use of "AM" on multi-account systems

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 CLI=$(basename "$0")
-AMVERSION="6.6.2"
+AMVERSION="6.6.2-1"
 
 SCRIPTDIR="$(if command -v xdg-user-dir &>/dev/null; then xdg-user-dir DESKTOP; else echo $HOME; fi)"
 
@@ -119,6 +119,20 @@ export AMCATALOGUEICONS="https://raw.githubusercontent.com/Portable-Linux-Apps/P
 # Determine system architecture and current user
 export arch="$HOSTTYPE"
 export currentuser="$USER"
+if [ "$AMCLI" == am ]; then
+	ampathowner=$(ls -ld /opt/am | awk 'NR==1 {print $3}')
+	if [ "$ampathowner" != "$currentuser" ]; then
+		echo ' 💀 ERROR: you are not the owner of /opt/am, so you cannot use "AM"'
+		echo '--------------------------------------------------------------------------'
+		echo ' The user that have installed "AM" on this system is "'"$ampathowner"'"'
+		echo ' you are only allowed to use the installed apps, not to manage them.'
+		echo '--------------------------------------------------------------------------'
+		echo ' Please, contact "'"$ampathowner"'" to change the ownership of /opt/am or'
+		echo ' consider using "AppMan" instead, see https://github.com/ivan-hc/AppMan'
+		echo '--------------------------------------------------------------------------'
+		exit
+	fi
+fi
 
 if [[ -f "$AMPATH"/new-repo.txt ]]; then
 	AMREPO=$(<"$AMPATH/new-repo.txt") # Utilizing command substitution with < for more efficient file reading

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Initially the two projects traveled in parallel to each other, until version 5, 
 #### To be more detailed, here is an overview of how apps are installed by "AM" and "AppMan"
 
 Where `$PROGRAM` is the application we're going to install:
-- "AM" (ie the `am` command) installs programs and works at system level (i.e. for all the users). "AM" requires the `sudo` privileges but only to install and remove the app, all the other commands can be executed as a normal user. This allows multiple users of the same system to be able to use the same installed applications. This is what an installation script installs with "AM":
+- "AM" (ie the `am` command) installs programs system-wide. "AM" requires the `sudo` privileges but only to install and remove the app, all the other commands can be executed as a normal user. This allows multiple users of the same system to be able to use the same installed applications, **while the general use of "AM" (installing, updating, consulting lists...) will only be permitted to the system administrator/owner of the /opt/am directory and all the directories managed by "AM", and to the user "root"**. This is what an installation script installs with "AM":
 
       /opt/$PROGRAM/
       /opt/$PROGRAM/$PROGRAM
@@ -100,6 +100,8 @@ If the distro is immutable instead, the path of the launcher (the last line abov
 
       /usr/local/share/applications/AM-$PROGRAM.desktop
 Since version 5.1 the installation process have introduced a check to find read-only filesystems (`grep "[[:space:]]ro[[:space:],]" /proc/mounts`), if there are mountpoints like this, your distro may be an immutable one, so an `/usr/local/share/applications` directory will be created and the installation script will be patched to redirect the installation of launchers in that path to solve the issue.
+
+**NOTE: Non-privileged users who wish to use "AM" on multi-account systems will be advised to contact the administrator to change ownership of /opt/am or to consider using "AppMan".**
 
 - "AppMan" (ie the `appman` command) instead does not need root privileges to work, it allows you to choose where to install your applications into your `$HOME` directory. AppMan is also usable as a portable app (i.e. you can download and place it wherever you want) and it is able to update itself, anywhere! At first start it will ask you where to install the apps and it will create the directory for you (the configuration file is in `~/.config/appman`). For example, suppose you want install everything in "Applicazioni" (the italian of "applications"), this is the structure of what an installation scripts installs with "AppMan" instead:
 


### PR DESCRIPTION
On systems with multiple accounts, only the user who installed "AM" and the root user will be able to use "AM" and all its options. Apps installed with "AM" will also be updateable and manageable by the system administrator.

Non-privileged users will instead be advised to contact the administrator to change permissions on the /opt/am directory or will be advised to use "AppMan" as an alternative.

![Istantanea_2024-04-23_12-42-11](https://github.com/ivan-hc/AM/assets/88724353/cbe6bb03-499d-420d-b404-f2034b9852bd)