### PR TITLE
Dev

### DIFF
--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -35,7 +35,7 @@ SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync]; then
+if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -35,13 +35,13 @@ SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(FUNCTION)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if [ "$version" != "$version0" ] || test -f /opt/"$APP"/*.zsync; then
+if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
 	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
-	zsync "/opt/$APP/$APP.zsync" 2>/dev/null
+	[ -e /opt/"$APP"/*.zsync] && { zsync "/opt/$APP/$APP.zsync" || notify-send -u critical "zsync failed to update $APP"; }
 	chmod a+x "/opt/$APP/$APP" || exit 1
 	echo "$version" > ./version
 	rm -R -f ./*zs-old ./*.part ./tmp ./*~


### PR DESCRIPTION
This change makes is obvious when the zsync update fails. 

Lets wait to see what happens at cpu-x before deciding on removing the file all together lol. 

Btw this new template is pretty much ready to be merged into main, the only thing is that the line that downloads the `.zsync` file can be disabled in the meantime. 