### PR TITLE
Monitor changes in the size of your installed apps!

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="6.10.1"
+AMVERSION="6.10.2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/modules/files.am
+++ b/modules/files.am
@@ -25,30 +25,31 @@ function _files_sizes() {
 		SIZE=$(du -sh -- $arg | cut -f1 -d"	")
 	fi
 	SIZE=$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')
+	echo " ◆ $arg	|	$SIZE" >> "$AMCACHEDIR"/files-sizes
 }
 
 function _files_if_binary_executable() {
-	echo " ◆ $arg	|	$APPVERSION	|	binary/executable	|	$SIZE" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	binary/executable" >> "$AMCACHEDIR"/files-type
 }
 
 function _files_if_unknown() {
-	echo " ◆ $arg	|	$APPVERSION	|	unknown	|	$SIZE" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	unknown" >> "$AMCACHEDIR"/files-type
 }
 
 function _files_if_other() {
-	echo " ◆ $arg	|	$APPVERSION	|	other	|	$SIZE" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	other" >> "$AMCACHEDIR"/files-type
 }
 
 function _files_if_launcher() {
-	echo " ◆ $arg	|	$APPVERSION	|	launcher	|	$SIZE" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	launcher" >> "$AMCACHEDIR"/files-type
 }
 
 function _files_if_set_tools() {
-	echo " ◆ $arg	|	$APPVERSION	|	set/tools	|	$SIZE" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	set/tools" >> "$AMCACHEDIR"/files-type
 }
 
 function _files_if_library() {
-	echo " ◆ $arg	|	$APPVERSION	|	library	|	$SIZE" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	library" >> "$AMCACHEDIR"/files-type
 }
 
 function _files_if_script() {
@@ -57,15 +58,15 @@ function _files_if_script() {
 	elif test -f $APPSPATH/$arg/$arg-bin; then
 		_files_if_binary_executable
 	else
-		echo " ◆ $arg	|	$APPVERSION	|	script	|	$SIZE" >> "$AMCACHEDIR"/files-args
+		echo " ◆ $arg	|	script" >> "$AMCACHEDIR"/files-type
 	fi
 }
 
 function _files_if_appimage() {
 	if [ -z "$(strings -d "./$arg/$arg" 2>/dev/null | grep -F 'AppImages require FUSE to run')" ] 2>/dev/null; then
-		echo " ◆ $arg	|	$APPVERSION	|	appimage-type3	|	$SIZE" >> "$AMCACHEDIR"/files-args
+		echo " ◆ $arg	|	appimage-type3" >> "$AMCACHEDIR"/files-type
 	else
-		echo " ◆ $arg	|	$APPVERSION	|	appimage-type2	|	$SIZE" >> "$AMCACHEDIR"/files-args
+		echo " ◆ $arg	|	appimage-type2" >> "$AMCACHEDIR"/files-type
 	fi
 }
 
@@ -118,17 +119,37 @@ function _files_type() {
 	fi
 }
 
-function _files() {
-	rm -f "$AMCACHEDIR"/files-args*
+function _files_files() {
 	cd $APPSPATH &&
 	INSTALLED_APPS=$(find -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null | sort -rh | sed 's@.*	@@')
 	if ! test -f "$AMCACHEDIR"/version-args; then
 		_check_version
 	fi
+	if ! test -f "$AMCACHEDIR"/files-type; then
+		for arg in $INSTALLED_APPS; do
+			if test -f ./$arg/remove 2>/dev/null; then
+		 		_files_type
+			fi
+		done
+	fi
+	rm -f "$AMCACHEDIR"/files-sizes
 	for arg in $INSTALLED_APPS; do
 		if test -f ./$arg/remove 2>/dev/null; then
-	 		_files_sizes
-	 		_files_type
+			_files_sizes
+		fi
+	done
+}
+
+function _files() {
+	_files_files
+	rm -f "$AMCACHEDIR"/files-args
+	INSTALLED_APPS=$(find -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null | sort -rh | sed 's@.*	@@')
+	for arg in $INSTALLED_APPS; do
+		if test -f ./$arg/remove 2>/dev/null; then
+			APPVERSION=$(cat "$AMCACHEDIR"/version-args | grep -w " ◆ $arg	|" | sed 's:.*|	::')
+			APPTYPE=$(cat "$AMCACHEDIR"/files-type | grep -w " ◆ $arg	|" | sed 's:.*|	::')
+			APPSYZE=$(cat "$AMCACHEDIR"/files-sizes | grep -w " ◆ $arg	|" | sed 's:.*|	::')
+			echo " ◆ $arg	|	$APPVERSION	|	$APPTYPE	|	$APPSYZE" >> "$AMCACHEDIR"/files-args
 		fi
 	done
 }
@@ -142,14 +163,9 @@ function _files_show_only_number() {
 function _files_sort_by_name() {
 	_files_header
 	rm -f "$AMCACHEDIR"/files-args-byname
-	if test -f "$AMCACHEDIR"/files-args; then
-		echo -e "- APPNAME | VERSION | TYPE | SIZE \n- ------- | ------- | ---- | ----" >> "$AMCACHEDIR"/files-args-byname
-		cat "$AMCACHEDIR"/files-args 2>/dev/null | sort >> "$AMCACHEDIR"/files-args-byname
-	else
-		_files
-		echo -e "- APPNAME | VERSION | TYPE | SIZE \n- ------- | ------- | ---- | ----" >> "$AMCACHEDIR"/files-args-byname
-		cat "$AMCACHEDIR"/files-args 2>/dev/null | sort >> "$AMCACHEDIR"/files-args-byname
-	fi
+	_files
+	echo -e "- APPNAME | VERSION | TYPE | SIZE \n- ------- | ------- | ---- | ----" >> "$AMCACHEDIR"/files-args-byname
+	cat "$AMCACHEDIR"/files-args 2>/dev/null | sort >> "$AMCACHEDIR"/files-args-byname
 	cat "$AMCACHEDIR"/files-args-byname | column -t
 	echo ""
 }
@@ -157,14 +173,9 @@ function _files_sort_by_name() {
 function _files_sort_by_size() {
 	_files_header
 	rm -f "$AMCACHEDIR"/files-args-bysize
-	if test -f "$AMCACHEDIR"/files-args; then
-		echo -e "- APPNAME | VERSION | TYPE | SIZE \n- ------- | ------- | ---- | ----" >> "$AMCACHEDIR"/files-args-bysize
-		cat "$AMCACHEDIR"/files-args >> "$AMCACHEDIR"/files-args-bysize 2>/dev/null
-	else
-		_files
-		echo -e "- APPNAME | VERSION | TYPE | SIZE \n- ------- | ------- | ---- | ----" >> "$AMCACHEDIR"/files-args-bysize
-		cat "$AMCACHEDIR"/files-args >> "$AMCACHEDIR"/files-args-bysize 2>/dev/null
-	fi
+	_files
+	echo -e "- APPNAME | VERSION | TYPE | SIZE \n- ------- | ------- | ---- | ----" >> "$AMCACHEDIR"/files-args-bysize
+	cat "$AMCACHEDIR"/files-args >> "$AMCACHEDIR"/files-args-bysize 2>/dev/null
 	cat "$AMCACHEDIR"/files-args-bysize | column -t
 	echo ""
 }

--- a/modules/files.am
+++ b/modules/files.am
@@ -146,9 +146,9 @@ function _files() {
 	INSTALLED_APPS=$(find -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null | sort -rh | sed 's@.*	@@')
 	for arg in $INSTALLED_APPS; do
 		if test -f ./$arg/remove 2>/dev/null; then
-			APPVERSION=$(cat "$AMCACHEDIR"/version-args | grep -w " ◆ $arg	|" | sed 's:.*|	::')
-			APPTYPE=$(cat "$AMCACHEDIR"/files-type | grep -w " ◆ $arg	|" | sed 's:.*|	::')
-			APPSYZE=$(cat "$AMCACHEDIR"/files-sizes | grep -w " ◆ $arg	|" | sed 's:.*|	::')
+			APPVERSION=$(cat "$AMCACHEDIR"/version-args | grep -w " ◆ $arg	|" | tr '	' '\n' | tail -1)
+			APPTYPE=$(cat "$AMCACHEDIR"/files-type | grep -w " ◆ $arg	|" | tr '	' '\n' | tail -1)
+			APPSYZE=$(cat "$AMCACHEDIR"/files-sizes | grep -w " ◆ $arg	|" | tr '	' '\n' | tail -1)
 			echo " ◆ $arg	|	$APPVERSION	|	$APPTYPE	|	$APPSYZE" >> "$AMCACHEDIR"/files-args
 		fi
 	done

--- a/modules/files.am
+++ b/modules/files.am
@@ -24,30 +24,31 @@ function _files_sizes() {
 	else
 		SIZE=$(du -sh -- $arg | cut -f1 -d"	")
 	fi
+	SIZE=$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')
 }
 
 function _files_if_binary_executable() {
-	echo " ◆ $arg	|	$APPVERSION	|	binary/executable	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	$APPVERSION	|	binary/executable	|	$SIZE" >> "$AMCACHEDIR"/files-args
 }
 
 function _files_if_unknown() {
-	echo " ◆ $arg	|	$APPVERSION	|	unknown	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	$APPVERSION	|	unknown	|	$SIZE" >> "$AMCACHEDIR"/files-args
 }
 
 function _files_if_other() {
-	echo " ◆ $arg	|	$APPVERSION	|	other	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	$APPVERSION	|	other	|	$SIZE" >> "$AMCACHEDIR"/files-args
 }
 
 function _files_if_launcher() {
-	echo " ◆ $arg	|	$APPVERSION	|	launcher	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	$APPVERSION	|	launcher	|	$SIZE" >> "$AMCACHEDIR"/files-args
 }
 
 function _files_if_set_tools() {
-	echo " ◆ $arg	|	$APPVERSION	|	set/tools	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	$APPVERSION	|	set/tools	|	$SIZE" >> "$AMCACHEDIR"/files-args
 }
 
 function _files_if_library() {
-	echo " ◆ $arg	|	$APPVERSION	|	library	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+	echo " ◆ $arg	|	$APPVERSION	|	library	|	$SIZE" >> "$AMCACHEDIR"/files-args
 }
 
 function _files_if_script() {
@@ -56,15 +57,15 @@ function _files_if_script() {
 	elif test -f $APPSPATH/$arg/$arg-bin; then
 		_files_if_binary_executable
 	else
-		echo " ◆ $arg	|	$APPVERSION	|	script	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+		echo " ◆ $arg	|	$APPVERSION	|	script	|	$SIZE" >> "$AMCACHEDIR"/files-args
 	fi
 }
 
 function _files_if_appimage() {
 	if [ -z "$(strings -d "./$arg/$arg" 2>/dev/null | grep -F 'AppImages require FUSE to run')" ] 2>/dev/null; then
-		echo " ◆ $arg	|	$APPVERSION	|	appimage-type3	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+		echo " ◆ $arg	|	$APPVERSION	|	appimage-type3	|	$SIZE" >> "$AMCACHEDIR"/files-args
 	else
-		echo " ◆ $arg	|	$APPVERSION	|	appimage-type2	|	$(echo "$SIZE" | sed 's/.$/ &/' | sed 's/$/iB/')" >> "$AMCACHEDIR"/files-args
+		echo " ◆ $arg	|	$APPVERSION	|	appimage-type2	|	$SIZE" >> "$AMCACHEDIR"/files-args
 	fi
 }
 
@@ -125,7 +126,7 @@ function _files() {
 		_check_version
 	fi
 	for arg in $INSTALLED_APPS; do
-		 if test -f ./$arg/remove 2>/dev/null; then
+		if test -f ./$arg/remove 2>/dev/null; then
 	 		_files_sizes
 	 		_files_type
 		fi


### PR DESCRIPTION
Now information about the size, type, and version of each app will be listed in three different files before being merged under a single file that will show information about individual installed apps.

This is to constantly update the file that lists the sizes of the applications. They will thus be monitored constantly.

The file relating to the type of app will remain unchanged, so as to avoid slowdowns, the same goes for the file that lists the versions (with the exception of self-updating applications, for example Firefox and Thunderbird).

In the example, here we have "chromium" installed with "AppMan":

- the old dimensions are indicated in the blue rectangles;
- the large green rectangle in the center indicates the AppImage launched from the terminal and which uses a .home directory previously created with the option `-H`, so as not to disperse the dotfiles in the user's $HOME;
- in the red rectangles there is a change in size after using the app.
 
 
![Istantanea_2024-06-06_21-53-09](https://github.com/ivan-hc/AM/assets/88724353/06c52040-8b37-4792-9b89-4e10340e39f7)

May users always keep an eye on their installed apps and have absolute control over their "AM"/"AppMan" experience!