### PR TITLE
Fix messages for "nolibfuse" after discovery of "fake" updates with zsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ to have a list of the installed programs use the option `-f` or `files` (syntax 
 
  `nolibfuse {PROGRAM}`
 
- DESCRIPTION:   Convert an installed Type2 AppImage to a Type3 AppImage. Type3 AppImages does not require libfuse2 installed. Only AppImages updatable with "zsync" can be updated keeping this format. Others will be replaced with the one provided from the upstream.
+ DESCRIPTION:   Convert an installed Type2 AppImage to a Type3 AppImage. Type3 AppImages does not require libfuse2 installed.
  __________________________________________________________________________
 
  `unlock`
@@ -781,17 +781,15 @@ Since version 6.1 it is possible to convert old Type2 AppImages (dependent on `l
 am nolibfuse ${PROGRAM}
 ```
 First the selected program type is checked, if it is a Type2 AppImage, it will be extracted and repackaged using the new version of `appimagetool` from https://github.com/probonopd/go-appimage :
-- If the installed AppImage can be updated via `zsync`, the update will take place while maintaining the status of Type3 AppImage;
-- On the contrary, if the update occurs through "comparison" of versions, the converted AppImage will be replaced by the upstream version, which could still be Type2. But from version 6.1.1 the command is added within the application's AM-updater script, so as to automatically start the conversion at each update (prolonging the update time, depending on the size of the AppImage). **I suggest anyone to contact the developers to update the packaging method of their AppImage!**
+- if the update occurs through "comparison" of versions, the converted AppImage will be replaced by the upstream version and the command is added within the application's AM-updater script, so as to automatically start the conversion at each update (prolonging the update time, depending on the size of the AppImage);
+- instead, if the installed AppImage can be updated via `zsync`, **this may no longer be updatable**.
+
+**I suggest anyone to contact the developers to update the packaging method of their AppImage!**
 
 NOTE, the conversion is not always successful, a lot depends on how the program is packaged. The conversion occurs in two steps:
-- if in the first case it succeeds without problems, the package will be repackaged as it was, but of Type 3 (and the AM-updater script will be patched if a .zsync file doesn't exist);
-- if the script encounters problems (due to Appstream validation), it will attempt to delete the contents of the /usr/share/metainfo directory inside the AppImage, as a workaround (which will probably make updates via `zsync` unusable);
+- if in the first case it succeeds without problems, the package will be repackaged as it was, but of Type 3;
+- if the script encounters problems (due to Appstream validation), it will attempt to delete the contents of the /usr/share/metainfo directory inside the AppImage, as a workaround;
 - if this step does not succeed either, the process will end with an error and the AppImage will remain Type2.
-
-See the video:
-
-https://github.com/ivan-hc/AM/assets/88724353/8b45d2c2-d2da-4a07-8b43-0cd77ffcb7cc
 
 </details>
 

--- a/modules/help.am
+++ b/modules/help.am
@@ -319,10 +319,6 @@ function _help_body() {
  DESCRIPTION:	Convert an installed Type2 AppImage to a Type3 AppImage.
 
  Type3 AppImages does not require libfuse2 installed.
-
- Only AppImages updatable with "zsync" can be updated keeping this format.
-
- Others will be replaced with the one provided from the upstream.
  __________________________________________________________________________
 
  unlock

--- a/modules/management.am
+++ b/modules/management.am
@@ -256,10 +256,62 @@ function _do_overwrite() {
 # FUNCTION TO CONVERT TYPE2 APPIMAGES TO TYPE3
 ##############################################
 
+function _nolibfuse_if_zsync_file_exists() {
+	if test -f ./*.zsync; then
+		echo "-----------------------------------------------------------------------"
+		echo -e " Warning! Your AppImage uses \"zsync\" to update. The .zsync file will\n no longer work and will be removed.\n"
+		echo -e " If your \"AM-updater\" script can compare versions, the update method\n will be changed, by downloading the new AppImage version in full,\n from the source.\n"
+		read -p " Do you want to proceede anyway (N,y)?" yn
+		case "$yn" in
+		'y'|'Y') echo "-----------------------------------------------------------------------";;
+		'n'|'N'|*) echo "-----------------------------------------------------------------------"; exit;;
+		esac
+	fi
+}
+
+function _nolibfuse_download_appimagetool() {
+	wget -q "$(curl -Ls $HeaderAuthWithGITPAT https://api.github.com/repos/probonopd/go-appimage/releases \
+		| grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url \
+		| cut -d '"' -f 4 | head -1)" -O appimagetool
+	chmod a+x ./appimagetool
+}
+
+function _nolibfuse_command_to_convert_to_type3_appimage() {
+	chmod 0755 ./squashfs-root
+	ARCH="$(uname -m)" VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./squashfs-root > /dev/null 2> /dev/null
+}
+
+function _nolibfuse_if_appimage_has_been_converted() {
+	rm -R -f ./appimagetool ./squashfs-root
+	if test -f ./AM-updater; then
+		if test -f ./*.zsync; then
+			rm -f ./*.zsync
+		fi
+		if ! grep -q 'nolibfuse' ./AM-updater; then
+			echo -e '\necho y | '$AMCLIPATH' nolibfuse $APP' >> ./AM-updater
+			echo -e "\n The next update may replace this AppImage with a Type2 one\n so I added this command to the bottom of the \"AM-updater\" script!"
+		fi
+	fi
+	echo -e "\n Contact the upstream developers to make them officially switch to Type3! \n"
+	read -p " Do you wish to remove the old Type2 AppImage (Y,n)?" yn
+	case $yn in
+	[Nn]* )
+		exit
+		;;
+	[Yy]*|* )
+		rm -R -f ./*.old
+		if test -f ./*.zsync; then
+			rm -f ./*.zsync
+		fi
+		exit
+		;;
+	esac
+}
+
 function _do_nolibfuse() {
 	cd "$APPSPATH" || exit 1
-	if test -f ./$2/$2 2>/dev/null; then
-		cd ./$2 || return
+	if test -f "./$2/$2" 2>/dev/null; then
+		cd ./"$2" || return
 		if [ -z "$(strings -d "./$2" 2>/dev/null | grep -F 'if you run it with the --appimage-extract option')" ] 2>/dev/null; then
 			echo " ⚠️ Error: $(echo "${2}" | tr a-z A-Z) is NOT an AppImage."
 			exit
@@ -268,40 +320,18 @@ function _do_nolibfuse() {
 				echo " ◆ $(echo "${2}" | tr a-z A-Z) is already a Type3 AppImage."
 				exit
 			else
-				wget -q "$(curl -Ls $HeaderAuthWithGITPAT https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1)" -O appimagetool
-				chmod a+x ./appimagetool
+				_nolibfuse_if_zsync_file_exists
+				_nolibfuse_download_appimagetool
 				echo -ne " ...extracting the AppImage\r"
-				./$2 --appimage-extract 2> /dev/null | grep -v "squashfs-root"
+				./"$2" --appimage-extract 2> /dev/null | grep -v "squashfs-root"
 				echo -ne " ...trying to convert in Type3 AppImage\r"
-				chmod 0755 ./squashfs-root
-				ARCH="$(uname -m)" VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./squashfs-root > /dev/null 2> /dev/null
+				_nolibfuse_command_to_convert_to_type3_appimage
 				if test -f ./*.AppImage; then
 					_remove_info_files
 					mv ./"$2" ./"$2".old
 					mv ./*.AppImage ./"$2"
-					echo " ◆ $(echo $2 | tr a-z A-Z) has been converted to Type3 AppImage."
-					rm -R -f ./appimagetool ./squashfs-root
-					if ! test -f ./*.zsync; then
-						echo " Note, your installed Appimage have not a .zsync file."
-						if test -f ./AM-updater; then
-							if ! grep -q 'nolibfuse' ./AM-updater; then
-								echo -e '\necho y | '$AMCLIPATH' nolibfuse $APP' >> ./AM-updater
-								echo " The next update may replace this AppImage with a Type2 one..."
-								echo ' ...so I added this command to the bottom of the "AM-updater" script!'
-							fi
-						fi
-					fi
-					echo -e " Contact the upstream developers to make them officially switch to Type3!\n"
-					read -p " Do you wish to remove the old Type2 AppImage (Y,n)?" yn
-					case $yn in
-						[Nn]* )
-							exit
-							;;
-						[Yy]*|* )
-							rm -R -f ./$2.old
-							exit
-							;;
-					esac
+					echo " ◆ $(echo "$2" | tr a-z A-Z) has been converted to Type3 AppImage."
+					_nolibfuse_if_appimage_has_been_converted
 				else
 					metainfodir=$(find ./squashfs-root -type d -name metainfo | grep "share/metainfo" | head -1)
 					if [ -z "$metainfodir" ]; then
@@ -314,37 +344,15 @@ function _do_nolibfuse() {
 						cd - > /dev/null || return
 					fi
 					echo -ne " ...found Appstream errors, I'm trying to fix them...\r"
-					ARCH="$(uname -m)" VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./squashfs-root > /dev/null 2> /dev/null
+					_nolibfuse_command_to_convert_to_type3_appimage
 					if test -f ./*.AppImage; then
 						_remove_info_files
 						mv ./"$2" ./"$2".old
 						mv ./*.AppImage ./"$2"
-						echo " ◆ $(echo $2 | tr a-z A-Z) has been converted to Type3 AppImage."
-						if test -f ./*.zsync; then
-							echo 'However, when trying again I had to remove some files to update with "zsync".'
-						else
-							if test -f ./AM-updater; then
-							if ! grep -q 'nolibfuse' ./AM-updater; then
-								echo -e '\necho y | '$AMCLIPATH' nolibfuse $APP' >> ./AM-updater
-								echo " The next update may replace this AppImage with a Type2 one..."
-								echo ' ...so I added this command to the bottom of the "AM-updater" script!'
-							fi
-						fi
-						fi
-						echo -e " Contact the upstream developers to make them officially switch to Type3!\n"
-						rm -R -f ./appimagetool ./squashfs-root
-						read -p " Do you wish to remove the old one (Y,n)?" yn
-						case $yn in
-							[Nn]* )
-								exit
-								;;
-							[Yy]*|* )
-								rm -R -f ./$2.old
-								exit
-								;;
-						esac
+						echo " ◆ $(echo "$2" | tr a-z A-Z) has been converted to Type3 AppImage."
+						_nolibfuse_if_appimage_has_been_converted
 					else
-						echo " 💀Errors while trying to export $(echo $2 | tr a-z A-Z) from Type2 AppImage. Aborted."
+						echo " 💀Errors while trying to export $(echo "$2" | tr a-z A-Z) from Type2 AppImage. Aborted."
 						rm -R -f ./appimagetool ./squashfs-root; exit
 					fi
 				fi


### PR DESCRIPTION
Unfortunately I was fooled by the notifications and tests with "AM" and "AppMan", and the various outputs about new releases in Libreoffice... instead of testing the "zsync" command directly in the terminal.

My collaborator @Samueru-sama pointed this out to me: the updates that were downloaded could not be inserted into the AppImage package. "Zsync" did not recognize the destination file. The screenshot below explains everything:

![image](https://github.com/ivan-hc/AM/assets/36420837/81d897ba-1dd6-47ce-bd4a-9ad0f3cfed05)

This is the whole conversation https://github.com/ivan-hc/AM/pull/639#issuecomment-2156949590

-------------------------------------


In this PR I've changed the messages in the README, the help.am and management.am modules.

The function for the option "nolibfuse" has been divided in more functions.

The new messages available are these:

### If any other AppImage without a .zsync file

![Istantanea_2024-06-10_06-12-13 png](https://github.com/ivan-hc/AM/assets/88724353/b09e6d7a-5dfd-4af6-9c06-121c0d716752)

### If a file .zsync exists

![Istantanea_2024-06-10_06-09-53 png](https://github.com/ivan-hc/AM/assets/88724353/a44d8781-19fc-4e44-8295-8795d4ee9bfd)

If the conversion in Type3 is success, then the .zsync file will be removed, if you remove the olf Type2 AppImage.

Anyway, if the AM-updater script supports the comparison of the versions, you can still update the AppImage using this method.

This is how a new generation AM-updater appears for now after being converted to Type3 Appimage, here "`brave-appimage`"
```
#!/usr/bin/env bash
APP=brave-appimage
SITE="srevinsaju/Brave-AppImage"
version0=$(cat /opt/$APP/version)
version=$(curl -Ls https://api.github.com/repos/srevinsaju/Brave-AppImage/releases/latest?per_page=100 | jq '.' | grep browser_download_url | grep -i stable  | grep -i appimage | cut -d '"' -f 4 | head -1)
if test -f /opt/$APP/*.zsync; then
	mkdir /opt/$APP/tmp
	cd /opt/$APP/tmp
	wget -q --no-verbose --show-progress --progress=bar $version.zsync 2> /dev/null
	cd ..
	mv ./tmp/*.zsync ./$APP.zsync
	rm -R -f ./tmp
	zsync /opt/$APP/$APP.zsync
	rm -R -f /opt/$APP/*zs-old /opt/$APP/*.part
	chmod a+x /opt/$APP/$APP
	if [ "$version" != "$version0" ]; then
		rm -f /opt/$APP/version
		echo "$version" >> /opt/$APP/version
	fi
else
	if [ $version = $version0 ]; then
		echo "Update not needed!"
	else
		notify-send "A new version of $APP is available, please wait"
		mkdir /opt/$APP/tmp
		cd /opt/$APP/tmp
		wget -q --no-verbose --show-progress --progress=bar $version
		if ls . | grep mage; then
			
			cd ..
			
	  		if test -f ./tmp/*mage; then rm ./version
	  		fi
	  		echo $version >> ./version
	  		mv --backup=t ./tmp/* ./$APP
	  		chmod a+x /opt/$APP/$APP
	  		rm -R -f ./tmp ./*~
		fi
		notify-send "$APP is updated!"
	fi
fi

echo y | am nolibfuse $APP
```
the last command has been included when the AppImage was converted to Type3.

In case you have not a .zsync file, the comparison method will be used instead.

---------------------------------

NOTE, future AM-updater for AppImages may be a bit different, since, while I'm writing this, my cooperator @Samueru-sama is working on the new templates, at https://github.com/ivan-hc/AM/pull/639