### PR TITLE
Lots of improvements

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -100,6 +100,11 @@ case "$1" in
 		DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 		CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 		CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+		# Try to find the right name of the app xdg directories, as sometimes it is not the same as $APPNAME
+		APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )
+		APPCONF=$( ls "$CONFIGDIR" | grep -i "$APPNAME" | head -1 ) 
+
 		mkdir -p "$SANDBOXDIR/$APPNAME"
 		if [ "$1" = "--disable-sandbox" ]; then
 			APPIMAGEPATH="$(echo ${APPEXEC%/*})"
@@ -113,15 +118,17 @@ case "$1" in
 			echo " \033[32m$APPEXEC successfully unsandboxed!\n"
 			exit 0
 		fi
+		if [ -z "$APPNAME" ]; then exit 1; fi
 
 		# Start at sandboxed home
 		# Edit below this to add or remove access to parts of the system
 		exec aisap --trust-once --level 2 \
 		--data-dir "$SANDBOXDIR/$APPNAME" \
-		--add-file "$DATADIR/$APPNAME":rw \
+		--add-file "$DATADIR/${APPDATA:-$APPNAME}":rw \
 		--add-file "$DATADIR"/themes \
 		--add-file "$DATADIR"/icons \
-		--add-file "$CONFIGDIR/$APPNAME":rw \
+		--add-file "$CONFIGDIR/${APPCONF:-$APPNAME}":rw \
+		--add-file "$CONFIGDIR"/dconf \
 		--add-file "$CONFIGDIR"/gtk3.0 \
 		--add-file "$CONFIGDIR"/gtk4.0 \
 		--add-file "$CONFIGDIR"/kdeglobals \
@@ -129,6 +136,12 @@ case "$1" in
 		--add-file "$CONFIGDIR"/qt6ct \
 		--add-file "$CONFIGDIR"/Kvantum \
 		--add-file "$HOME"/.local/lib \
+		--rm-file xdg-download \
+		--rm-file xdg-music \
+		--rm-file xdg-pictures \
+		--rm-file xdg-videos \
+		--rm-file xdg-documents \
+		--add-socket dbus \
 		--add-socket x11 \
 		--add-socket wayland \
 		--add-socket pulseaudio \
@@ -138,6 +151,22 @@ case "$1" in
 		HEREDOC
 		$SUDOCOMMAND mv "$AMCACHEDIR/sandbox-scripts/$2" "$TARGET" && rmdir "$AMCACHEDIR/sandbox-scripts" || exit 1
 		$SUDOCOMMAND chmod a+x "$TARGET" && $SUDOCOMMAND sed -i "s|DUMMY|$APPIMAGE|g; s|SUDO |$SUDOCOMMAND |g" "$TARGET" || exit 1
+		read -p "Allow $2 to access ~/Downloads? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-download|--add-file xdg-download:rw|g" "$TARGET" || exit 1
+		fi
+		read -p "Allow $2 to access ~/Documents? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-documents|--add-file xdg-documents:rw|g" "$TARGET" || exit 1
+		fi
+		read -p "Allow $2 to access ~/Pictures (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-pictures|--add-file xdg-pictures:rw|g" "$TARGET" || exit 1
+		fi
+		read -p "Allow $2 to access ~/Videos (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-videos|--add-file xdg-videos:rw|g" "$TARGET" || exit 1
+		fi
 		echo -e "\n \033[33m\"$2\" successfully sandboxed!"
 		echo -e "\n \033[0mThe sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
 		echo -e "\n This location can be moved by setting the 'SANDBOXDIR' env variable"

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -151,28 +151,29 @@ case "$1" in
 		HEREDOC
 		$SUDOCOMMAND mv "$AMCACHEDIR/sandbox-scripts/$2" "$TARGET" && rmdir "$AMCACHEDIR/sandbox-scripts" || exit 1
 		$SUDOCOMMAND chmod a+x "$TARGET" && $SUDOCOMMAND sed -i "s|DUMMY|$APPIMAGE|g; s|SUDO |$SUDOCOMMAND |g" "$TARGET" || exit 1
-		read -p "Allow $2 to access ~/Downloads? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i "s|--rm-file xdg-download|--add-file xdg-download:rw|g" "$TARGET" || exit 1
-		fi
-		read -p "Allow $2 to access ~/Documents? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i "s|--rm-file xdg-documents|--add-file xdg-documents:rw|g" "$TARGET" || exit 1
-		fi
-		read -p "Allow $2 to access ~/Pictures (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i "s|--rm-file xdg-pictures|--add-file xdg-pictures:rw|g" "$TARGET" || exit 1
-		fi
-		read -p "Allow $2 to access ~/Videos (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i "s|--rm-file xdg-videos|--add-file xdg-videos:rw|g" "$TARGET" || exit 1
-		fi
 		echo -e "\n \033[33m\"$2\" successfully sandboxed!"
 		echo -e "\n \033[0mThe sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
 		echo -e "\n This location can be moved by setting the 'SANDBOXDIR' env variable"
 		echo -e "\n --------------------------------------------------------------------------"
 		echo -e "\n \033[33mUse the --disable-sandbox flag if you want to revert the changes"
-		echo -e "\n \033[0mIn this case that is: \033[33m$2 --disable-sandbox\n"
+		echo -e "\n \033[0mIn this case that is: \033[33m$2 --disable-sandbox\n\033[36m"
+		read -p " Allow $2 access to ~/Downloads? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-download|--add-file xdg-download:rw|g" "$TARGET" || exit 1
+		fi
+		read -p " Allow $2 access to ~/Documents? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-documents|--add-file xdg-documents:rw|g" "$TARGET" || exit 1
+		fi
+		read -p " Allow $2 access to ~/Pictures (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-pictures|--add-file xdg-pictures:rw|g" "$TARGET" || exit 1
+		fi
+		read -p " Allow $2 access to ~/Videos (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i "s|--rm-file xdg-videos|--add-file xdg-videos:rw|g" "$TARGET" || exit 1
+		fi
+		echo -e "\n \033[33mUser directories access configured successfully!"
 		exit 0
 	done
 


### PR DESCRIPTION
mgord9518 fixed the issue with some apps not getting their fake home 🎉 I haven't thanked then yet, I will right after I write this. 

New improvements to sandboxes. 

* Now it better tries to give access to the sandboxed app original config directory.
For example gimp names its `$XDG_CONFIG_HOME` directory `GIMP` in all caps, to fix that issue I added this check in the sandbox script: 

`APPCONF=$( ls "$CONFIGDIR" | grep -i "$APPNAME" | head -1 )`

Which will correctly find the name of the directory we want. 

If that directory doesn't exist, it defaults to using the name of the binary. `--add-file "$CONFIGDIR/${APPCONF:-$APPNAME}":rw \`

* **Now `sandboxes.am` asks the user which user directories it should give access to:** 

![image](https://github.com/ivan-hc/AM/assets/36420837/398dfe2f-f76f-4e5c-a3d3-4c3b15a010d0)

By default access to `~/Downloads ~/Documents ~/Pictures ~/Videos` will be denied, unless the user says yes to each respective question. If nothing is entered then it assumes that you said no in each question (You can also type N, n, No, etc).

**I will likely expand this to also allow access to a specific directory that the user writes its path to.**

* Added more access to `dconf` and `dbus` by default, now when you sandbox `cpu-x` you don't have a broken theme (Well not in the case of my PC, but this is because I don't have a `~/.config` directory and aisap assumes that it is located there 😅, **but for most users it should not break the theme**).

![image](https://github.com/ivan-hc/AM/assets/36420837/8d1e7b7d-868a-4fac-a7c4-333998afa300)








