### PR TITLE
i3-auto-layout and new(ish) template?

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -751,6 +751,7 @@
 ◆ hyperkeys : Unleash you keyboard shorcuts.
 ◆ hyperspace : A fluffy client for Mastodon in React.
 ◆ hypertrader : Trade like a PRO, robust tools to monitor your accounts.
+◆ i3-auto-layout : Automatic, optimal tiling for i3wm. Fork of dead version.
 ◆ i3lock-color : The world's most popular non-default computer lockscreen.
 ◆ iagoncloudapp : Iagon Cloud Application.
 ◆ ibus-rime : Zhongzhou Yun input method (ibus-rime) in AppImage format.

--- a/programs/x86_64/i3-auto-layout
+++ b/programs/x86_64/i3-auto-layout
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3. 
+
+set -u
+APP=i3-auto-layout
+SITE="pando85/i3-auto-layout"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+echo "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
+#echo "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
+
+# DOWNLOAD AND PREPARE THE APP
+# $version is also used for updates
+
+
+version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*i3-auto-layout.*tar.gz$' | head -1)
+wget "$version" && echo "$version" > "/opt/$APP/version" || exit 1
+
+tar fx ./*tar* || exit 1
+cd ..
+mv --backup=t ./tmp/"$APP" ./"$APP" && rm -R -f ./tmp || exit 1
+chmod a+x "/opt/$APP/$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/bin/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> "/opt/$APP/AM-updater" << 'EOF'
+#!/bin/sh
+set -u
+APP=i3-auto-layout
+SITE="pando85/i3-auto-layout"
+version0=$(cat /opt/$APP/version)
+version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | jq '.' | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -o 'https.*i3-auto-layout.*tar.gz$' | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	notify-send "A new version of $APP is available, please wait"
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	wget "$version" || exit 1
+	tar fx ./*tar* || exit 1
+	cd ..
+	mv --backup=t ./tmp/"$APP" ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	chmod a+x "/opt/$APP/$APP" || exit 1
+	notify-send "$APP is updated!"
+	exit 0
+fi
+echo "Update not needed!"
+EOF
+chmod a+x "/opt/$APP/AM-updater" || exit 1


### PR DESCRIPTION
I made some changes to the template that optimize and makes the script safer and easier to work with. As the template is now universal: 

**I MADE SURE THAT THIS WORKS WITH APPMAN BTW** As I know you might be worried that it interferes with some of your patch funtions, here is a explanation of the changes:

`set -u` exits the script if some reason a variable is not set, that is if for example `$SITE` were to be deleted. 

`[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1` does the same thing that the older `if then exit` check that was being used to make sure that $APP wasn't empty, it basically only proceeds if $APP isn't empty and quits if any of those 3 command fail for some reason. 

`echo "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"` Is a universal remover, it is harder to read but that's on purpose, as that line will always be the same in every script, because it creates the basic remover, that is:

```
#!/bin/sh
set -e
rm -f /home/samuel/.local/bin/i3-auto-layout
rm -R -f /home/samuel/.local/opt/i3-auto-layout

```

Which does the following, `set -e` exits the remover if there is an error with the first rm.  And the rest is will always be needed, as all applications will always have a symlink in `$PATH`. 

If we need to add other stuff to be removed by the remover, for example the `AM-$APP.desktop` that extra info gets appended to the `./remove` file by commenting out line 12. 

```
#echo "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
```

It is disabled by the # in this script because this application doesn't have a `.desktop` file.

When the # is removed that extra line get **appended** to the ./remover, and it looks like this now: 

```
#!/bin/sh
set -e
rm -f /home/samuel/.local/bin/i3-auto-layout
rm -R -f /home/samuel/.local/opt/i3-auto-layout
rm -f /home/samuel/.local/share/applications/AM-i3-auto-layout.desktop
```

And more lines can be added if the applications needs a extra symlink in `$PATH` for example.

`wget "$version" && echo "$version" > "/opt/$APP/version" || exit 1` will exit the script if some reason wget can't download a file.

Now to the changes in AM-updater: 

The main change was this: 

```
[ -n "$version" ] || { echo "Error getting link"; exit 1; }
if [ "$version" != "$version0" ]; then
```

Which first makes sure that `$version` isn't empty like it could happen if there is a wget error (before the script would have continued) and if it doesn't match the existing `$version0` then it proceeds with the update. 

When the update completes the script exits with 0 indicating that everything went ok, that way the `echo "Update not needed!"` doesn't run when there was actually an update. 



