### PR TITLE
Temporary disable zsync downloads

### DIFF
--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -14,7 +14,7 @@ chmod a+x "/opt/$APP/remove"
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
 version=$(FUNCTION)
 wget "$version" || exit 1
-#wget "$version.zsync" 2> /dev/null
+#wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync, warning that more often than not it is broken
 echo "$version" > /opt/$APP/version
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -14,7 +14,7 @@ chmod a+x "/opt/$APP/remove"
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
 version=$(FUNCTION)
 wget "$version" || exit 1
-wget "$version.zsync" 2> /dev/null
+#wget "$version.zsync" 2> /dev/null
 echo "$version" > /opt/$APP/version
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..


### PR DESCRIPTION
We already ran into two appimages with broken zsync, those are `brave` and `cpu-x`

This disables it until we figure out a way to fix those issues. In the meantime we should only focus on getting zsync to work on big applications like libreoffice (which it does work already). 