### PR TITLE
👀

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -72,22 +72,25 @@ case "$1" in
 		# Check if we are using AM or AppMan
 		printf '\n%s\n' " Making aisap script for \"$(echo "$AMCLI" | tr a-z A-Z)\"..."
 
+		[ -z "$AMCACHEDIR" ] && exit 1
 		rm -Rf "$AMCACHEDIR/sandbox-scripts"
 		mkdir -p "$AMCACHEDIR/sandbox-scripts"
 
 		# Get xdg variables
+		XDG_DESKTOP_DIR="$(xdg-user-dir DESKTOP 2>/dev/null)"
+		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
 		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
 		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
 		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
 		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
-		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
 
 		# Unset the xdg variable if it equals to $HOME
+		if [ "$XDG_DESKTOP_DIR" = "$HOME" ] || [ "$XDG_DESKTOP_DIR" = "$HOME/" ]; then XDG_DESKTOP_DIR=""; fi
+		if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ] || [ "$XDG_DOCUMENTS_DIR" = "$HOME/" ]; then XDG_DOCUMENTS_DIR=""; fi
 		if [ "$XDG_DOWNLOAD_DIR" = "$HOME" ] || [ "$XDG_DOWNLOAD_DIR" = "$HOME/" ]; then XDG_DOWNLOAD_DIR=""; fi
 		if [ "$XDG_MUSIC_DIR" = "$HOME" ] || [ "$XDG_MUSIC_DIR" = "$HOME/" ]; then XDG_MUSIC_DIR=""; fi
 		if [ "$XDG_PICTURES_DIR" = "$HOME" ] || [ "$XDG_PICTURES_DIR" = "$HOME/" ]; then XDG_PICTURES_DIR=""; fi
 		if [ "$XDG_VIDEOS_DIR" = "$HOME" ] || [ "$XDG_VIDEOS_DIR" = "$HOME/" ]; then XDG_VIDEOS_DIR=""; fi
-		if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ] || [ "$XDG_DOCUMENTS_DIR" = "$HOME/" ]; then XDG_DOCUMENTS_DIR=""; fi
 
 		cat <<-"HEREDOC" >> "$AMCACHEDIR/sandbox-scripts/$2"
 		#!/bin/sh
@@ -111,17 +114,21 @@ case "$1" in
 		CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 		CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 
+		XDG_DESKTOP_DIR="$(xdg-user-dir DESKTOP 2>/dev/null)"
+		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
 		XDG_DOWNLOAD_DIR="$(xdg-user-dir DOWNLOAD 2>/dev/null)"
+		XDG_GAMES_DIR="$(xdg-user-dir GAMES 2>/dev/null)"
 		XDG_MUSIC_DIR="$(xdg-user-dir MUSIC 2>/dev/null)"
 		XDG_PICTURES_DIR="$(xdg-user-dir PICTURES 2>/dev/null)"
 		XDG_VIDEOS_DIR="$(xdg-user-dir VIDEOS 2>/dev/null)"
-		XDG_DOCUMENTS_DIR="$(xdg-user-dir DOCUMENTS 2>/dev/null)"
 
+		if [ "$XDG_DESKTOP_DIR" = "$HOME" ] || [ "$XDG_DESKTOP_DIR" = "$HOME/" ]; then XDG_DESKTOP_DIR=""; fi
+		if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ] || [ "$XDG_DOCUMENTS_DIR" = "$HOME/" ]; then XDG_DOCUMENTS_DIR=""; fi
 		if [ "$XDG_DOWNLOAD_DIR" = "$HOME" ] || [ "$XDG_DOWNLOAD_DIR" = "$HOME/" ]; then XDG_DOWNLOAD_DIR=""; fi
+		if [ "$XDG_GAMES_DIR" = "$HOME" ] || [ "$XDG_GAMES_DIR" = "$HOME/" ]; then XDG_GAMES_DIR=""; fi
 		if [ "$XDG_MUSIC_DIR" = "$HOME" ] || [ "$XDG_MUSIC_DIR" = "$HOME/" ]; then XDG_MUSIC_DIR=""; fi
 		if [ "$XDG_PICTURES_DIR" = "$HOME" ] || [ "$XDG_PICTURES_DIR" = "$HOME/" ]; then XDG_PICTURES_DIR=""; fi
 		if [ "$XDG_VIDEOS_DIR" = "$HOME" ] || [ "$XDG_VIDEOS_DIR" = "$HOME/" ]; then XDG_VIDEOS_DIR=""; fi
-		if [ "$XDG_DOCUMENTS_DIR" = "$HOME" ] || [ "$XDG_DOCUMENTS_DIR" = "$HOME/" ]; then XDG_DOCUMENTS_DIR=""; fi
 
 		# Try to find the right name of the app xdg directories, as sometimes it is not the same as $APPNAME
 		APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )
@@ -159,43 +166,70 @@ case "$1" in
 		--add-file "$CONFIGDIR"/Kvantum \
 		--add-file "$HOME"/.local/lib \
 		--add-file /usr/share \
+		--rm-file /path/to/nothing \
+		--rm-file "${XDG_DESKTOP_DIR:-~/Desktop}" \
+		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}" \
 		--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}" \
+		--rm-file "${XDG_GAMES_DIR:-~/Games}" \
 		--rm-file "${XDG_MUSIC_DIR:-~/Music}" \
 		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}" \
 		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}" \
-		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}" \
 		--add-file /var/lib/dbus \
 		--add-file /tmp/dbus* \
+		--add-socket pulseaudio \
 		--add-socket dbus \
+		--add-socket network \
 		--add-socket x11 \
 		--add-socket wayland \
-		--add-socket pulseaudio \
-		--add-socket network \
 		--add-device dri -- \
 		"$APPEXEC" "$@"
 		HEREDOC
-		printf '\033[36m\n'
-		read -p " Allow $2 access to ${XDG_DOWNLOAD_DIR:-~/Downloads}? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+		printf '\033[33m\n'
+		read -p " Do you want configure access to directories? (Y/n): " yn
+		if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+			printf '\033[36m\n'
+			read -p " Allow $2 access to ${XDG_DESKTOP_DIR:-~/Desktop}? (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_DESKTOP_DIR:-~/Desktop}"|--add-file "${XDG_DESKTOP_DIR:-~/Desktop}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			read -p " Allow $2 access to ${XDG_DOCUMENTS_DIR:-~/Documents}? (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			read -p " Allow $2 access to ${XDG_DOWNLOAD_DIR:-~/Downloads}? (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_DOWNLOAD_DIR:-~/Downloads}"|--add-file "${XDG_DOWNLOAD_DIR:-~/Downloads}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			read -p " Allow $2 access to ${XDG_GAMES_DIR:-~/Games} (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_GAMES_DIR:-~/Games}"|--add-file "${XDG_GAMES_DIR:-~/Games}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			read -p " Allow $2 access to ${XDG_MUSIC_DIR:-~/Music} (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			read -p " Allow $2 access to ${XDG_PICTURES_DIR:-~/Pictures} (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			read -p " Allow $2 access to ${XDG_VIDEOS_DIR:-~/Videos} (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+			fi
+			printf '\033[31m'
+			read -p " Allow $2 access to a specific directory? (y/N): " yn
+			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				printf '\n%s\n' "   Warning: giving access to all of $HOME or / and similar is not safe"
+				printf '%s\n\033[33m\n' "   Also aisap might not let the application start when such paths are given"
+				read -p "   Type the path to the directory, for example /media/external-drive or ~/Backups: " NEWDIR
+				if [ -n "$NEWDIR" ]; then
+					sed -i "s|--rm-file /path/to/nothing|--add-file \"$NEWDIR\":rw|g" "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
+				else
+					echo "No path given, aborting"; exit 1
+				fi
+			fi
+			printf '\n\033[32m%s\n' " User directories access configured successfully!"
 		fi
-		read -p " Allow $2 access to ${XDG_DOCUMENTS_DIR:-~/Documents}? (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i 's|--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}"|--add-file "${XDG_DOCUMENTS_DIR:-~/Documents}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
-		fi
-		read -p " Allow $2 access to ${XDG_MUSIC_DIR:-~/Music} (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i 's|--rm-file "${XDG_MUSIC_DIR:-~/Music}"|--add-file "${XDG_MUSIC_DIR:-~/Music}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
-		fi
-		read -p " Allow $2 access to ${XDG_PICTURES_DIR:-~/Pictures} (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i 's|--rm-file "${XDG_PICTURES_DIR:-~/Pictures}"|--add-file "${XDG_PICTURES_DIR:-~/Pictures}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
-		fi
-		read -p " Allow $2 access to ${XDG_VIDEOS_DIR:-~/Videos} (y/N): " yn
-		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			sed -i 's|--rm-file "${XDG_VIDEOS_DIR:-~/Videos}"|--add-file "${XDG_VIDEOS_DIR:-~/Videos}":rw|g' "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
-		fi
-		printf '\n\033[33m%s\n' " User directories access configured successfully!"
 
 		chmod a+x "$AMCACHEDIR/sandbox-scripts/$2" && sed -i "s|DUMMY|$APPIMAGE|g; s|SUDO |$SUDOCOMMAND |g" "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
 

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -224,6 +224,12 @@ case "$1" in
 				printf '\n%s\n' "   Type the path to the directory"
 				read -p "   Example /media/external-drive or ~/Backups: " NEWDIR
 				[ -z "$NEWDIR" ] && printf '\033[31m\n%s\n' "   No path given, aborting" && exit 1
+				if [ "$NEWDIR" = '$HOME' ] || [ "$NEWDIR" = '$HOME/' ] || [ "$NEWDIR" = "~/" ] || [ "$NEWDIR" = "~" ] \
+				|| [ "$NEWDIR" = "/" ] || [ "$NEWDIR" = "/home" ] || [ "$NEWDIR" = "/home" ] || [ "$NEWDIR" = "/home/" ]; then
+					notify-send -u critical "DO YOU WANT THE FBI TO GET YA?"
+					printf '\033[31m%s\n' && read -p "   SPOOKY LOCATION DETECTED! ARE YOU SURE? IF SO TYPE \"YES\": "
+					[ $YES != "YES" ] && echo "That's not a \"YES\", aborting" && exit 1
+				fi			
 				printf '\n%s\n' "   Giving access to \"$NEWDIR\"..."
 				sed -i "s|--rm-file /path/to/nothing|--add-file $NEWDIR:rw|g" "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
 			fi

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -220,13 +220,12 @@ case "$1" in
 			read -p " Allow $2 access to a specific directory? (y/N): " yn
 			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 				printf '\n%s\n' "   Warning: giving access to all of $HOME or / and similar is not safe"
-				printf '%s\n\033[33m\n' "   Also aisap might not let the application start when such paths are given"
-				read -p "   Type the path to the directory, for example /media/external-drive or ~/Backups: " NEWDIR
-				if [ -n "$NEWDIR" ]; then
-					sed -i "s|--rm-file /path/to/nothing|--add-file \"$NEWDIR\":rw|g" "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
-				else
-					echo "No path given, aborting"; exit 1
-				fi
+				printf '%s\n\033[33m' "   Also aisap might not let the application start when such paths are given"
+				printf '\n%s\n' "   Type the path to the directory"
+				read -p "   Example /media/external-drive or ~/Backups: " NEWDIR
+				[ -z "$NEWDIR" ] && printf '\033[31m\n%s\n' "   No path given, aborting" && exit 1
+				printf '\n%s\n' "   Giving access to \"$NEWDIR\"..."
+				sed -i "s|--rm-file /path/to/nothing|--add-file $NEWDIR:rw|g" "$AMCACHEDIR/sandbox-scripts/$2" || exit 1
 			fi
 			printf '\n\033[32m%s\n' " User directories access configured successfully!"
 		fi

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -164,6 +164,8 @@ case "$1" in
 		--rm-file "${XDG_PICTURES_DIR:-~/Pictures}" \
 		--rm-file "${XDG_VIDEOS_DIR:-~/Videos}" \
 		--rm-file "${XDG_DOCUMENTS_DIR:-~/Documents}" \
+		--add-file /var/lib/dbus \
+		--add-file /tmp/dbus* \
 		--add-socket dbus \
 		--add-socket x11 \
 		--add-socket wayland \

--- a/programs/x86_64/nvtop
+++ b/programs/x86_64/nvtop
@@ -1,114 +1,75 @@
 #!/bin/sh
 
+# AM INSTALL SCRIPT VERSION 3. 
+set -u
 APP=nvtop
-REPO="Syllo/nvtop"
+SITE="Syllo/nvtop"
 
-# CREATE THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
+echo "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+chmod a+x "/opt/$APP/remove"
 
-# ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
-
-# DOWNLOAD THE ARCHIVE
-mkdir tmp
-cd ./tmp
-
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq '.' | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
-wget $version
-echo "$version" >> /opt/$APP/version
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/Syllo/nvtop/releases | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -oi 'https.*nvtop.*x86_64.*mage$' | head -1)
+wget "$version" || exit 1
+#wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync, warning that more often than not it is broken
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..
-mv ./tmp/*mage ./$APP
-chmod a+x /opt/$APP/$APP
-rmdir ./tmp
+mv ./tmp/*mage ./"$APP"
+mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x "/opt/$APP/$APP" || exit 1
 
-# LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
-cat >> /opt/$APP/AM-updater << 'EOF'
-#!/usr/bin/env bash
+cat >> "/opt/$APP/AM-updater" << 'EOF'
+#!/bin/sh
+set -u
 APP=nvtop
-REPO="Syllo/nvtop"
-version0=$(cat /opt/$APP/version)
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | jq '.' | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i appimage | cut -d '"' -f 4 | head -1)
-if [ $version = $version0 ]; then
-  echo "Update not needed!"
-else
-  notify-send "A new version of $APP is available, please wait"
-  mkdir /opt/$APP/tmp
-  cd /opt/$APP/tmp
-  wget $version
-  if ls . | grep mage; then
+SITE="Syllo/nvtop"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/Syllo/nvtop/releases | sed 's/[()",{}]/ /g; s/ /\n/g' | grep -oi 'https.*nvtop.*x86_64.*mage$' | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	[ -e /opt/"$APP"/*.zsync ] || notify-send "A new version of $APP is available, please wait"
+	[ -e /opt/"$APP"/*.zsync ] && wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
-  	if test -f ./tmp/*mage; then rm ./version
-  	fi
-  	echo $version >> ./version
-  	mv --backup=t ./tmp/*mage ./$APP
-  	chmod a+x /opt/$APP/$APP
-  	rm -R -f ./tmp ./*~
-  fi
-  notify-send "$APP is updated!"
+	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
+	[ -e /opt/"$APP"/*.zsync ] && { zsync "/opt/$APP/$APP.zsync" || notify-send -u critical "zsync failed to update $APP"; }
+	chmod a+x "/opt/$APP/$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+	exit 0
 fi
+echo "Update not needed!"
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x "/opt/$APP/AM-updater"
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
-cd /opt/$APP
-./$APP --appimage-extract *.desktop 1>/dev/null
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null
-mv squashfs-root/*.desktop ./$APP.desktop
-mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
-	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-fi
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
-	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep $app | head -1)
-sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
-sed -i "s#AppRun#$APP#g" ./$APP.desktop
-sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
-sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
-
-mkdir icons
-./$APP --appimage-extract *.png 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
-./$APP --appimage-extract *.svg 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
-./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-mv ./squashfs-root/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-
-rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
-
-
-
-
+cd "/opt/$APP" || exit 1
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH=$(readlink ./"$APP".desktop)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH=$(readlink ./DirIcon)
+		./"$APP" --appimage-extract "$LINKPATH" && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/share/applications/AM-"$APP".desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
* Now sandboxes asks if you want to configure access to directories, By default hitting enter without anything will say Yes, but if you say no it will skip the several questions for each directory, essentially denying the access to them.

Very useful for when you want to sandbox a CLI appliation that often doesn't need access to any of these directories. 

![image](https://github.com/ivan-hc/AM/assets/36420837/8e3cf03b-7f5f-496e-9074-7a4565476c55)

* Added `~/Desktop` and `~/Games` to the list of directories. 

`XDG_GAMES_DIR` is technically not part of the spec but it is commonly used and [requested](https://xdg.freedesktop.narkive.com/5opetQ4G/recognizing-games-dir). And `aisap` has ~/Games as a common rule as well, so with this method we can't deny it if the user wants to. 

I actually had a `~/Games` directory before I discovered aisap lol.

* Added to option to allow a specified directory

![image](https://github.com/ivan-hc/AM/assets/36420837/4a9fc8ba-4015-432a-be3e-b2d62e85568b)


**I also tested this with both `bash` and `dash` as sh so I don't run into another surprise.** 

~~I may later add a check that prints a big warning if the user gives access to a spooky location~~ 😆

EDIT: Done!

