### PR TITLE
Fix issue with flags

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -114,8 +114,7 @@ case "$1" in
 		fi
 		# Start at sandboxed home
 		# Edit below this to add or remove access to parts of the system
-		exec aisap --trust-once \
-		--level 2 \
+		exec aisap --trust-once --level 2 \
 		--data-dir "$SANDBOXDIR" \
 		--add-file "$DATADIR"/themes \
 		--add-file "$DATADIR"/icons \
@@ -131,7 +130,7 @@ case "$1" in
 		--add-socket pulseaudio \
 		--add-socket network \
 		--add-device dri \
-		"$APPEXEC" "$@"
+		"$APPEXEC" -- "$@"
 		HEREDOC
 		$SUDOCOMMAND mv "$AMCACHEDIR/sandbox-scripts/$2" "$TARGET" &&
 		rmdir "$AMCACHEDIR/sandbox-scripts" &&


### PR DESCRIPTION
Turns out aisap also takes flags after `$APPEXEC` and this causes an issue that it can conflict with app specific flags.

grep has a similar issue when you are parsing flags, the solution is the same `--`.