### PR TITLE
Update pkg2appimage-based installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,17 +1043,15 @@ https://github.com/ivan-hc/AM/assets/88724353/b6513e8a-17ab-4671-baf7-d86183d57c
 #### Option One: "build AppImages on-the-fly"
 This was one of the very first approaches used to create this project. Before I started building AppImage packages myself, they were first compiled just like using any AUR-helper.
 
-The syntax seems simple, but you have to know what you're building. You'll need to decide what kind of AppImage you want to build on the fly, whether to include a custom AppRun, "libunionpreload", and detect system libraries. It will be used as the Debian base, but you can manually modify the script to suit your needs.
+The syntax seems simple, but you have to know what you're building.
 
-https://github.com/ivan-hc/AM/assets/88724353/db516c23-9b9a-4287-9cdd-d6a153065c8b
+You'll need to decide what kind of AppImage you want to build on the fly, whether to include a custom AppRun, "libunionpreload", and detect system libraries.
 
-I took "Abiword" as an example because it is something I have already experienced in the past.
+It will be used as the Debian base, but you can manually modify the script to suit your needs.
 
-In the following video you see how option 1 (formerly option 5) is able to create AppImage packages on the fly (here "Abiword" from Debian Unstable), like an AUR compiler would:
+In this example I'll create the script for Abiword with "AM" and I'll install it using AppMan:
 
-https://user-images.githubusercontent.com/88724353/150619523-a45455f6-a656-4753-93fe-aa99babc1083.mp4
-
-NOTE, the video above is from before Type3 AppImages were used, the ones that do not require "libfuse2". Encountering "Appstream" errors is very common.
+https://github.com/ivan-hc/AM/assets/88724353/6ae38787-e0e5-4b63-b020-c89c1e975ddd
 
 #### Option Two: "Archives and other programs"
 Option two is very similar to option zero. What changes is the number of questions, which allow you to customize both the application's .desktop file and the way a program should be extracted.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ You can consult the entire **list of managed apps** at [**portable-linux-apps.gi
 - [Backup and restore installed apps using snapshots](#backup-and-restore-installed-apps-using-snapshots)
 - [Remove one or more applications](#remove-one-or-more-applications)
 - [Convert Type2 AppImages requiring libfuse2 to Type3 AppImages](#convert-type2-appimages-requiring-libfuse2-to-type3-appimages)
-- [Integrate local AppImages into the menu by dragging and dropping them, as you do with AppImageLauncher](#integrate-local-appimages-into-the-menu-by-dragging-and-dropping-them-as-you-do-with-appimagelauncher)
+- [Integrate local AppImages into the menu by dragging and dropping them](#integrate-local-appimages-into-the-menu-by-dragging-and-dropping-them)
+  - [How to create a launcher for a local AppImage](#how-to-create-a-launcher-for-a-local-appimage)
+  - [How to remove the orphan launchers](#how-to-remove-the-orphan-launchers)
+  - [AppImages from external media](#appimages-from-external-media)
 - [How to use "AM" in non-privileged mode, like "AppMan"](#how-to-use-am-in-non-privileged-mode-like-appman)
 - [Sandbox an AppImage](#sandbox-an-appimage)
 - [How to enable bash completion](#how-to-enable-bash-completion)
@@ -699,7 +702,10 @@ This section is committed to giving small demonstrations of each available optio
   - [Backup and restore installed apps using snapshots](#backup-and-restore-installed-apps-using-snapshots)
   - [Remove one or more applications](#remove-one-or-more-applications)
   - [Convert Type2 AppImages requiring libfuse2 to Type3 AppImages](#convert-type2-appimages-requiring-libfuse2-to-type3-appimages)
-  - [Integrate local AppImages into the menu by dragging and dropping them, as you do with AppImageLauncher](#integrate-local-appimages-into-the-menu-by-dragging-and-dropping-them-as-you-do-with-appimagelauncher)
+  - [Integrate local AppImages into the menu by dragging and dropping them](#integrate-local-appimages-into-the-menu-by-dragging-and-dropping-them)
+    - [How to create a launcher for a local AppImage](#how-to-create-a-launcher-for-a-local-appimage)
+    - [How to remove the orphan launchers](#how-to-remove-the-orphan-launchers)
+    - [AppImages from external media](#appimages-from-external-media)
   - [How to use "AM" in non-privileged mode, like "AppMan"](#how-to-use-am-in-non-privileged-mode-like-appman)
   - [Sandbox an AppImage](#sandbox-an-appimage)
   - [How to enable bash completion](#how-to-enable-bash-completion)
@@ -852,11 +858,16 @@ If also the second step does not succeed either, the process will end with an er
 ------------------------------------------------------------------------
 
 __________________________________________________________________________
-### Integrate local AppImages into the menu by dragging and dropping them, as you do with AppImageLauncher
+### Integrate local AppImages into the menu by dragging and dropping them
 If you are a user who is used to dragging your local AppImages scattered around the system and if you are a user who likes clutter and wants to place their packages in different places... this option is for you.
 
-The option `--launcher` allows you to drag and drop a local AppImage to create a launcher to place in the menu, like [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) or [Gear Lever](https://github.com/mijorus/gearlever), or any other classic AppImage package helper would... but in SHELL.
+The option `--launcher` allows you to drag and drop a local AppImage to create a launcher to place in the menu, like any other classic AppImage helper would... but in SHELL.
 
+This option also allows you to create a symbolic link or a shell script that calls your AppImage, to place in "`~/.local/bin`", so that you can call it from the terminal:
+- if you choose Y or ENTER, you can choose the name to use in $PATH
+- if you choose N, the option will take care of the name to give to a script with ".appimage" extension (in lower case)
+
+##### How to create a launcher for a local AppImage
 ```
 am --launcher /path/to/File.AppImage
 ```
@@ -864,15 +875,7 @@ or
 ```
 appman --launcher /path/to/File.AppImage
 ```
-
-https://github.com/ivan-hc/AM/assets/88724353/97c2b88d-f330-490c-970b-0f0bb89040dc
-
-As you can see in detail, all you need to do is drag/drop the AppImage package and press ENTER.
-
-This option also allows you to create a symbolic link or shell script that calls your AppImage, to place in "`~/.local/bin`":
-- if you choose Y or ENTER, you can choose the name to use in $PATH
-- if you choose N, the option will take care of the name to give to a script with ".appimage" extension (in lower case)
-
+##### How to remove the orphan launchers
 In case you move your AppImages somewhere else or remove them, use the following otion `-c` or `clean` to get rid of all the orphaned launchers and dead symlinks and scripts you created earlier:
 ```
 am -c
@@ -881,12 +884,20 @@ or
 ```
 appman -c
 ```
+In the first video it shows three AppImages first positioned in one directory and then moved to another, in order to show you both how launchers are created (option "`--launcher`") and how to remove them (option "`-c`" , started first with the AppImage packages in the starting directory and then with the aforementioned moved elsewhere). The second video is a close-up on the terminal, to see in detail how the "`--launcher`" option works:
 
+##### Video 1
 https://github.com/ivan-hc/AM/assets/88724353/25d9df2b-3c4d-4494-8bbc-12e6ab2371fd
 
-NOTE, as you can see, icons are also placed in ~/.local/share/icons, however the `-c` option cannot remove them. This is a known issue.
+##### Video 2
+https://github.com/ivan-hc/AM/assets/88724353/97c2b88d-f330-490c-970b-0f0bb89040dc
 
-Another peculiarity concerns the use of this cleanup option on launchers created on AppImage packages placed on removable devices: if in the .desktop file it appears that the path of the AppImage file is in /mnt or /media and none of the references are mounted, the option `-c` will not be able to remove the launcher. This is very useful if you have large AppImage packages that you necessarily need to place in a different partition.
+##### AppImages from external media
+Another peculiarity concerns the use of the `-c` option on launchers created on AppImage packages placed on removable devices:
+- if in the .desktop file belongs to an AppImage placed in /mnt or /media and none of the references are mounted, the option `-c` will not be able to remove it until you mount the exact device where it was placed in the moment you have created the launcher;
+- if you mount that same device and the AppImage is not where it was when you created the launcher, it will be removed.
+
+This is very useful if you have large AppImage packages that you necessarily need to place in a different partition.
 
 ------------------------------------------------------------------------
 

--- a/templates/AM-SAMPLE-pkg2appimage
+++ b/templates/AM-SAMPLE-pkg2appimage
@@ -19,14 +19,14 @@ echo "app: SAMPLE
 binpatch: true
 
 ingredients:
-	dist: oldstable
-	sources:
-		- deb http://deb.debian.org/debian/ oldstable main contrib non-free
-		- deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
-		- deb http://deb.debian.org/debian oldstable-updates main contrib non-free
-		- deb http://deb.debian.org/debian oldstable-backports main contrib non-free
-	packages:
-		- SAMPLE" >> recipe.yml
+  dist: oldstable
+  sources:
+    - deb http://deb.debian.org/debian/ oldstable main contrib non-free
+    - deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
+    - deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+    - deb http://deb.debian.org/debian oldstable-backports main contrib non-free
+  packages:
+    - SAMPLE" >> recipe.yml
 
 cp /opt/"$APP"/tmp/recipe.yml /opt/"$APP"/recipe.yml
 

--- a/templates/AM-SAMPLE-pkg2appimage
+++ b/templates/AM-SAMPLE-pkg2appimage
@@ -38,6 +38,17 @@ cp /opt/$APP/tmp/recipe.yml /opt/$APP/recipe.yml
 
 ./pkg2appimage ./recipe.yml;
 
+# CLEAN METAINFO DIRECTORY
+metainfodir=$(find ./$APP/$APP.AppDir -type d -name metainfo | grep "share/metainfo" | head -1)
+if [ -z "$metainfodir" ]; then
+	exit 1
+else
+	cd "$metainfodir" || return
+	rm -R -f ./*.xml
+	cd - > /dev/null || return
+fi
+
+# ...EXPORT THE APPDIR TO AN APPIMAGE!
 ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP/$APP.AppDir;
 underscore=_
 mkdir version

--- a/templates/AM-SAMPLE-pkg2appimage
+++ b/templates/AM-SAMPLE-pkg2appimage
@@ -1,23 +1,17 @@
 #!/bin/sh
 
+set -u
 APP=SAMPLE
 
-# CREATING THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP;
-
-# ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
-
-mkdir tmp;
-cd tmp;
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+echo "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
+echo "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
 # DOWNLOADING THE DEPENDENCIES
-wget -q $(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1) -O appimagetool
-wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
-# wget https://github.com/ivan-hc/pkg2appimage-32bit/releases/download/continuous/pkg2appimage-i386.AppImage -O pkg2appimage # 32 BIT ONLY (uncomment to enable)
+wget -q "$(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1)" -O appimagetool
+wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage
 chmod a+x ./appimagetool ./pkg2appimage
 
 # CREATING THE APPIMAGE
@@ -25,23 +19,23 @@ echo "app: SAMPLE
 binpatch: true
 
 ingredients:
-  dist: oldstable
-  sources:
-    - deb http://deb.debian.org/debian/ oldstable main contrib non-free
-    - deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
-    - deb http://deb.debian.org/debian oldstable-updates main contrib non-free
-    - deb http://deb.debian.org/debian oldstable-backports main contrib non-free
-  packages:
-    - SAMPLE" >> recipe.yml;
+	dist: oldstable
+	sources:
+		- deb http://deb.debian.org/debian/ oldstable main contrib non-free
+		- deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
+		- deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+		- deb http://deb.debian.org/debian oldstable-backports main contrib non-free
+	packages:
+		- SAMPLE" >> recipe.yml
 
-cp /opt/$APP/tmp/recipe.yml /opt/$APP/recipe.yml
+cp /opt/"$APP"/tmp/recipe.yml /opt/"$APP"/recipe.yml
 
-./pkg2appimage ./recipe.yml;
+./pkg2appimage ./recipe.yml
 
 # CLEAN METAINFO DIRECTORY
-metainfodir=$(find ./$APP/$APP.AppDir -type d -name metainfo | grep "share/metainfo" | head -1)
+metainfodir=$(find ./"$APP"/"$APP".AppDir -type d -name metainfo | grep "share/metainfo" | head -1)
 if [ -z "$metainfodir" ]; then
-	exit 1
+	return
 else
 	cd "$metainfodir" || return
 	rm -R -f ./*.xml
@@ -49,108 +43,74 @@ else
 fi
 
 # ...EXPORT THE APPDIR TO AN APPIMAGE!
-ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP/$APP.AppDir;
+ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP"/"$APP".AppDir
 underscore=_
 mkdir version
-mv ./$APP/$APP$underscore*.deb ./version/
-version=$(ls /opt/$APP/tmp/version)
-echo "$version" >> /opt/$APP/version
+mv ./"$APP"/"$APP""$underscore"*.deb ./version/
+version=$(ls /opt/"$APP"/tmp/version)
+echo "$version" >> /opt/"$APP"/version
 
-cd ..;
-mv ./tmp/*.AppImage ./$APP;
-chmod a+x ./$APP
+cd ..
+mv ./tmp/*.AppImage ./"$APP"
+chmod a+x ./"$APP"
 
 rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+ln -s /opt/"$APP"/"$APP" /usr/local/bin/"$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
-cat >> /opt/$APP/AM-updater << 'EOF'
+cat >> /opt/"$APP"/AM-updater << 'EOF'
 #!/bin/sh
 APP=SAMPLE
 initial=$(echo $APP | head -c 1)
-version0=$(cat /opt/$APP/version)
-url="http://http.us.debian.org/debian/pool/main/$initial/$APP/$version0"
+version0=$(cat /opt/"$APP"/version)
+url="http://http.us.debian.org/debian/pool/main/$initial/"$APP"/$version0"
 if curl --output /dev/null --silent --head --fail "$url"; then
-  echo "Update not needed, exit!"
+	echo "Update not needed, exit!"
 else
-  notify-send "A new version of $APP is available, please wait!"
-  mkdir /opt/$APP/tmp
-  cd /opt/$APP/tmp
-  wget -q $(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1) -O appimagetool
-  wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
-# wget https://github.com/ivan-hc/pkg2appimage-32bit/releases/download/continuous/pkg2appimage-i386.AppImage -O pkg2appimage # 32 BIT ONLY (uncomment to enable)
-  chmod a+x ./appimagetool ./pkg2appimage
-  cp /opt/$APP/recipe.yml /opt/$APP/tmp/recipe.yml
-  ./pkg2appimage ./recipe.yml;
-  ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP/$APP.AppDir
-  underscore=_
-  mkdir version
-  mv ./$APP/$APP$underscore*.deb ./version/
-  cd ..
-  version=$(ls /opt/$APP/tmp/version)
-  if test -f ./tmp/version/$version; then rm -R -f ./version
-  fi
-  echo "$version" >> /opt/$APP/version
-  mv ./tmp/*.AppImage ./$APP;
-  chmod a+x ./$APP
-  rm -R -f ./tmp
-  notify-send "$APP is updated!"
+	notify-send "A new version of $APP is available, please wait!"
+	mkdir /opt/"$APP"/tmp
+	cd /opt/"$APP"/tmp || exit 1
+	wget -q $(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1) -O appimagetool
+	wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
+	chmod a+x ./appimagetool ./pkg2appimage
+	cp /opt/"$APP"/recipe.yml /opt/"$APP"/tmp/recipe.yml
+	./pkg2appimage ./recipe.yml
+	ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP"/"$APP".AppDir
+	underscore=_
+	mkdir version
+	mv ./"$APP"/"$APP""$underscore"*.deb ./version/
+	cd ..
+	version=$(ls /opt/"$APP"/tmp/version)
+	if test -f ./tmp/version/$version; then rm -R -f ./version
+	fi
+	echo "$version" >> /opt/"$APP"/version
+	mv ./tmp/*.AppImage ./"$APP";
+	chmod a+x ./"$APP"
+	rm -R -f ./tmp
+	notify-send "$APP is updated!"
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x /opt/"$APP"/AM-updater
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
-cd /opt/$APP
-./$APP --appimage-extract *.desktop 1>/dev/null
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null
-mv squashfs-root/*.desktop ./$APP.desktop
-mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
-	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-fi
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
-	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep $app | head -1)
-sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
-sed -i "s#AppRun#$APP#g" ./$APP.desktop
-sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
-sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
-
-mkdir icons
-mv $(./$APP --appimage-extract *.png) ./icons/$APP 2>/dev/null
-mv $(./$APP --appimage-extract *.svg) ./icons/$APP 2>/dev/null
-./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-mv ./squashfs-root/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-
-rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+cd "/opt/$APP" || exit 1
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH=$(readlink ./"$APP".desktop)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH=$(readlink ./DirIcon)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root

--- a/templates/AM-SAMPLE-pkg2appimage-custom
+++ b/templates/AM-SAMPLE-pkg2appimage-custom
@@ -88,6 +88,16 @@ cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/512x512/apps/*$ICONNAME* ./$APP/$A
 cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/scalable/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
 cp ./$APP/$APP.AppDir/usr/share/applications/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
 
+# CLEAN METAINFO DIRECTORY
+metainfodir=$(find ./$APP/$APP.AppDir -type d -name metainfo | grep "share/metainfo" | head -1)
+if [ -z "$metainfodir" ]; then
+	exit 1
+else
+	cd "$metainfodir" || return
+	rm -R -f ./*.xml
+	cd - > /dev/null || return
+fi
+
 # ...EXPORT THE APPDIR TO AN APPIMAGE!
 ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP/$APP.AppDir;
 underscore=_

--- a/templates/AM-SAMPLE-pkg2appimage-custom
+++ b/templates/AM-SAMPLE-pkg2appimage-custom
@@ -19,14 +19,14 @@ echo "app: SAMPLE
 binpatch: true
 
 ingredients:
-	dist: oldstable
-	sources:
-		- deb http://deb.debian.org/debian/ oldstable main contrib non-free
-		- deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
-		- deb http://deb.debian.org/debian oldstable-updates main contrib non-free
-		- deb http://deb.debian.org/debian oldstable-backports main contrib non-free
-	packages:
-		- SAMPLE" >> recipe.yml
+  dist: oldstable
+  sources:
+    - deb http://deb.debian.org/debian/ oldstable main contrib non-free
+    - deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
+    - deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+    - deb http://deb.debian.org/debian oldstable-backports main contrib non-free
+  packages:
+    - SAMPLE" >> recipe.yml
 
 cp /opt/"$APP"/tmp/recipe.yml /opt/"$APP"/recipe.yml
 

--- a/templates/AM-SAMPLE-pkg2appimage-custom
+++ b/templates/AM-SAMPLE-pkg2appimage-custom
@@ -1,23 +1,17 @@
 #!/bin/sh
 
+set -u
 APP=SAMPLE
  
-# CREATING THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP;
-
-# ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
-
-mkdir tmp;
-cd tmp;
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+echo "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
+echo "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
 # DOWNLOADING THE DEPENDENCIES
-wget -q $(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1) -O appimagetool
-wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
-# wget https://github.com/ivan-hc/pkg2appimage-32bit/releases/download/continuous/pkg2appimage-i386.AppImage -O pkg2appimage # 32 BIT ONLY (uncomment to enable)
+wget -q "$(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1)" -O appimagetool
+wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage
 chmod a+x ./appimagetool ./pkg2appimage
 
 # CREATING THE APPIMAGE: APPDIR FROM A RECIPE...
@@ -25,18 +19,18 @@ echo "app: SAMPLE
 binpatch: true
 
 ingredients:
-  dist: oldstable
-  sources:
-    - deb http://deb.debian.org/debian/ oldstable main contrib non-free
-    - deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
-    - deb http://deb.debian.org/debian oldstable-updates main contrib non-free
-    - deb http://deb.debian.org/debian oldstable-backports main contrib non-free
-  packages:
-    - SAMPLE" >> recipe.yml;
+	dist: oldstable
+	sources:
+		- deb http://deb.debian.org/debian/ oldstable main contrib non-free
+		- deb http://deb.debian.org/debian-security/ oldstable-security main contrib non-free
+		- deb http://deb.debian.org/debian oldstable-updates main contrib non-free
+		- deb http://deb.debian.org/debian oldstable-backports main contrib non-free
+	packages:
+		- SAMPLE" >> recipe.yml
 
-cp /opt/$APP/tmp/recipe.yml /opt/$APP/recipe.yml
+cp /opt/"$APP"/tmp/recipe.yml /opt/"$APP"/recipe.yml
 
-./pkg2appimage ./recipe.yml;
+./pkg2appimage ./recipe.yml
 
 # ...DOWNLOADING LIBUNIONPRELOAD...
 #wget https://github.com/project-portable/libunionpreload/releases/download/amd64/libunionpreload.so
@@ -44,7 +38,7 @@ cp /opt/$APP/tmp/recipe.yml /opt/$APP/recipe.yml
 #mv ./libunionpreload.so ./$APP/$APP.AppDir/
 
 # ...REPLACING THE EXISTING APPRUN WITH A CUSTOM ONE...
-rm -R -f ./$APP/$APP.AppDir/AppRun
+rm -R -f ./"$APP"/"$APP".AppDir/AppRun
 cat > AppRun << 'EOF'
 #!/bin/sh
 APP=SAMPLE
@@ -65,33 +59,33 @@ EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2- | s
 #exec "${HERE}"CUSTOMPATH "$@"
 EOF
 chmod a+x AppRun
-cp ./AppRun /opt/$APP/
-mv ./AppRun ./$APP/$APP.AppDir
+cp ./AppRun /opt/"$APP"/
+mv ./AppRun ./"$APP"/"$APP".AppDir
 
 # IMPORT THE LAUNCHER AND THE ICON TO THE APPDIR IF THEY NOT EXIST
-if test -f ./$APP/$APP.AppDir/*.desktop; then
+if test -f ./"$APP"/"$APP".AppDir/*.desktop; then
 	echo "The desktop file exists"
 else
 	echo "Trying to get the .desktop file"
-	cp ./$APP/$APP.AppDir/usr/share/applications/*$(ls . | grep -i $APP | cut -c -4)*desktop ./$APP/$APP.AppDir/ 2>/dev/null
+	cp ./"$APP"/"$APP".AppDir/usr/share/applications/*"$(ls . | grep -i "$APP" | cut -c -4)"*desktop ./"$APP"/"$APP".AppDir/ 2>/dev/null
 fi
 
-ICONNAME=$(cat ./$APP/$APP.AppDir/*desktop | grep "Icon=" | head -1 | cut -c 6-)
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/22x22/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/24x24/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/32x32/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/48x48/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/64x64/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/128x128/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/256x256/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/512x512/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/icons/hicolor/scalable/apps/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
-cp ./$APP/$APP.AppDir/usr/share/applications/*$ICONNAME* ./$APP/$APP.AppDir/ 2>/dev/null
+ICONNAME=$(cat ./"$APP"/"$APP".AppDir/*desktop | grep "Icon=" | head -1 | cut -c 6-)
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/22x22/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/24x24/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/32x32/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/48x48/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/64x64/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/128x128/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/256x256/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/512x512/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/icons/hicolor/scalable/apps/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
+cp ./"$APP"/"$APP".AppDir/usr/share/applications/*"$ICONNAME"* ./"$APP"/"$APP".AppDir/ 2>/dev/null
 
 # CLEAN METAINFO DIRECTORY
-metainfodir=$(find ./$APP/$APP.AppDir -type d -name metainfo | grep "share/metainfo" | head -1)
+metainfodir=$(find ./"$APP"/"$APP".AppDir -type d -name metainfo | grep "share/metainfo" | head -1)
 if [ -z "$metainfodir" ]; then
-	exit 1
+	return
 else
 	cd "$metainfodir" || return
 	rm -R -f ./*.xml
@@ -99,112 +93,78 @@ else
 fi
 
 # ...EXPORT THE APPDIR TO AN APPIMAGE!
-ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP/$APP.AppDir;
+ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP"/"$APP".AppDir
 underscore=_
 mkdir version
-mv ./$APP/$APP$underscore*.deb ./version/
-version=$(ls /opt/$APP/tmp/version)
-echo "$version" >> /opt/$APP/version
+mv ./"$APP"/"$APP""$underscore"*.deb ./version/
+version=$(ls /opt/"$APP"/tmp/version)
+echo "$version" >> /opt/"$APP"/version
 
-cd ..;
-mv ./tmp/*.AppImage ./$APP;
-chmod a+x ./$APP
+cd ..
+mv ./tmp/*.AppImage ./"$APP"
+chmod a+x ./"$APP"
 rm -R -f ./tmp
 
 # LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+ln -s /opt/"$APP"/"$APP" /usr/local/bin/"$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
-cat >> /opt/$APP/AM-updater << 'EOF'
+cat >> /opt/"$APP"/AM-updater << 'EOF'
 #!/bin/sh
 APP=SAMPLE
 initial=$(echo $APP | head -c 1)
-version0=$(cat /opt/$APP/version)
-url="http://http.us.debian.org/debian/pool/main/$initial/$APP/$version0"
+version0=$(cat /opt/"$APP"/version)
+url="http://http.us.debian.org/debian/pool/main/$initial/"$APP"/$version0"
 if curl --output /dev/null --silent --head --fail "$url"; then
-  echo "Update not needed, exit!"
+	echo "Update not needed, exit!"
 else
-  notify-send "A new version of $APP is available, please wait!"
-  mkdir /opt/$APP/tmp
-  cd /opt/$APP/tmp
-  wget -q $(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1) -O appimagetool
-  wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
-# wget https://github.com/ivan-hc/pkg2appimage-32bit/releases/download/continuous/pkg2appimage-i386.AppImage -O pkg2appimage # 32 BIT ONLY (uncomment to enable)
-  chmod a+x ./appimagetool ./pkg2appimage
-  cp /opt/$APP/recipe.yml /opt/$APP/tmp/recipe.yml
-  ./pkg2appimage ./recipe.yml;
-  #wget https://github.com/project-portable/libunionpreload/releases/download/amd64/libunionpreload.so
-  #chmod a+x libunionpreload.so
-  #mv ./libunionpreload.so ./$APP/$APP.AppDir/
-  rm -R -f ./$APP/$APP.AppDir/AppRun
-  cp /opt/$APP/AppRun ./$APP/$APP.AppDir/
-  ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./$APP/$APP.AppDir
-  underscore=_
-  mkdir version
-  mv ./$APP/$APP$underscore*.deb ./version/
-  cd ..
-  version=$(ls /opt/$APP/tmp/version)
-  if test -f ./tmp/version/$version; then rm -R -f ./version
-  fi
-  echo "$version" >> /opt/$APP/version
-  mv ./tmp/*.AppImage ./$APP;
-  chmod a+x ./$APP
-  rm -R -f ./tmp
-  notify-send "$APP is updated!"
+	notify-send "A new version of $APP is available, please wait!"
+	mkdir /opt/"$APP"/tmp
+	cd /opt/"$APP"/tmp || exit 1
+	wget -q $(curl -Ls https://api.github.com/repos/probonopd/go-appimage/releases | grep -v zsync | grep -i continuous | grep -i appimagetool | grep -i "$(uname -m)" | grep browser_download_url | cut -d '"' -f 4 | head -1) -O appimagetool
+	wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
+	chmod a+x ./appimagetool ./pkg2appimage
+	cp /opt/"$APP"/recipe.yml /opt/"$APP"/tmp/recipe.yml
+	./pkg2appimage ./recipe.yml
+	#wget https://github.com/project-portable/libunionpreload/releases/download/amd64/libunionpreload.so
+	#chmod a+x libunionpreload.so
+	#mv ./libunionpreload.so ./"$APP"/"$APP".AppDir/
+	rm -R -f ./"$APP"/"$APP".AppDir/AppRun
+	cp /opt/"$APP"/AppRun ./"$APP"/"$APP".AppDir/
+	ARCH=$(uname -m) VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP"/"$APP".AppDir
+	underscore=_
+	mkdir version
+	mv ./"$APP"/"$APP""$underscore"*.deb ./version/
+	cd ..
+	version=$(ls /opt/"$APP"/tmp/version)
+	if test -f ./tmp/version/$version; then rm -R -f ./version
+	fi
+	echo "$version" >> /opt/"$APP"/version
+	mv ./tmp/*.AppImage ./"$APP"
+	chmod a+x ./"$APP"
+	rm -R -f ./tmp
+	notify-send "$APP is updated!"
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x /opt/"$APP"/AM-updater
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
-cd /opt/$APP
-./$APP --appimage-extract *.desktop 1>/dev/null
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null
-mv squashfs-root/*.desktop ./$APP.desktop
-mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
-	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-fi
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
-	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep $app | head -1)
-sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
-sed -i "s#AppRun#$APP#g" ./$APP.desktop
-sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
-sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
-
-mkdir icons
-mv $(./$APP --appimage-extract *.png) ./icons/$APP 2>/dev/null
-mv $(./$APP --appimage-extract *.svg) ./icons/$APP 2>/dev/null
-./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-mv ./squashfs-root/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-
-rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+cd "/opt/$APP" || exit 1
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH=$(readlink ./"$APP".desktop)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH=$(readlink ./DirIcon)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
Trying to bypass Appstream validation by removing the content of the "metainfo" directory, to create Type3 AppImages