### PR TITLE
Fix testdisk

### DIFF
--- a/programs/x86_64/testdisk
+++ b/programs/x86_64/testdisk
@@ -7,12 +7,13 @@ SITE="https://www.cgsecurity.org/wiki/TestDisk_Download"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
-printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP /usr/local/bin/photorec /usr/local/bin/fidentify\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
-#printf '\n%s' "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
+printf '\n%s' "rm -f /usr/local/bin/photorec" >> "/opt/$APP/remove"
+printf '\n%s' "rm -f /usr/local/bin/fidentify" >> "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(wget -q https://www.cgsecurity.org/wiki/TestDisk_Download -O - | tr '"' '\n' | grep http | grep -i linux | grep -i tar | head -1)
+version=$(wget -q https://www.cgsecurity.org/wiki/TestDisk_Download -O - | tr '"' '\n' | grep -oi "https.*testdisk.*linux.*x86_64.*bz2$" | grep -v donate | head -1)
 wget "$version" || exit 1
 [ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
 [ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
@@ -21,7 +22,7 @@ cd ..
 if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
-chmod a+x "/opt/$APP/*_static" || exit 1
+chmod a+x /opt/"$APP"/*static || exit 1
 
 # LINK TO PATH
 ln -s "/opt/$APP/testdisk_static" "/usr/local/bin/$APP"
@@ -35,7 +36,7 @@ set -u
 APP=testdisk
 SITE="https://www.cgsecurity.org/wiki/TestDisk_Download"
 version0=$(cat "/opt/$APP/version")
-version=$(wget -q https://www.cgsecurity.org/wiki/TestDisk_Download -O - | tr '"' '\n' | grep http | grep -i linux | grep -i tar | head -1)
+version=$(wget -q https://www.cgsecurity.org/wiki/TestDisk_Download -O - | tr '"' '\n' | grep -oi "https.*testdisk.*linux.*x86_64.*bz2$" | grep -v donate | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
@@ -46,7 +47,7 @@ if [ "$version" != "$version0" ]; then
 	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 	cd ..
 	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
-	chmod a+x "/opt/$APP/*_static" || exit 1
+	chmod a+x /opt/"$APP"/*static || exit 1
 	echo "$version" > ./version
 	rm -R -f ./tmp ./*~
 	notify-send "$APP is updated!"


### PR DESCRIPTION
Btw Ivan check how I changed the remover, that is how the remover is meant to be used when new files have to be removed. 

Adding the extra files instead of the existing line is something one is likely to make a mistake when doing, that is why I have a commented out line for the .desktop as that is what is more likely to be the extra file that needs to be removed, but it also applies to all other extra files. 

Also you had the `chmod a+x "/opt/$APP/*static"` inside quotes which would never expand. 