### PR TITLE
Changed a lot of things

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -30,8 +30,7 @@ function _clean_amcachedir() {
 }
 
 APPMANCONFIG="$CONFIGDIR/appman"
-
-export SCRIPTDIR="$(if command -v xdg-user-dir &>/dev/null; then xdg-user-dir DESKTOP; else echo $HOME; fi)"
+export SCRIPTDIR="$(xdg-user-dir DESKTOP 2>/dev/null || echo "$HOME")"
 
 # Determine sytem package manager
 function _system_package_manager_check() {

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -62,12 +62,6 @@ case "$1" in
 		APPIMAGEPATH="$APPSPATH/$2"
 		APPIMAGE="$APPIMAGEPATH/$2"
 
-		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
-		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
-		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
-		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
-		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
-
 		# Check if TARGET is an AppImage or was already sandboxed
 		if grep "aisap-am" "$TARGET" >/dev/null 2>&1; then
 			echo " $2 is already sandboxed!"; exit 1
@@ -75,16 +69,26 @@ case "$1" in
 			echo " $TARGET doesn't look like an AppImage, aborting"; exit 1
 		fi
 
-		# Remove the exec permission from the AppImage and its updater for better safety™
-		$SUDOCOMMAND rm -f "$TARGET" &&
-		chmod a-x "$APPIMAGE" &&
-		sed -i 's|chmod a+x|chmod a-x|g' "$APPIMAGEPATH/AM-updater" || exit 1
-
 		# Check if we are using AM or AppMan
 		printf '\n%s\n' " Making aisap script for \"$(echo "$AMCLI" | tr a-z A-Z)\"..."
-
+		
 		rm -Rf "$AMCACHEDIR/sandbox-scripts"
 		mkdir -p "$AMCACHEDIR/sandbox-scripts"
+
+		# Get xdg variables
+		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
+		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
+		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
+		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
+		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
+
+		# Unset the xdg variable if it equals to $HOME
+		if [ "$XDG_DOWNLOAD_DIR" = "$HOME" ]; then XDG_DOWNLOAD_DIR=""; fi
+		if [ "$XDG_MUSIC_DIR" = "$HOME" ]; then XDG_MUSIC_DIR=""; fi
+		if [ "$XDG_PICTURES_DIR" = "$HOME" ]; then XDG_PICTURES_DIR=""; fi
+		if [ "$XDG_VIDEOS_DIR" = "$HOME" ]; then XDG_VIDEOS_DIR=""; fi
+		if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ]; then XDG_DOCUMENTS_DIR=""; fi
+
 		cat <<-"HEREDOC" >> "$AMCACHEDIR/sandbox-scripts/$2"
 		#!/bin/sh
 
@@ -106,6 +110,18 @@ case "$1" in
 		DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 		CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 		CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+		
+		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
+		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
+		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
+		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
+		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
+
+		if [ "$XDG_DOWNLOAD_DIR" = "$HOME" ]; then XDG_DOWNLOAD_DIR=""; fi
+		if [ "$XDG_MUSIC_DIR" = "$HOME" ]; then XDG_MUSIC_DIR=""; fi
+		if [ "$XDG_PICTURES_DIR" = "$HOME" ]; then XDG_PICTURES_DIR=""; fi
+		if [ "$XDG_VIDEOS_DIR" = "$HOME" ]; then XDG_VIDEOS_DIR=""; fi
+		if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ]; then XDG_DOCUMENTS_DIR=""; fi
 
 		# Try to find the right name of the app xdg directories, as sometimes it is not the same as $APPNAME
 		APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )
@@ -114,13 +130,13 @@ case "$1" in
 		mkdir -p "$SANDBOXDIR/$APPNAME"
 		if [ "$1" = "--disable-sandbox" ]; then
 			APPIMAGEPATH="$(echo ${APPEXEC%/*})"
-			THISFILE="$(realpath "$0")"
-			SUDO ln -sf "$APPEXEC" "$THISFILE" || exit 1
 			printf '\n%s' " Giving exec permissions back to $APPEXEC..."
 			chmod a+x "$APPEXEC" || exit 1
 			printf '\n%s' " Patching $APPIMAGEPATH/AM-updater to give permissions back..."
 			sed -i 's|chmod a-x|chmod a+x|g' "$APPIMAGEPATH/AM-updater" || exit 1
+			THISFILE="$(realpath "$0")"
 			printf '\n%s\n' " Replacing $THISFILE with a link to the AppImage..."
+			SUDO ln -sf "$APPEXEC" "$THISFILE" || exit 1
 			printf '\033[32m\n%s\n\n' " $APPEXEC successfully unsandboxed!"
 			exit 0
 		fi
@@ -143,51 +159,11 @@ case "$1" in
 		--add-file "$CONFIGDIR"/Kvantum \
 		--add-file "$HOME"/.local/lib \
 		--add-file /usr/share \
-		HEREDOC
-		printf '\n\033[33m%s\n' " \"$2\" successfully sandboxed!"
-		printf '\n\033[0m%s\n' " The sandboxed app home will be in \"${SANDBOXDIR:-$HOME/.local/am-sandboxes}\" once launched"
-		printf '\n%s\n' " This location can be moved by setting the 'SANDBOXDIR' env variable"
-		printf '\n%s\n' " --------------------------------------------------------------------------"
-		printf '\n\033[33m%s\n' " Use the --disable-sandbox flag if you want to revert the changes"
-		printf '\n\033[0m%s' " In this case that is:"
-		printf '\033[33m%s\033[36m\n\n' " $2 --disable-sandbox"
-
-		read -p " Allow $2 access to $XDG_DOCUMENTS_DIR? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
-			--add-file "$XDG_DOCUMENTS_DIR":rw \\
-			HEREDOC
-		fi
-
-		read -p " Allow $2 access to $XDG_DOWNLOAD_DIR? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
-			--add-file "$XDG_DOWNLOAD_DIR":rw \\
-			HEREDOC
-		fi
-
-		read -p " Allow $2 access to $XDG_MUSIC_DIR? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
-			--add-file "$XDG_MUSIC_DIR":rw \\
-			HEREDOC
-		fi
-
-		read -p " Allow $2 access to $XDG_PICTURES_DIR? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
-			--add-file "$XDG_PICTURES_DIR":rw \\
-			HEREDOC
-		fi
-
-		read -p " Allow $2 access to $XDG_VIDEOS_DIR? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			cat <<-HEREDOC >> "$AMCACHEDIR/sandbox-scripts/$2"
-			--add-file "$XDG_VIDEOS_DIR":rw \\
-			HEREDOC
-		fi
-
-		cat <<-"HEREDOC" >> "$AMCACHEDIR/sandbox-scripts/$2"
+		--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}" \
+		--rm-file "${XDG_MUSIC_DIR:-~/Music}" \
+		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}" \
+		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}" \
+		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}" \
 		--add-socket dbus \
 		--add-socket x11 \
 		--add-socket wayland \
@@ -196,11 +172,46 @@ case "$1" in
 		--add-device dri -- \
 		"$APPEXEC" "$@"
 		HEREDOC
+		printf '\033[36m\n'
+		read -p " Allow $2 access to ${XDG_DOWNLOAD_DIR:-~/Downloads}? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+		fi
+		read -p " Allow $2 access to ${XDG_DOCUMENTS_DIR:-~/Documents}? (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+		fi
+		read -p " Allow $2 access to ${XDG_MUSIC_DIR:-~/Music} (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+		fi
+		read -p " Allow $2 access to ${XDG_PICTURES_DIR:-~/Pictures} (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+		fi
+		read -p " Allow $2 access to ${XDG_VIDEOS_DIR:-~/Videos} (y/N): " yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+		fi
+		printf '\n\033[33m%s\n' " User directories access configured successfully!"
 
 		chmod a+x "$AMCACHEDIR/sandbox-scripts/$2" && sed -i "s|DUMMY|$APPIMAGE|g; s|SUDO |$SUDOCOMMAND |g" "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+
+		# Remove the exec permission from the AppImage and its updater for better safety™
+		$SUDOCOMMAND rm -f "$TARGET" && chmod a-x "$APPIMAGE" &&
+		sed -i 's|chmod a+x|chmod a-x|g' "$APPIMAGEPATH/AM-updater" || exit 1
+
+		# Put sandbox script in the place of the appimage symlink
 		$SUDOCOMMAND mv "$AMCACHEDIR/sandbox-scripts/$2" "$TARGET" && rmdir "$AMCACHEDIR/sandbox-scripts" || exit 1
 
-		printf '\n\033[33m%s\n\n' " User directories access configured successfully!"
+		printf '\n%s\n' " \"$2\" successfully sandboxed!"
+		printf '\n\033[0m%s\n' " The sandboxed app home will be in \"${SANDBOXDIR:-$HOME/.local/am-sandboxes}\" once launched"
+		printf '\n%s\n' " This location can be moved by setting the 'SANDBOXDIR' env variable"
+		printf '\n%s\n' " --------------------------------------------------------------------------"
+		printf '\n\033[33m%s\n' " Use the --disable-sandbox flag if you want to revert the changes"
+		printf '\n\033[0m%s' " In this case that is:"
+		printf '\033[33m%s\033[36m\n\n' " $2 --disable-sandbox"
+
 		exit 0
 	done
 


### PR DESCRIPTION
I put a check inside the sandbox script and module that if for some reason one of the xdg user dir variables equals `$HOME` it will empty  the variable:

```
if [ "$XDG_DOWNLOAD_DIR" = "$HOME" ]; then XDG_DOWNLOAD_DIR=""; fi
if [ "$XDG_MUSIC_DIR" = "$HOME" ]; then XDG_MUSIC_DIR=""; fi
if [ "$XDG_PICTURES_DIR" = "$HOME" ]; then XDG_PICTURES_DIR=""; fi
if [ "$XDG_VIDEOS_DIR" = "$HOME" ]; then XDG_VIDEOS_DIR=""; fi
if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ]; then XDG_DOCUMENTS_DIR=""; fi
```

This causes both, sandbox script and the sandbox module to use the fallback value of each variable.

Here for example I defined `XDG_DOWNLOAD_DIR=$HOME` in my `xdg-user-dirs.dirs` 

![image](https://github.com/ivan-hc/AM/assets/36420837/53762009-b612-4dcc-81de-fa217963590c)

As result the script will instead use the default value of `~/Downloads`. 

----------------------------------

The good thing of this approach is that it prevents the issue that the user might allow access to `~/Downloads` but then later on their xdg-user-dirs for some reason starts defining `XDG_DOWNLOAD_DIR=$HOME` without them knowing. 


----------------------------------

I also changed the order of operations so that sudo is only needed once. This also means that the moving of the script and the removing of exec permissions for the appimage won't take place until the very end. That way if the user control+c half way it doesn't result in changes to the appimage. 

-----------------------------------

I removed the several `cat HEREDOC` you were using before and changed it back for the older method. 

The problem with the multiple  `cat HEREDOC` is that if the user says no to any of the questions, we have to have the `--rm-file` line in the script, because remember that `aisap` has an internal set of rules that have to be overwritten. So we cannot simply not add the line if they say no. 

**What I mean is that if the `-rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"` is not added to the script, aisap might still allow access to it depending on the application.**
