### PR TITLE
If version is not in .zsync file, use the last edit date

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="6.9-1"
+AMVERSION="6.9-2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -347,9 +347,7 @@ function _check_version_if_any_version_reference_is_somewhere() {
 function _check_version_if_zsync_file_exists() {
 	APPVERSION=$(strings -d ./$arg/*.zsync | grep -i "$(echo $arg | sed 's/-appimage//g')" | grep -Eo "([0-9]{1,}\.)+[0-9]{1,}" | head -1)
 	if [ -z "$APPVERSION" ]; then
-		if grep -q "continuous" ./$arg/version; then
-			APPVERSION="continuous"
-		fi
+		APPVERSION=$(date -r ./$arg/*.zsync "+%Y.%m.%d")
 	fi
 }
 


### PR DESCRIPTION
From now on, if the .zsync files do not have a version of the program they refer to, we will use the date of the last modification to that same file. No other files will be affected for this function (removed the reference to the "continuous" keyword in the "version" file, which should be handled by another function instead):

![Istantanea_2024-06-03_01-54-39](https://github.com/ivan-hc/AM/assets/88724353/79f63535-3b71-432a-b864-a25c8b0f30d4)

