### PR TITLE
fix(dbgate): download the incorrect appimage file and code improvements

### DIFF
--- a/programs/x86_64/dbgate
+++ b/programs/x86_64/dbgate
@@ -16,7 +16,8 @@ chmod a+x /opt/$APP/remove
 mkdir tmp
 cd ./tmp
 
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq '.' | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
+version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq "." | grep -v i386 | grep -v i686 | grep -v aarch64 | grep -v arm64 | grep -v armv7l | grep -wv beta | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
+
 wget $version
 echo "$version" >> /opt/$APP/version
 cd ..
@@ -33,7 +34,7 @@ cat >> /opt/$APP/AM-updater << 'EOF'
 APP=dbgate
 REPO="dbgate/dbgate"
 version0=$(cat /opt/$APP/version)
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq '.' | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
+version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq "." | grep -v i386 | grep -v i686 | grep -v aarch64 | grep -v arm64 | grep -v armv7l | grep -wv beta | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
 if [ $version = $version0 ]; then
   echo "Update not needed!"
 else
@@ -72,13 +73,9 @@ if [ ! -e ./$APP.desktop ]; then
 	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
 	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
 fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep $app | head -1)
-sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
 sed -i "s#AppRun#$APP#g" ./$APP.desktop
 sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
 sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
 
 mkdir icons
 ./$APP --appimage-extract *.png 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
@@ -87,28 +84,27 @@ mkdir icons
 ./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
 ./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
 ./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-mv ./squashfs-root/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
+folders=("22x22" "24x24" "32x32" "48x48" "64x64" "128x128" "256x256" "512x512" "scalable")
+for folder in ${folders[@]}; do
+	for icon in ./squashfs-root/share/icons/hicolor/$folder/apps/*$app*; do
+		if [ ! -h "$icon" ]; then
+			extension="${icon##*.}"
+			mv "$icon" "./icons/$APP"."$extension"
+		fi
+	done
+	for icon in ./squashfs-root/usr/share/icons/hicolor/$folder/apps/*$app*; do
+		if [ ! -h "$icon" ]; then
+			extension="${icon##*.}"
+			mv "$icon" "./icons/$APP"."$extension"
+		fi
+	done
+done
+
+ICONPATH=./icons/$APP*.*
+ICONBASE=$(basename $ICONPATH)
+ICONEXTENSION="${ICONBASE##*.}"
+CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
+sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP.$ICONEXTENSION#g" ./$APP.desktop
 
 rm -R -f /opt/$APP/squashfs-root
 mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
-
-
-
-

--- a/programs/x86_64/dbgate
+++ b/programs/x86_64/dbgate
@@ -1,110 +1,92 @@
 #!/bin/sh
 
 APP=dbgate
-REPO="dbgate/dbgate"
+SITE="dbgate/dbgate"
 
-# CREATE THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP
+# CREATE DIRECTORIES
+if [ -z "$APP" ]; then exit 1; fi
+mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 
 # ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
+echo "#!/bin/sh
+rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
+rm -R -f /opt/$APP" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
-# DOWNLOAD THE ARCHIVE
-mkdir tmp
-cd ./tmp
+# DOWNLOAD AND PREPARE THE APP
+# $version is also used for updates
 
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq "." | grep -v i386 | grep -v i686 | grep -v aarch64 | grep -v arm64 | grep -v armv7l | grep -wv beta | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
-
-wget $version
+version=$(curl -Ls https://api.github.com/repos/dbgate/dbgate/releases/latest | jq '.' | grep browser_download_url | grep -i x86_64  | grep -i appimage | cut -d '"' -f 4 | head -1)
+wget "$version"
+wget "$version.zsync" 2> /dev/null
 echo "$version" >> /opt/$APP/version
+# Use tar fx ./*tar* for example in this line in case a compressed file is downloaded.
 cd ..
-mv ./tmp/*mage ./$APP
-chmod a+x /opt/$APP/$APP
-rmdir ./tmp
+mv ./tmp/*mage ./"$APP"
+mv ./tmp/*.zsync ./"$APP".zsync 2> /dev/null
+chmod a+x "/opt/$APP/$APP"
+rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
-cat >> /opt/$APP/AM-updater << 'EOF'
-#!/usr/bin/env bash
+cat >> "/opt/$APP/AM-updater" << 'EOF'
+#!/bin/sh
 APP=dbgate
-REPO="dbgate/dbgate"
-version0=$(cat /opt/$APP/version)
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq "." | grep -v i386 | grep -v i686 | grep -v aarch64 | grep -v arm64 | grep -v armv7l | grep -wv beta | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
-if [ $version = $version0 ]; then
-  echo "Update not needed!"
-else
-  notify-send "A new version of $APP is available, please wait"
-  mkdir /opt/$APP/tmp
-  cd /opt/$APP/tmp
-  wget $version
-  if ls . | grep mage; then
+SITE="dbgate/dbgate"
+if [ -z "$APP" ]; then exit 1; fi
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/dbgate/dbgate/releases/latest | jq '.' | grep browser_download_url | grep -i x86_64  | grep -i appimage | cut -d '"' -f 4 | head -1)
+if test -f "/opt/$APP/*.zsync"; then
+	mkdir "/opt/$APP/tmp"
+	cd "/opt/$APP/tmp" || exit 1
+	wget "$version.zsync" 2> /dev/null
 	cd ..
-  	if test -f ./tmp/*mage; then rm ./version
-  	fi
-  	echo $version >> ./version
-  	mv --backup=t ./tmp/*mage ./$APP
-  	chmod a+x /opt/$APP/$APP
-  	rm -R -f ./tmp ./*~
-  fi
-  notify-send "$APP is updated!"
+	mv ./tmp/*.zsync ./"$APP".zsync
+	rm -R -f ./tmp
+	zsync "/opt/$APP/$APP.zsync"
+	rm -R -f "/opt/$APP/*zs-old" "/opt/$APP/*.part"
+	chmod a+x /opt/$APP/$APP
+	if [ "$version" != "$version0" ]; then
+		rm -f /opt/$APP/version
+		echo "$version" >> /opt/$APP/version
+	fi
+else
+	if [ "$version" = "$version0" ]; then
+		echo "Update not needed!" && exit 0
+	else
+		notify-send "A new version of $APP is available, please wait"
+		mkdir "/opt/$APP/tmp"
+		cd "/opt/$APP/tmp" || exit 1
+		wget $version
+		if ls . | grep mage; then
+			
+			cd ..
+			
+	  		if test -f ./tmp/*mage; then rm ./version
+	  		fi
+	  		echo "$version" >> ./version
+	  		mv --backup=t ./tmp/* ./"$APP"
+	  		chmod a+x "/opt/$APP/$APP"
+	  		rm -R -f ./tmp ./*~
+		fi
+		notify-send "$APP is updated!"
+	fi
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x "/opt/$APP/AM-updater"
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
-cd /opt/$APP
-./$APP --appimage-extract *.desktop 1>/dev/null
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null
-mv squashfs-root/*.desktop ./$APP.desktop
-mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
-	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
+cd "/opt/$APP" || exit 1
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract share/applications/*.desktop 1>/dev/null && mv ./squashfs-root/share/applications/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract usr/share/applications/*.desktop 1>/dev/null && mv ./squashfs-root/usr/share/applications/*.desktop ./"$APP".desktop
+if [ -L ./DirIcon ]; then
+	LINKPATH=$(readlink ./DirIcon)
+	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 fi
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
-	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-fi
-sed -i "s#AppRun#$APP#g" ./$APP.desktop
-sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
-sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-
-mkdir icons
-./$APP --appimage-extract *.png 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
-./$APP --appimage-extract *.svg 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
-./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-folders=("22x22" "24x24" "32x32" "48x48" "64x64" "128x128" "256x256" "512x512" "scalable")
-for folder in ${folders[@]}; do
-	for icon in ./squashfs-root/share/icons/hicolor/$folder/apps/*$app*; do
-		if [ ! -h "$icon" ]; then
-			extension="${icon##*.}"
-			mv "$icon" "./icons/$APP"."$extension"
-		fi
-	done
-	for icon in ./squashfs-root/usr/share/icons/hicolor/$folder/apps/*$app*; do
-		if [ ! -h "$icon" ]; then
-			extension="${icon##*.}"
-			mv "$icon" "./icons/$APP"."$extension"
-		fi
-	done
-done
-
-ICONPATH=./icons/$APP*.*
-ICONBASE=$(basename $ICONPATH)
-ICONEXTENSION="${ICONBASE##*.}"
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP.$ICONEXTENSION#g" ./$APP.desktop
-
-rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 2>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
## Refactors
- I change the way that extract icons to more readeable code using for loops, in this case my eyes don't get so tired. Maybe this change can be used in another scripts.
- Because of my preference, the script will ignore the beta versions.
- I removed the old lines 75 and 76, because is unnecessary for this case.

## Fixes
- The appimage name in [DbGate repository](https://github.com/dbgate/dbgate/releases/) uses the underscore (_). The problem is that the `-w` flag in the `version` variable will match arm64, for example, and download it.
- In lines 103-107, I am using the icon extension, because in my system menu the icon not appear. 