### PR TITLE
Update sandboxes.am

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -118,10 +118,10 @@ case "$1" in
 		# Edit below this to add or remove access to parts of the system
 		exec aisap --trust-once --level 2 \
 		--data-dir "$SANDBOXDIR/$APPNAME" \
-		--add-file "$DATADIR/$APPNAME" \
+		--add-file "$DATADIR/$APPNAME":rw \
 		--add-file "$DATADIR"/themes \
 		--add-file "$DATADIR"/icons \
-		--add-file "$CONFIGDIR/$APPNAME" \
+		--add-file "$CONFIGDIR/$APPNAME":rw \
 		--add-file "$CONFIGDIR"/gtk3.0 \
 		--add-file "$CONFIGDIR"/gtk4.0 \
 		--add-file "$CONFIGDIR"/kdeglobals \


### PR DESCRIPTION
This gives write access to the sandboxed application to its own config/data directory in home, as by default it is read only (with the exception of the sandboxed home which does have write access by default)