### PR TITLE
Fixes and changes

### DIFF
--- a/programs/x86_64/fastcompmgr
+++ b/programs/x86_64/fastcompmgr
@@ -10,7 +10,7 @@ mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 # ADD THE REMOVER
 echo "#!/bin/sh
 rm -f /usr/local/bin/$APP
-rm -R -f /opt/$APP" >> "/opt/$APP/remove"
+rm -R -f /opt/$APP" > "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP
@@ -18,7 +18,7 @@ chmod a+x "/opt/$APP/remove"
 
 version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*fastcompmgr$' | head -1)
 wget "$version"
-echo "$version" >> "/opt/$APP/version"
+echo "$version" > "/opt/$APP/version"
 cd ..
 mv --backup=t ./tmp/* ./"$APP"
 rm -R -f ./tmp
@@ -43,8 +43,7 @@ else
 	wget "$version"
 	cd ..
 	mv --backup=t ./tmp/* ./"$APP"
-	rm ./version
-	echo "$version" >> ./version
+	echo "$version" > ./version
 	rm -R -f ./tmp ./*~
 	chmod a+x "/opt/$APP/$APP"
 	notify-send "$APP is updated!"

--- a/programs/x86_64/fastcompmgr
+++ b/programs/x86_64/fastcompmgr
@@ -22,6 +22,7 @@ echo "$version" >> "/opt/$APP/version"
 cd ..
 mv --backup=t ./tmp/* ./"$APP"
 rm -R -f ./tmp
+chmod a+x "/opt/$APP/$APP"
 
 # LINK
 ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
@@ -41,10 +42,11 @@ else
 	cd "/opt/$APP/tmp" || exit 1
 	wget "$version"
 	cd ..
-	mv --backup=t ./tmp/* ./$APP
+	mv --backup=t ./tmp/* ./"$APP"
 	rm ./version
 	echo "$version" >> ./version
 	rm -R -f ./tmp ./*~
+	chmod a+x "/opt/$APP/$APP"
 	notify-send "$APP is updated!"
 fi
 EOF

--- a/programs/x86_64/fastfetch
+++ b/programs/x86_64/fastfetch
@@ -3,53 +3,52 @@
 APP=fastfetch
 SITE="fastfetch-cli/fastfetch"
 
-# CREATE THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP
+# CREATE DIRECTORIES
+if [ -z "$APP" ]; then exit 1; fi
+mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 
 # ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /opt/$APP /usr/local/bin/$APP /usr/local/bin/flashfetch" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
+echo "#!/bin/sh
+rm -f /usr/local/bin/$APP /usr/local/bin/flashfetch
+rm -R -f /opt/$APP" > "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
-# DOWNLOAD THE ARCHIVE
-mkdir tmp
-cd ./tmp
+# DOWNLOAD AND PREPARE THE APP
+# $version is also used for updates
 
-version=$(curl -Ls https://api.github.com/repos/fastfetch-cli/fastfetch/releases | jq '.' | grep browser_download_url | grep -i linux-amd64.tar.gz  | cut -d '"' -f 4 | head -1)
-wget $version
-echo "$version" >> /opt/$APP/version
-tar fx ./*tar*; rm -R -f ./*tar*
+version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*linux-amd64.tar.gz$' | head -1)
+wget "$version"
+echo "$version" > "/opt/$APP/version"
+tar fx ./*tar*
 cd ..
 mv --backup=t ./tmp/*/usr/* ./
 rm -R -f ./tmp
+chmod a+x /opt/"$APP"/bin/*
 
 # LINK
-ln -s /opt/$APP/bin/$APP /usr/local/bin/$APP; ln -s /opt/$APP/bin/flashfetch /usr/local/bin/flashfetch
+ln -s "/opt/$APP/bin/$APP" "/usr/local/bin/$APP" 
+ln -s /opt/"$APP"/bin/flashfetch /usr/local/bin/flashfetch
 
 # SCRIPT TO UPDATE THE PROGRAM
-cat >> /opt/$APP/AM-updater << 'EOF'
-#!/usr/bin/env bash
+cat >> "/opt/$APP/AM-updater" << 'EOF'
+#!/bin/sh
 APP=fastfetch
+SITE="fastfetch-cli/fastfetch"
 version0=$(cat /opt/$APP/version)
-version=$(curl -Ls https://api.github.com/repos/fastfetch-cli/fastfetch/releases | jq '.' | grep browser_download_url | grep -i linux-amd64.tar.gz  | cut -d '"' -f 4 | head -1)
+version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*linux-amd64.tar.gz$' | head -1)
 if [ $version = $version0 ]; then
 	echo "Update not needed!"
 else
 	notify-send "A new version of $APP is available, please wait"
-	mkdir /opt/$APP/tmp
-	cd /opt/$APP/tmp
-	wget $version
-  tar fx ./*tar*; rm -R -f ./*tar*
+	mkdir "/opt/$APP/tmp" && cd /opt/$APP/tmp || exit 1
+	wget "$version"
+	tar fx ./*tar*
 	cd ..
-  mv --backup=t ./tmp/*/usr/* ./
-	rm ./version
-	echo $version >> ./version
+	mv --backup=t ./tmp/*/usr/* ./
+	echo "$version" > ./version
 	rm -R -f ./tmp ./*~
+	chmod a+x /opt/"$APP"/bin/*
 	notify-send "$APP is updated!"
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
-
-
-
+chmod a+x "/opt/$APP/AM-updater"

--- a/programs/x86_64/handlr
+++ b/programs/x86_64/handlr
@@ -10,7 +10,7 @@ mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 # ADD THE REMOVER
 echo "#!/bin/sh
 rm -f /usr/local/bin/$APP /usr/local/bin/xdg-open
-rm -R -f /opt/$APP" >> "/opt/$APP/remove"
+rm -R -f /opt/$APP" > "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP
@@ -18,7 +18,7 @@ chmod a+x "/opt/$APP/remove"
 
 version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*handlr$' | head -1)
 wget "$version"
-echo "$version" >> "/opt/$APP/version"
+echo "$version" > "/opt/$APP/version"
 cd ..
 mv --backup=t ./tmp/* ./"$APP"
 rm -R -f ./tmp
@@ -30,6 +30,7 @@ cat >> "/usr/local/bin/xdg-open" << 'EOF'
 #!/bin/sh
 handlr open "$@"
 EOF
+chmod a+x "/usr/local/bin/xdg-open"
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> "/opt/$APP/AM-updater" << 'EOF'
@@ -42,13 +43,11 @@ if [ "$version" = "$version0" ]; then
 	echo "Update not needed!" && exit 0
 else
 	notify-send "A new version of $APP is available, please wait"
-	mkdir "/opt/$APP/tmp"
-	cd "/opt/$APP/tmp" || exit 1
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version"
 	cd ..
 	mv --backup=t ./tmp/* ./"$APP"
-	rm ./version
-	echo "$version" >> ./version
+	echo "$version" > ./version
 	rm -R -f ./tmp ./*~
 	chmod a+x "/opt/$APP/$APP"
 	notify-send "$APP is updated!"

--- a/programs/x86_64/handlr
+++ b/programs/x86_64/handlr
@@ -22,6 +22,7 @@ echo "$version" >> "/opt/$APP/version"
 cd ..
 mv --backup=t ./tmp/* ./"$APP"
 rm -R -f ./tmp
+chmod a+x "/opt/$APP/$APP"
 
 # LINK
 ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
@@ -45,10 +46,11 @@ else
 	cd "/opt/$APP/tmp" || exit 1
 	wget "$version"
 	cd ..
-	mv --backup=t ./tmp/* ./$APP
+	mv --backup=t ./tmp/* ./"$APP"
 	rm ./version
 	echo "$version" >> ./version
 	rm -R -f ./tmp ./*~
+	chmod a+x "/opt/$APP/$APP"
 	notify-send "$APP is updated!"
 fi
 EOF

--- a/programs/x86_64/lf
+++ b/programs/x86_64/lf
@@ -3,29 +3,30 @@
 APP=lf
 SITE="gokcehan/lf"
 
-# CREATE THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP
+# CREATE DIRECTORIES
+if [ -z "$APP" ]; then exit 1; fi
+mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 
 # ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
+echo "#!/bin/sh
+rm -f /usr/local/bin/$APP /usr/local/bin/xdg-open
+rm -R -f /opt/$APP" > "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
-# DOWNLOAD THE ARCHIVE
-mkdir tmp
-cd ./tmp
+# DOWNLOAD AND PREPARE THE APP
+# $version is also used for updates
 
 version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*lf-linux-amd64.*gz$' | head -1)
-wget $version
-echo "$version" >> /opt/$APP/version
-tar fx ./*tar*; rm -R -f ./*tar*
+wget "$version"
+echo "$version" > "/opt/$APP/version"
+tar fx ./*tar*
 cd ..
-mv --backup=t ./tmp/* ./$APP
+mv --backup=t ./tmp/"$APP" ./"$APP"
 rm -R -f ./tmp
+chmod a+x "/opt/$APP/$APP"
 
 # LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> /opt/$APP/AM-updater << 'EOF'
@@ -34,20 +35,19 @@ APP=lf
 SITE="gokcehan/lf"
 version0=$(cat /opt/$APP/version)
 version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*lf-linux-amd64.*gz$' | head -1)
-if [ $version = $version0 ]; then
-	echo "Update not needed!"
+if [ "$version" = "$version0" ]; then
+	echo "Update not needed!" && exit 0
 else
 	notify-send "A new version of $APP is available, please wait"
-	mkdir /opt/$APP/tmp
-	cd /opt/$APP/tmp
-	wget $version
-  tar fx ./*tar*; rm -R -f ./*tar*
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	wget "$version"
+	tar fx ./*tar*
 	cd ..
-  mv --backup=t ./tmp/* ./$APP
-	rm ./version
-	echo $version >> ./version
+	mv --backup=t ./tmp/"$APP" ./"$APP"
+	echo "$version" > ./version
 	rm -R -f ./tmp ./*~
+	chmod a+x "/opt/$APP/$APP"
 	notify-send "$APP is updated!"
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x "/opt/$APP/AM-updater"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -10,7 +10,7 @@ mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 # ADD THE REMOVER
 echo "#!/bin/sh
 rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
-rm -R -f /opt/$APP" >> "/opt/$APP/remove"
+rm -R -f /opt/$APP" > "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP
@@ -47,10 +47,9 @@ if test -f "/opt/$APP/*.zsync"; then
 	rm -R -f ./tmp
 	zsync "/opt/$APP/$APP.zsync"
 	rm -R -f "/opt/$APP/*zs-old" "/opt/$APP/*.part"
-	chmod a+x /opt/$APP/$APP
+	chmod a+x "/opt/$APP/$APP"
 	if [ "$version" != "$version0" ]; then
-		rm -f /opt/$APP/version
-		echo "$version" >> /opt/$APP/version
+		echo "$version" > /opt/$APP/version
 	fi
 else
 	if [ "$version" = "$version0" ]; then
@@ -64,9 +63,8 @@ else
 			
 			cd ..
 			
-	  		if test -f ./tmp/*mage; then rm ./version
-	  		fi
-	  		echo "$version" >> ./version
+	  		if ! test -f ./tmp/*mage; then exit 1; fi
+	  		echo "$version" > ./version
 	  		mv --backup=t ./tmp/* ./"$APP"
 	  		chmod a+x "/opt/$APP/$APP"
 	  		rm -R -f ./tmp ./*~


### PR DESCRIPTION
I noticed that the handlr script wasn't working on my pc, this was because I didn't add the `chmod a+x` to the binary that gets downloaded. 

I based the script from the lf script script which was based from fastfetch, which fastfetch was also missing the `chmod a+x` there the issue didn't happen because the fastfetch devs upload the binary with the permissions to run. I updated that script anyway just in case. 

Also I made changes to the way `./version` gets created, you don't need to be doing `rm ./version` and then `echo $version >> ./version` as you can use instead the single `>` operator. Which automatically **overwrites** the `./version` file and will not append to a existing file which was what you didn't want to happen by removing the file. I also applied those changes to the appimage template. 