### PR TITLE
If "AM" is read-only, suggest using "AppMan Mode" (for multiuser systems)

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="6.9-3"
+AMVERSION="6.10"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -807,7 +807,7 @@ function _sync_amcli() {
 	echo -ne '\n ◆ SYNCHRONIZING "'"$(echo "$AMCLI" | tr a-z A-Z)"'" VERSION '"$CURRENT_AM_VERSION"'...\r'; sleep 1
 	_clean_amcachedir 1>/dev/null; cd "$AMCACHEDIR" || return
 	if [ "$AMCLI" == am ] 2>/dev/null; then
-		wget -q "$AMREPO"/APP-MANAGER && chmod a+x ./APP-MANAGER && chmod 777 ./APP-MANAGER
+		wget -q "$AMREPO"/APP-MANAGER && chmod a+x ./APP-MANAGER
 		cd ..
 		echo y | mv "$AMCACHEDIR"/APP-MANAGER /opt/am/APP-MANAGER
 	else

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -639,6 +639,17 @@ if [ "$AMCLI" == am ] 2>/dev/null; then
 			AMCLIPATH="/opt/am/APP-MANAGER"
 			;;
 		esac
+	elif [ ! -w /opt/am ]; then
+		read -p " \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
+		case $yn in
+		'N'|'n')
+			exit 0;;
+		'Y'|'y'|*)
+			echo '--------------------------------------------------------------------------'
+			echo " \"AppMan Mode\" enabled!" | tr a-z A-Z
+			echo '--------------------------------------------------------------------------'
+			_use_appman 1>/dev/null;;
+		esac
 	fi
 fi
 
@@ -962,7 +973,6 @@ case "$1" in
 	'-l'|'list'|\
 	'-q'|'query')
 		MODULE="database.am"
-		_if_appman_mode_enabled
 		_use_module "$@"
 		;;
 	'-b'|'backup'|\
@@ -981,7 +991,6 @@ case "$1" in
 		;;
 	'-f'|'files')
 		MODULE="files.am"
-		_if_appman_mode_enabled
 		_use_module "$@"
 		_betatester_message_on
 		;;

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -802,7 +802,7 @@ function _sync_amcli() {
 	else
 		wget -q "$AMREPO"/APP-MANAGER -O appman && chmod a+x ./"$AMCLI"
 		cd ..
-		echo y | mv "$AMCACHEDIR"/"$AMCLI" "$AMCLIPATH"
+		echo y | mv "$AMCACHEDIR"/"$AMCLI" "$AMCLIPATH" 2>/dev/null
 	fi
 	if [ ! "$CURRENT_AM_VERSION" == "$("$AMCLIPATH" -v)" ] ; then
 		echo -ne ' A new release of "'"$(echo "$AMCLI" | tr a-z A-Z)"'" is available, please wait...\r'


### PR DESCRIPTION
# Why?

Since the beginning, the rule has always been the same: the user who installed "AM" owns "AM, and with it all the contents of the /opt/am directory.

This results in constant error messages for other users of the system, whether privileged or not, like these:

![Istantanea_2024-06-04_22-40-07 png](https://github.com/ivan-hc/AM/assets/88724353/e6cbad18-491a-4681-bccf-4b5a96c6ecf6)

# Resume of our past attempts

In the past we have already tried to make "AM" more democratic, and to do so, we tried to compare the name of the owner of /opt/am with the one that used "AM", we even tried to change the permissions making all the content writable of /opt/am, to the detriment of security... all failed attempts!

# What I've learned

But going back to the screenshot above, it is known that whatever user receives those error messages, it is definitely a user who does not have "write permissions" in /opt/am... and this is the focus of this PR .

# Solution

We have an "AppMan Mode", which can be activated with the `--user` option, so... why not suggest to these excluded users to use "AM" as non-privileged users? Like "AppMan" indeed!

# Examples

In the following examples I've already configured AppMan, so you will not see the prompt that appears when we need to configure it, this:

![Istantanea_2024-06-05_04-36-24](https://github.com/ivan-hc/AM/assets/88724353/5682fc02-3b98-4b0a-bbf0-addb7a604ddb)

## A common unprivileged user not in sudoers

This is the prompt for those who don't have write permissions in /opt/am (choose Y or N, default is Y):

![Istantanea_2024-06-05_04-24-39](https://github.com/ivan-hc/AM/assets/88724353/06968ef9-25ea-4821-bf81-c1edaa2c0a6d)

## A privileged user without "write permissions" in /opt/am

This is the same for all users without write permissions in /opt/am (here is a privileged user without permissions in /opt/am):

![Istantanea_2024-06-05_04-27-05](https://github.com/ivan-hc/AM/assets/88724353/791aa15f-ca9c-4771-9251-84326ee92cec)

## The admin that owns "AM"

For the main admin (the one that have installed "AM") its different, to enable "AppMan Mode" its necessary to use the option `--user`, as always:

![Istantanea_2024-06-05_04-30-47](https://github.com/ivan-hc/AM/assets/88724353/046bb487-9610-4c43-89f8-c6a2001dedb0)

# Update "AM" in "AppMan Mode"

The user that have installed "AM" is also the only one that can update the core script APP-MANAGER, other users are not allowed.

# How I know that I'm in "AppMan Mode"?

The following message only appears to the owner of "AM"...
```
"AM" is running as "AppMan", use am --system to switch it back to "AM"
```
...for other users, the use of "AM" in "AppMan Mode" will be discounted.

# Again, why all this?

It's all about consistency, we have to explain to the user without write permissions in /opt/am why he can't use "AM" normally, and give him a chance to use it.

# What changes are been done?

You don't need to go to https://github.com/ivan-hc/AM/pull/626/files

The changes in the code are minimal, just this part of the code in APP-MANAGER
```
	elif [ ! -w /opt/am ]; then
		read -p " \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
		case $yn in
		'N'|'n')
			exit 0;;
		'Y'|'y'|*)
			echo '--------------------------------------------------------------------------'
			echo " \"AppMan Mode\" enabled!" | tr a-z A-Z
			echo '--------------------------------------------------------------------------'
			_use_appman 1>/dev/null;;
		esac
	fi
```

this is the full condition to check if "AM" should be used in "AppMan Mode":
```
if [ "$AMCLI" == am ] 2>/dev/null; then
	if test -f "$APPMANCONFIG"/appman-mode; then
		case "$1" in
		'--system')
			_back_to_am
			;;
		''|*)
			if ! test -f "$APPMANCONFIG"/appman-config; then
				_appman_mode_enabled_message
			fi
			_appman
			AMCLIPATH="/opt/am/APP-MANAGER"
			;;
		esac
	elif [ ! -w /opt/am ]; then
		read -p " \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
		case $yn in
		'N'|'n')
			exit 0;;
		'Y'|'y'|*)
			echo '--------------------------------------------------------------------------'
			echo " \"AppMan Mode\" enabled!" | tr a-z A-Z
			echo '--------------------------------------------------------------------------'
			_use_appman 1>/dev/null;;
		esac
	fi
fi
```


