### PR TITLE
Update INSTALL to a wget2 compatible grep

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -26,7 +26,7 @@ ln -s /opt/am/APP-MANAGER /usr/local/bin/am
 wget -q "https://raw.githubusercontent.com/ivan-hc/AM/main/programs/$arch-apps"
 
 # DOWNLOAD MODULES
-MODULES=$(wget -q https://api.github.com/repos/ivan-hc/AM/contents/modules -O - | grep download_url | cut -d '"' -f 4)
+MODULES=$(wget -q https://api.github.com/repos/ivan-hc/AM/contents/modules -O - | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*raw.*modules.*am$')
 for module in $MODULES; do
 	for v in $module; do
 		cd /opt/am/modules || exit


### PR DESCRIPTION
Test: this method works with both wget and wget2

![image](https://github.com/ivan-hc/AM/assets/36420837/06601d16-e6a7-418d-8a62-59b20e72111c)

Also made sure that it installs am using both wget and wget2. Fixes #496 for good. 