### PR TITLE
Now "AppMan" prompts you to enable ~/.local/bin in $PATH, if not in place

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="6.14-1"
+AMVERSION="6.14-2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -78,8 +78,8 @@ function _am() {
 #######################################
 
 function _patch_bashrc_and_profile() {
-	if ! echo "$PATH" | grep "$BINDIR"; then
-		read -p "Warming: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, would you like appman to patch your .profile or .bash_profile? Y/n): " yn
+	if ! echo "$PATH" | grep -q "$BINDIR"; then
+		read -rp "Warming: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, would you like appman to patch your .profile or .bash_profile? (Y/n): " yn
 		if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 			if test -f "$HOME/.profile"; then
 				printf "export PATH=$PATH:$BINDIR" >> "$HOME/.profile"
@@ -92,6 +92,7 @@ function _patch_bashrc_and_profile() {
 		fi
 	fi
 }
+
 
 function _appman_initialize() {
 	APPSDIR=$1

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -82,9 +82,9 @@ function _patch_bashrc_and_profile() {
 		read -rp "Warming: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, would you like appman to patch your .profile or .bash_profile? (Y/n): " yn
 		if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 			if test -f "$HOME/.profile"; then
-				printf "export PATH=$PATH:$BINDIR" >> "$HOME/.profile"
+				printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.profile"
 			elif test -f "$HOME/.bash_profile"; then
-				printf "export PATH=$PATH:$BINDIR" >> "$HOME/.bash_profile"
+				printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.bash_profile"
 			fi
 			echo "You might need to resource your .profile / .bash_profile or reboot for these changes to take effect"
 		else

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -78,11 +78,17 @@ function _am() {
 #######################################
 
 function _patch_bashrc_and_profile() {
-	if ! echo "$PATH" | grep -q "$BINDIR"; then
-		if test -f "$HOME/.profile"; then
-			printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.profile"
-		elif test -f "$HOME/.bash_profile"; then
-			printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.bash_profile"
+	if ! echo "$PATH" | grep "$BINDIR"; then
+		read -p "Warming: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, would you like appman to patch your .profile or .bash_profile? Y/n): " yn
+		if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+			if test -f "$HOME/.profile"; then
+				printf "export PATH=$PATH:$BINDIR" >> "$HOME/.profile"
+			elif test -f "$HOME/.bash_profile"; then
+				printf "export PATH=$PATH:$BINDIR" >> "$HOME/.bash_profile"
+			fi
+			echo "You might need to resource your .profile / .bash_profile or reboot for these changes to take effect"
+		else
+			exit 1
 		fi
 	fi
 }

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -77,7 +77,7 @@ function _am() {
 # "APPMAN" CORE VARIABLES AND FUNCTIONS
 #######################################
 
-function _patch_bashrc_and_profile() {
+function _check_if_home_local_bin_is_not_in_path() {
 	if  echo "$PATH" | grep -q "$BINDIR"; then
 		echo "--------------------------------------------------------------------------"
 		echo " ⚠️ WARNING: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, apps may not run."
@@ -161,7 +161,7 @@ function _appman() {
 	fi
 	_appman_initialize "$(<"$APPMANCONFIG"/appman-config)"
 
-	_patch_bashrc_and_profile
+	_check_if_home_local_bin_is_not_in_path
 }
 
 ########################################

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -78,21 +78,22 @@ function _am() {
 #######################################
 
 function _patch_bashrc_and_profile() {
-	if ! echo "$PATH" | grep -q "$BINDIR"; then
-		read -rp "Warming: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, would you like appman to patch your .profile or .bash_profile? (Y/n): " yn
+	if  echo "$PATH" | grep -q "$BINDIR"; then
+		echo "--------------------------------------------------------------------------"
+		echo " ⚠️ WARNING: \"${XDG_BIN_HOME:-$HOME/.local/bin}\" is not in PATH, apps may not run."
+		read -rp " ◆ Want to add it to ~/.profile and ~/.bash_profile? (Y/n): " yn
 		if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 			if test -f "$HOME/.profile"; then
 				printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.profile"
 			elif test -f "$HOME/.bash_profile"; then
 				printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.bash_profile"
 			fi
-			echo "You might need to resource your .profile / .bash_profile or reboot for these changes to take effect"
-		else
-			exit 1
+			echo "--------------------------------------------------------------------------"
+			echo " You might need to resource above files or reboot to apply these changes."
+			echo "--------------------------------------------------------------------------"
 		fi
 	fi
 }
-
 
 function _appman_initialize() {
 	APPSDIR=$1

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -15,6 +15,7 @@ arch="$HOSTTYPE"
 export currentuser="$USER"
 
 # XDG Variables
+BINDIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
 DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 export CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
@@ -77,22 +78,11 @@ function _am() {
 #######################################
 
 function _patch_bashrc_and_profile() {
-	# Fix order in "echo $PATH" in case "$HOME/.local/bin" is placed at the beginning instead of the end
-	# Check if the custom PATH is not already in .bashrc, then append it (fix - exclamation mark negates the entire command substitution)
-	if test -f "$HOME/.bashrc"; then
-		if ! grep -q 'export PATH=$PATH:$HOME/.local/bin' "$HOME/.bashrc"; then
-			echo 'export PATH=$(echo $PATH | tr ":" "\n" | grep -v "/.local/bin" | tr "\n" ":" | sed ''s/.$//'')' >> "$HOME/.bashrc"
-			echo -e 'export PATH=$PATH:$HOME/.local/bin\n' >> "$HOME/.bashrc"
-		fi
-	fi
-	# Correct the order of .local/bin in .profile if necessary
-	if test -f "$HOME/.profile"; then
-		if grep -q 'PATH="$HOME/.local/bin:$PATH"' "$HOME/.profile"; then
-			sed -i 's#PATH="$HOME/.local/bin:$PATH"#PATH="$PATH:$HOME/.local/bin"#g' "$HOME/.profile"
-		fi
-	elif test -f "$HOME/.bash_profile"; then
-		if grep -q 'PATH="$HOME/.local/bin:$PATH"' "$HOME/.bash_profile"; then
-			sed -i 's#PATH="$HOME/.local/bin:$PATH"#PATH="$PATH:$HOME/.local/bin"#g' "$HOME/.bash_profile"
+	if ! echo "$PATH" | grep -q "$BINDIR"; then
+		if test -f "$HOME/.profile"; then
+			printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.profile"
+		elif test -f "$HOME/.bash_profile"; then
+			printf '\n%s\n' 'export PATH="$PATH:${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$HOME/.bash_profile"
 		fi
 	fi
 }

--- a/modules/launcher.am
+++ b/modules/launcher.am
@@ -61,7 +61,6 @@ function _launcher_appimage_integration() {
 
 function _launcher_appimage_bin() {
 	mkdir -p "$HOME"/.local/bin
-	_patch_bashrc_and_profile
 	read -p "Do you want to customize the name of a symbolic link (Y) or let me choose (n)?" yn
 	case "$yn" in
 	'N'|'n')

--- a/modules/launcher.am
+++ b/modules/launcher.am
@@ -61,7 +61,7 @@ function _launcher_appimage_integration() {
 
 function _launcher_appimage_bin() {
 	mkdir -p "$HOME"/.local/bin
-	_patch_bashrc_and_profile
+	_check_if_home_local_bin_is_not_in_path
 	read -p "Do you want to customize the name of a symbolic link (Y) or let me choose (n)?" yn
 	case "$yn" in
 	'N'|'n')

--- a/modules/launcher.am
+++ b/modules/launcher.am
@@ -61,6 +61,7 @@ function _launcher_appimage_integration() {
 
 function _launcher_appimage_bin() {
 	mkdir -p "$HOME"/.local/bin
+	_patch_bashrc_and_profile
 	read -p "Do you want to customize the name of a symbolic link (Y) or let me choose (n)?" yn
 	case "$yn" in
 	'N'|'n')


### PR DESCRIPTION
I did some limited testing, but I'm not a bash user so let me know if I need to change anything. 

I removed the patching of the `.bashrc` because as far as I know it isn't needed and can actually cause problems like I mentioned in the issue.

closes #705 #706