### PR TITLE
Improve sandboxes to allow access to user directories in other languages

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -42,15 +42,14 @@ case "$1" in
 			echo " '$2' is not a valid argument or is not installed."; exit
 		elif [ "$2" = "aisap" ]; then
 			echo " Error: You can't sandbox aisap"; exit 1
-		elif ! command -v am 1>/dev/null && ! command -v appman 1>/dev/null; then
-			echo -e " Error: You need AM or AppMan for this script work\nInstall AM/AppMan and try again"; exit 1
 		elif ! command -v aisap 1>/dev/null; then
-			echo -e " Error: You need aisap for this script work\n"
-			read -p " ◆ DO YOU WISH TO INSTALL AISAP (y,n)?: " yn
-			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-				$AMCLIPATH -i aisap >/dev/null 2>&1
+			printf '\n%s\n\n' " Error: You need aisap for this script work"
+			read -p " ◆ DO YOU WISH TO INSTALL AISAP? Install size <5 MIB, (Y/n)?: " yn
+			if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+				printf '\n%s\n\n' "Installation aborted"; exit 1
 			fi
-			command -v aisap 1>/dev/null && echo " aisap installed successfully" || exit 1
+			$AMCLIPATH -i aisap >/dev/null 2>&1
+			command -v aisap 1>/dev/null && printf '\n%s\n\n' " aisap installed successfully" || exit 1
 		fi
 
 		# Set variables
@@ -76,7 +75,7 @@ case "$1" in
 		sed -i 's|chmod a+x|chmod a-x|g' "$APPIMAGEPATH/AM-updater" || exit 1
 
 		# Check if we are using AM or AppMan
-		echo -e "\n Making aisap script for \"$(echo "$AMCLI" | tr a-z A-Z)\"..."
+		printf '\n%s\n' " Making aisap script for \"$(echo "$AMCLI" | tr a-z A-Z)\"..."
 
 		mkdir -p "$AMCACHEDIR/sandbox-scripts"
 		cat <<-"HEREDOC" >> "$AMCACHEDIR/sandbox-scripts/$2"
@@ -114,14 +113,14 @@ case "$1" in
 		mkdir -p "$SANDBOXDIR/$APPNAME"
 		if [ "$1" = "--disable-sandbox" ]; then
 			APPIMAGEPATH="$(echo ${APPEXEC%/*})"
-			echo "\n Giving exec permissions back to $APPEXEC..."
+			printf '\n%s' " Giving exec permissions back to $APPEXEC..."
 			chmod a+x "$APPEXEC" || exit 1
-			echo " Patching $APPIMAGEPATH/AM-updater to give permissions back..."
+			printf '\n%s' " Patching $APPIMAGEPATH/AM-updater to give permissions back..."
 			sed -i 's|chmod a-x|chmod a+x|g' "$APPIMAGEPATH/AM-updater" || exit 1
 			THISFILE="$(realpath "$0")"
-			echo " Replacing $THISFILE with a link to the AppImage...\n"
+			printf '\n%s\n' " Replacing $THISFILE with a link to the AppImage..."
 			SUDO ln -sf "$APPEXEC" "$THISFILE" || exit 1
-			echo " \033[32m$APPEXEC successfully unsandboxed!\n"
+			printf '\033[32m\n%s\n\n' " $APPEXEC successfully unsandboxed!"
 			exit 0
 		fi
 		if [ -z "$APPNAME" ]; then exit 1; fi
@@ -158,12 +157,13 @@ case "$1" in
 		HEREDOC
 		$SUDOCOMMAND mv "$AMCACHEDIR/sandbox-scripts/$2" "$TARGET" && rmdir "$AMCACHEDIR/sandbox-scripts" || exit 1
 		$SUDOCOMMAND chmod a+x "$TARGET" && $SUDOCOMMAND sed -i "s|DUMMY|$APPIMAGE|g; s|SUDO |$SUDOCOMMAND |g" "$TARGET" || exit 1
-		echo -e "\n \033[33m\"$2\" successfully sandboxed!"
-		echo -e "\n \033[0mThe sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
-		echo -e "\n This location can be moved by setting the 'SANDBOXDIR' env variable"
-		echo -e "\n --------------------------------------------------------------------------"
-		echo -e "\n \033[33mUse the --disable-sandbox flag if you want to revert the changes"
-		echo -e "\n \033[0mIn this case that is: \033[33m$2 --disable-sandbox\n\033[36m"
+		printf '\n\033[33m%s\n' " \"$2\" successfully sandboxed!"
+		printf '\n\033[0m%s\n' " The sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
+		printf '\n%s\n' " This location can be moved by setting the 'SANDBOXDIR' env variable"
+		printf '\n%s\n' " --------------------------------------------------------------------------"
+		printf '\n\033[33m%s\n' " Use the --disable-sandbox flag if you want to revert the changes"
+		printf '\n\033[0m%s' " In this case that is:"
+		printf '\033[33m%s\033[36m\n\n' " $2 --disable-sandbox"
 		read -p " Allow $2 access to ~/Downloads? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw|g' "$TARGET" || exit 1
@@ -184,7 +184,7 @@ case "$1" in
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}":rw|g' "$TARGET" || exit 1
 		fi
-		echo -e "\n \033[33mUser directories access configured successfully!"
+		printf '\n\033[33m%s\n\n' " User directories access configured successfully!"
 		exit 0
 	done
 

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -160,23 +160,23 @@ case "$1" in
 		echo -e "\n \033[0mIn this case that is: \033[33m$2 --disable-sandbox\n\033[36m"
 		read -p " Allow $2 access to ~/Downloads? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file ${XDG_DOWNLOAD_DIR:-~/Downloads}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Documents? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Downloads}"|--add-file ${XDG_DOCUMENTS_DIR:-~/Documents}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Downloads}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Music (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Downloads}"|--add-file ${XDG_MUSIC_DIR:-~/Music}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Downloads}"|--add-file "${XDG_MUSIC_DIR:-~/Music}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Pictures (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Downloads}"|--add-file ${XDG_PICTURES_DIR:-~/Pictures}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Downloads}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Videos (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Downloads}"|--add-file ${XDG_VIDEOS_DIR:-~/Videos}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Downloads}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}"|g' "$TARGET" || exit 1
 		fi
 		echo -e "\n \033[33mUser directories access configured successfully!"
 		exit 0

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -101,11 +101,11 @@ case "$1" in
 		CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 		CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 		
-		XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD 2>/dev/null)
-		XDG_MUSIC_DIR=$(xdg-user-dir MUSIC 2>/dev/null)
-		XDG_PICTURES_DIR=$(xdg-user-dir PICTURES 2>/dev/null)
-		XDG_VIDEOS_DIR=$(xdg-user-dir VIDEOS 2>/dev/null)
-		XDG_DOCUMENTS_DIR=$(xdg-user-dir DOCUMENTS 2>/dev/null)
+		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
+		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
+		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
+		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
+		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
 
 		# Try to find the right name of the app xdg directories, as sometimes it is not the same as $APPNAME
 		APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -144,7 +144,7 @@ case "$1" in
 		--add-file /usr/share \
 		HEREDOC
 		printf '\n\033[33m%s\n' " \"$2\" successfully sandboxed!"
-		printf '\n\033[0m%s\n' " The sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
+		printf '\n\033[0m%s\n' " The sandboxed app home will be in \"${SANDBOXDIR:-$HOME/.local/am-sandboxes}\" once launched"
 		printf '\n%s\n' " This location can be moved by setting the 'SANDBOXDIR' env variable"
 		printf '\n%s\n' " --------------------------------------------------------------------------"
 		printf '\n\033[33m%s\n' " Use the --disable-sandbox flag if you want to revert the changes"

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -108,14 +108,14 @@ case "$1" in
 		mkdir -p "$SANDBOXDIR/$APPNAME"
 		if [ "$1" = "--disable-sandbox" ]; then
 			APPIMAGEPATH="$(echo ${APPEXEC%/*})"
-			echo -e "\n Giving exec permissions back to $APPEXEC..."
+			echo "\n Giving exec permissions back to $APPEXEC..."
 			chmod a+x "$APPEXEC" || exit 1
 			echo " Patching $APPIMAGEPATH/AM-updater to give permissions back..."
 			sed -i 's|chmod a-x|chmod a+x|g' "$APPIMAGEPATH/AM-updater" || exit 1
 			THISFILE="$(realpath "$0")"
-			echo -e " Replacing $THISFILE with a link to the AppImage...\n"
+			echo " Replacing $THISFILE with a link to the AppImage...\n"
 			SUDO ln -sf "$APPEXEC" "$THISFILE" || exit 1
-			echo -e " \033[32m$APPEXEC successfully unsandboxed!\n"
+			echo " \033[32m$APPEXEC successfully unsandboxed!\n"
 			exit 0
 		fi
 		if [ -z "$APPNAME" ]; then exit 1; fi
@@ -137,11 +137,11 @@ case "$1" in
 		--add-file "$CONFIGDIR"/Kvantum \
 		--add-file "$HOME"/.local/lib \
 		--add-file /usr/share \
-		--rm-file xdg-download \
-		--rm-file xdg-music \
-		--rm-file xdg-pictures \
-		--rm-file xdg-videos \
-		--rm-file xdg-documents \
+		--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw \
+		--rm-file "${XDG_MUSIC_DIR:-~/Music}":rw \
+		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}":rw \
+		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}":rw \
+		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw \
 		--add-socket dbus \
 		--add-socket x11 \
 		--add-socket wayland \
@@ -160,23 +160,23 @@ case "$1" in
 		echo -e "\n \033[0mIn this case that is: \033[33m$2 --disable-sandbox\n\033[36m"
 		read -p " Allow $2 access to ~/Downloads? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i "s|--rm-file xdg-download|--add-file xdg-download:rw|g" "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file ${XDG_DOWNLOAD_DIR:-~/Downloads}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Documents? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i "s|--rm-file xdg-documents|--add-file xdg-documents:rw|g" "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Downloads}"|--add-file ${XDG_DOCUMENTS_DIR:-~/Documents}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Music (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i "s|--rm-file xdg-music|--add-file xdg-music:rw|g" "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Downloads}"|--add-file ${XDG_MUSIC_DIR:-~/Music}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Pictures (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i "s|--rm-file xdg-pictures|--add-file xdg-pictures:rw|g" "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Downloads}"|--add-file ${XDG_PICTURES_DIR:-~/Pictures}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Videos (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i "s|--rm-file xdg-videos|--add-file xdg-videos:rw|g" "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Downloads}"|--add-file ${XDG_VIDEOS_DIR:-~/Videos}"|g' "$TARGET" || exit 1
 		fi
 		echo -e "\n \033[33mUser directories access configured successfully!"
 		exit 0

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -143,11 +143,11 @@ case "$1" in
 		--add-file "$CONFIGDIR"/Kvantum \
 		--add-file "$HOME"/.local/lib \
 		--add-file /usr/share \
-		--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw \
-		--rm-file "${XDG_MUSIC_DIR:-~/Music}":rw \
-		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}":rw \
-		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}":rw \
-		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw \
+		--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}" \
+		--rm-file "${XDG_MUSIC_DIR:-~/Music}" \
+		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}" \
+		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}" \
+		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}" \
 		--add-socket dbus \
 		--add-socket x11 \
 		--add-socket wayland \
@@ -166,23 +166,23 @@ case "$1" in
 		echo -e "\n \033[0mIn this case that is: \033[33m$2 --disable-sandbox\n\033[36m"
 		read -p " Allow $2 access to ~/Downloads? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Documents? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Music (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}":rw|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Pictures (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}":rw|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Videos (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}":rw|g' "$TARGET" || exit 1
 		fi
 		echo -e "\n \033[33mUser directories access configured successfully!"
 		exit 0

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -164,19 +164,19 @@ case "$1" in
 		fi
 		read -p " Allow $2 access to ~/Documents? (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Downloads}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Music (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Downloads}"|--add-file "${XDG_MUSIC_DIR:-~/Music}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Pictures (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Downloads}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}"|g' "$TARGET" || exit 1
 		fi
 		read -p " Allow $2 access to ~/Videos (y/N): " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Downloads}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}"|g' "$TARGET" || exit 1
+			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}"|g' "$TARGET" || exit 1
 		fi
 		echo -e "\n \033[33mUser directories access configured successfully!"
 		exit 0

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -100,6 +100,12 @@ case "$1" in
 		DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 		CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 		CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+		
+		XDG_DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD 2>/dev/null)
+		XDG_MUSIC_DIR=$(xdg-user-dir MUSIC 2>/dev/null)
+		XDG_PICTURES_DIR=$(xdg-user-dir PICTURES 2>/dev/null)
+		XDG_VIDEOS_DIR=$(xdg-user-dir VIDEOS 2>/dev/null)
+		XDG_DOCUMENTS_DIR=$(xdg-user-dir DOCUMENTS 2>/dev/null)
 
 		# Try to find the right name of the app xdg directories, as sometimes it is not the same as $APPNAME
 		APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -62,6 +62,12 @@ case "$1" in
 		APPIMAGEPATH="$APPSPATH/$2"
 		APPIMAGE="$APPIMAGEPATH/$2"
 
+		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
+		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
+		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
+		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
+		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
+
 		# Check if TARGET is an AppImage or was already sandboxed
 		if grep "aisap-am" "$TARGET" >/dev/null 2>&1; then
 			echo " $2 is already sandboxed!"; exit 1
@@ -99,12 +105,6 @@ case "$1" in
 		DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 		CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 		CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
-		
-		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
-		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
-		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
-		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
-		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
 
 		# Try to find the right name of the app xdg directories, as sometimes it is not the same as $APPNAME
 		APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )
@@ -142,11 +142,51 @@ case "$1" in
 		--add-file "$CONFIGDIR"/Kvantum \
 		--add-file "$HOME"/.local/lib \
 		--add-file /usr/share \
-		--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}" \
-		--rm-file "${XDG_MUSIC_DIR:-~/Music}" \
-		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}" \
-		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}" \
-		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}" \
+		HEREDOC
+		printf '\n\033[33m%s\n' " \"$2\" successfully sandboxed!"
+		printf '\n\033[0m%s\n' " The sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
+		printf '\n%s\n' " This location can be moved by setting the 'SANDBOXDIR' env variable"
+		printf '\n%s\n' " --------------------------------------------------------------------------"
+		printf '\n\033[33m%s\n' " Use the --disable-sandbox flag if you want to revert the changes"
+		printf '\n\033[0m%s' " In this case that is:"
+		printf '\033[33m%s\033[36m\n\n' " $2 --disable-sandbox"
+
+		read -p " Allow $2 access to $XDG_DOCUMENTS_DIR? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
+			--add-file "$XDG_DOCUMENTS_DIR":rw \\
+			HEREDOC
+		fi
+
+		read -p " Allow $2 access to $XDG_DOWNLOAD_DIR? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
+			--add-file "$XDG_DOWNLOAD_DIR":rw \\
+			HEREDOC
+		fi
+
+		read -p " Allow $2 access to $XDG_MUSIC_DIR? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
+			--add-file "$XDG_MUSIC_DIR":rw \\
+			HEREDOC
+		fi
+
+		read -p " Allow $2 access to $XDG_PICTURES_DIR? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
+			--add-file "$XDG_PICTURES_DIR":rw \\
+			HEREDOC
+		fi
+
+		read -p " Allow $2 access to $XDG_VIDEOS_DIR? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
+			--add-file "$XDG_VIDEOS_DIR":rw \\
+			HEREDOC
+		fi
+
+		cat <<-"HEREDOC" >> "$AMCACHEDIR/sandbox-scripts/$2"
 		--add-socket dbus \
 		--add-socket x11 \
 		--add-socket wayland \
@@ -155,35 +195,10 @@ case "$1" in
 		--add-device dri -- \
 		"$APPEXEC" "$@"
 		HEREDOC
+
 		$SUDOCOMMAND mv "$AMCACHEDIR/sandbox-scripts/$2" "$TARGET" && rmdir "$AMCACHEDIR/sandbox-scripts" || exit 1
 		$SUDOCOMMAND chmod a+x "$TARGET" && $SUDOCOMMAND sed -i "s|DUMMY|$APPIMAGE|g; s|SUDO |$SUDOCOMMAND |g" "$TARGET" || exit 1
-		printf '\n\033[33m%s\n' " \"$2\" successfully sandboxed!"
-		printf '\n\033[0m%s\n' " The sandboxed app home will be in "${SANDBOXDIR:-$HOME/.local/am-sandboxes}" once launched"
-		printf '\n%s\n' " This location can be moved by setting the 'SANDBOXDIR' env variable"
-		printf '\n%s\n' " --------------------------------------------------------------------------"
-		printf '\n\033[33m%s\n' " Use the --disable-sandbox flag if you want to revert the changes"
-		printf '\n\033[0m%s' " In this case that is:"
-		printf '\033[33m%s\033[36m\n\n' " $2 --disable-sandbox"
-		read -p " Allow $2 access to ~/Downloads? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw|g' "$TARGET" || exit 1
-		fi
-		read -p " Allow $2 access to ~/Documents? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw|g' "$TARGET" || exit 1
-		fi
-		read -p " Allow $2 access to ~/Music (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}":rw|g' "$TARGET" || exit 1
-		fi
-		read -p " Allow $2 access to ~/Pictures (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}":rw|g' "$TARGET" || exit 1
-		fi
-		read -p " Allow $2 access to ~/Videos (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			$SUDOCOMMAND sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}":rw|g' "$TARGET" || exit 1
-		fi
+
 		printf '\n\033[33m%s\n\n' " User directories access configured successfully!"
 		exit 0
 	done


### PR DESCRIPTION
![image](https://github.com/ivan-hc/AM/assets/36420837/bcca1342-209c-4523-b4c9-bb8daf94278d)

I denied access to `~/Downloads` and it works.  Good thing this method also overwrites aisap's internal database. 

Now the script uses `"${XDG_DOWNLOAD_DIR:-~/Downloads}"` instead of aisaps internal method to get it. If `$XDG_DOWNLOAD_DIR` is not defined, it will default to using `~/Downloads`. 

I removed the -e flag from the echo in the sandbox script, because that was causing a literal `-e` to be printed on my terminal when I disabled the sandbox:

![image](https://github.com/ivan-hc/AM/assets/36420837/fe0f9cf6-200a-41ec-9296-a315461fdbde)

I didn't touch the `-e` in the module, just removed the `-e` in the script that gets made. 




