### PR TITLE
Small improvement, ready to merge

### DIFF
--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -55,15 +55,15 @@ chmod a+x "/opt/$APP/AM-updater"
 # LAUNCHER & ICON
 cd "/opt/$APP" || exit 1
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
-if [ -L ./"$APP".desktop ]; then
+while [ -L ./"$APP".desktop ]; do
 	LINKPATH=$(readlink ./"$APP".desktop)
 	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
-fi
+done
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
-if [ -L ./DirIcon ]; then
+while [ -L ./DirIcon ]; do
 	LINKPATH=$(readlink ./DirIcon)
 	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
-fi
+done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -57,7 +57,7 @@ cd "/opt/$APP" || exit 1
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
-while [ $COUNT -ne 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink.
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
 	if [ -L ./"$APP".desktop ]; then
 		LINKPATH=$(readlink ./"$APP".desktop)
 		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -55,14 +55,19 @@ chmod a+x "/opt/$APP/AM-updater"
 # LAUNCHER & ICON
 cd "/opt/$APP" || exit 1
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
-while [ -L ./"$APP".desktop ]; do
-	LINKPATH=$(readlink ./"$APP".desktop)
-	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
-done
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
-while [ -L ./DirIcon ]; do
-	LINKPATH=$(readlink ./DirIcon)
-	./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+COUNT=0
+while [ $COUNT -ne 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink.
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH=$(readlink ./"$APP".desktop)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH=$(readlink ./DirIcon)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null


### PR DESCRIPTION
This way I don't have to be repeating code if the appimage contains a symlink to another symlink. 

However it means that it is possible for the script to get stuck in a loop if the appimage for some reason has a symlink loop ( I don't think that is possible but be aware of that if a install script ever hangs and uses a lot of cpu lol). 
