### PR TITLE
Update AM-SAMPLE-AppImage

### DIFF
--- a/modules/template.am
+++ b/modules/template.am
@@ -314,7 +314,7 @@ while [ -n "$1" ]; do
 								mv ./am-scripts/$arch/$arg ./am-scripts/$arch/$arg.old
 								sed -n '1,14p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
 								echo 'version=$('$DOWNLOADURL')' >> ./am-scripts/$arch/$arg
-								sed -n '15,34p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
+								sed -n '16,34p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
 								echo 'version=$('$DOWNLOADURL')' >> ./am-scripts/$arch/$arg
 								sed -n '36,71p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
 								rm -f ./am-scripts/$arch/$arg.old;;

--- a/modules/template.am
+++ b/modules/template.am
@@ -312,9 +312,9 @@ while [ -n "$1" ]; do
 							case "$DOWNLOADURL" in
 							*)
 								mv ./am-scripts/$arch/$arg ./am-scripts/$arch/$arg.old
-								sed -n '1,18p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
+								sed -n '1,14p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
 								echo 'version=$('$DOWNLOADURL')' >> ./am-scripts/$arch/$arg
-								sed -n '20,34p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
+								sed -n '15,34p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
 								echo 'version=$('$DOWNLOADURL')' >> ./am-scripts/$arch/$arg
 								sed -n '36,71p' ./am-scripts/$arch/$arg.old >> ./am-scripts/$arch/$arg
 								rm -f ./am-scripts/$arch/$arg.old;;

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -39,7 +39,7 @@ SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if [ "$version" != "$version0" ] || test -f "/opt/$APP/*.zsync"; then
+if [ "$version" != "$version0" ] || test -f /opt/"$APP"/*.zsync; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -39,7 +39,7 @@ SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if test -f "/opt/$APP/*.zsync"; then
+if test -f /opt/"$APP"/*.zsync; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version.zsync" || exit 1
 	cd ..
@@ -57,7 +57,6 @@ elif [ "$version" != "$version0" ]; then
 
 	cd ..
 	mv --backup=t ./tmp/*mage ./"$APP" || exit 1
-	mv --backup=t ./tmp/* ./"$APP"
 	chmod a+x "/opt/$APP/$APP"
 	echo "$version" > ./version
 	notify-send "$APP is updated!"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -54,6 +54,7 @@ elif [ "$version" != "$version0" ]; then
 	notify-send "A new version of $APP is available, please wait"
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version" || exit 1
+
 	cd ..
 	mv --backup=t ./tmp/*mage ./"$APP" || exit 1
 	mv --backup=t ./tmp/* ./"$APP"

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -39,26 +39,15 @@ SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if test -f /opt/"$APP"/*.zsync; then
+if [ "$version" != "$version0" ] || test -f "/opt/$APP/*.zsync"; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
-	wget "$version.zsync" || exit 1
+	wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
 	cd ..
-	mv ./tmp/*.zsync ./"$APP".zsync
-	zsync "/opt/$APP/$APP.zsync"
-	rm -R -f ./*zs-old ./*.part ./tmp
-	chmod a+x "/opt/$APP/$APP"
-	echo "$version" > /opt/$APP/version
-	notify-send "$APP is updated!"
-	exit 0
-elif [ "$version" != "$version0" ]; then
-	notify-send "A new version of $APP is available, please wait"
-	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
-	wget "$version" || exit 1
-
-	cd ..
-	mv --backup=t ./tmp/*mage ./"$APP" || exit 1
-	chmod a+x "/opt/$APP/$APP"
+	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
+	zsync "/opt/$APP/$APP.zsync" 2>/dev/null
+	chmod a+x "/opt/$APP/$APP" || exit 1
 	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
 	notify-send "$APP is updated!"
 	exit 0
 fi

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -1,90 +1,83 @@
 #!/bin/sh
 
+# AM INSTALL SCRIPT VERSION 3. 
+
+set -u
 APP=SAMPLE
 SITE="REPLACETHIS"
 
-# CREATE DIRECTORIES
-if [ -z "$APP" ]; then exit 1; fi
-mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
-
-# ADD THE REMOVER
-echo "#!/bin/sh
-rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
-rm -R -f /opt/$APP" > "/opt/$APP/remove"
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+echo "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
+echo "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP
 # $version is also used for updates
 
+
 version=$(FUNCTION)
-wget "$version"
+wget "$version" || exit 1
 wget "$version.zsync" 2> /dev/null
 echo "$version" >> /opt/$APP/version
 # Use tar fx ./*tar* for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
-mv ./tmp/*.zsync ./"$APP".zsync 2> /dev/null
-chmod a+x "/opt/$APP/$APP"
-rm -R -f ./tmp
+mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
+rm -R -f ./tmp || exit 1
+chmod a+x "/opt/$APP/$APP" || exit 1
 
-# LINK
+# LINK TO PATH
 ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> "/opt/$APP/AM-updater" << 'EOF'
 #!/bin/sh
+set -u
 APP=SAMPLE
 SITE="REPLACETHIS"
-if [ -z "$APP" ]; then exit 1; fi
 version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if test -f "/opt/$APP/*.zsync"; then
-	mkdir "/opt/$APP/tmp"
-	cd "/opt/$APP/tmp" || exit 1
-	wget "$version.zsync" 2> /dev/null
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	wget "$version.zsync" || exit 1
 	cd ..
 	mv ./tmp/*.zsync ./"$APP".zsync
-	rm -R -f ./tmp
 	zsync "/opt/$APP/$APP.zsync"
-	rm -R -f "/opt/$APP/*zs-old" "/opt/$APP/*.part"
+	rm -R -f ./*zs-old ./*.part ./tmp
 	chmod a+x "/opt/$APP/$APP"
-	if [ "$version" != "$version0" ]; then
-		echo "$version" > /opt/$APP/version
-	fi
-else
-	if [ "$version" = "$version0" ]; then
-		echo "Update not needed!" && exit 0
-	else
-		notify-send "A new version of $APP is available, please wait"
-		mkdir "/opt/$APP/tmp"
-		cd "/opt/$APP/tmp" || exit 1
-		wget $version
-		if ls . | grep mage; then
-			
-			cd ..
-			
-	  		if ! test -f ./tmp/*mage; then exit 1; fi
-	  		echo "$version" > ./version
-	  		mv --backup=t ./tmp/* ./"$APP"
-	  		chmod a+x "/opt/$APP/$APP"
-	  		rm -R -f ./tmp ./*~
-		fi
-		notify-send "$APP is updated!"
-	fi
+	echo "$version" > /opt/$APP/version
+	notify-send "$APP is updated!"
+	exit 0
+elif [ "$version" != "$version0" ]; then
+	notify-send "A new version of $APP is available, please wait"
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	wget "$version" || exit 1
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP" || exit 1
+	mv --backup=t ./tmp/* ./"$APP"
+	chmod a+x "/opt/$APP/$APP"
+	echo "$version" > ./version
+	notify-send "$APP is updated!"
+	exit 0
 fi
+echo "Update not needed!"
 EOF
 chmod a+x "/opt/$APP/AM-updater"
 
 # LAUNCHER & ICON
 cd "/opt/$APP" || exit 1
-./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
-./"$APP" --appimage-extract share/applications/*.desktop 1>/dev/null && mv ./squashfs-root/share/applications/*.desktop ./"$APP".desktop
-./"$APP" --appimage-extract usr/share/applications/*.desktop 1>/dev/null && mv ./squashfs-root/usr/share/applications/*.desktop ./"$APP".desktop
+if [ -L ./"$APP".desktop ]; then
+	LINKPATH=$(readlink ./"$APP".desktop)
+	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+fi
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 if [ -L ./DirIcon ]; then
 	LINKPATH=$(readlink ./DirIcon)
 	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 fi
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
-mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 2>/dev/null
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -19,8 +19,8 @@ chmod a+x "/opt/$APP/remove"
 version=$(FUNCTION)
 wget "$version" || exit 1
 wget "$version.zsync" 2> /dev/null
-echo "$version" >> /opt/$APP/version
-# Use tar fx ./*tar* for example in this line in case a compressed file is downloaded.
+echo "$version" > /opt/$APP/version
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
 mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
@@ -42,6 +42,7 @@ version=$(FUNCTION)
 if [ "$version" != "$version0" ] || test -f "/opt/$APP/*.zsync"; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
 	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
 	zsync "/opt/$APP/$APP.zsync" 2>/dev/null


### PR DESCRIPTION
Hey @ivan-hc I noticed you were updating the WINE appimages, I assume it was because of what I told you about hyperfine having a check before downloading.

However we are still using the older template in the repo, the template that I was talking about is something that I was experimenting with personally, I haven't done the PR because I don't know if it works ok with appimages that have a `zsync` file. So I'm making this PR with those changes included (+ some more).

**I HAVE NOT TESTED THIS YET!** (I mean this exact template, but most of the changes here have been tested in several apps before).

-------------------------------------------------------------------------

The main questions are: 

* Does the way I changed the zsync work? The only appimage that I use that has a zsync file is libreoffice, and that one uses a whole different script. **Also should the AM-updater script exit 1 if the zsync download fails or should it then try to manually download the file? (that wasn't being done before btw).**

**Also I think there was a mistake before**, there were was a `rm -R -f "/opt/$APP/*zs-old" "/opt/$APP/*.part"` but I that will not work, because the wildcard `*` inside quotes `""` doesn't expand as far as I know lol. Sorry if it was me that made this change before.

* The other questions is, are there appimages that don't have a top level .desktop file or symlink?

I made this change: 

```
./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
if [ -L ./"$APP".desktop ]; then
	LINKPATH=$(readlink ./"$APP".desktop)
	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
fi
```

So that we don't have to try several different .desktop locations like we were doing before with the Icon, however this will not work if it is possible for an appimage to not have a top level `.desktop` file, I've seen some that have a symlink and that works here, but if there is no symlink or .desktop it will not work. I don't know if it is possible for one to exist. 

* Finally does `$version` still need to be on line 19?

