### PR TITLE
Fix launchers for aarch64 and i686 apps...

### DIFF
--- a/programs/aarch64/86box
+++ b/programs/aarch64/86box
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,4 +107,4 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop

--- a/programs/aarch64/antares
+++ b/programs/aarch64/antares
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,7 +64,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Antares
 Exec=antares --no-sandbox %U
@@ -73,7 +73,7 @@ Type=Application
 Icon=/opt/$APP/$APP.svg
 StartupWMClass=Antares
 Comment=A cross-platform easy to use SQL client.
-Categories=Development;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Development;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/aarch64/btop
+++ b/programs/aarch64/btop
@@ -9,7 +9,7 @@ mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 
 # ADD THE REMOVER
 echo "#!/bin/sh
-rm -f /usr/share/applications/AM-$APP.desktop /usr/local/bin/$APP
+rm -f /usr/local/share/applications/AM-$APP.desktop /usr/local/bin/$APP
 rm -R -f /opt/$APP" >> "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
@@ -55,4 +55,4 @@ EOF
 chmod a+x "/opt/$APP/AM-updater"
 
 # LAUNCHER & ICON
-mv ./*.desktop /usr/share/applications/AM-"$APP".desktop && mv ./*mg/*.svg ./icons/btop 2>/dev/null #btop already ships the files
+mv ./*.desktop /usr/local/share/applications/AM-"$APP".desktop && mv ./*mg/*.svg ./icons/btop 2>/dev/null #btop already ships the files

--- a/programs/aarch64/crossmobile
+++ b/programs/aarch64/crossmobile
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,14 +65,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=CrossMobile
 Exec=crossmobile
 Comment=COMMENT
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Development;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Development;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/aarch64/figma-linux
+++ b/programs/aarch64/figma-linux
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,14 +65,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Figma Linux
 Exec=figma-linux
 Comment=Figma is the first interface design tool based in the browser, making it easier for teams to create software. 
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Graphics;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Graphics;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/aarch64/freac
+++ b/programs/aarch64/freac
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,7 +65,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=fre:ac
 Comment=A free audio converter
@@ -74,7 +74,7 @@ Type=Application
 Icon=/opt/$APP/$APP.svg
 Categories=AudioVideo;Audio;
 Keywords=freac;
-MimeType=x-content/audio-cdda;application/x-cue;audio/aac;audio/flac;audio/mpeg;audio/mp2;audio/mp4;audio/x-m4b;audio/ogg;audio/x-flac+ogg;audio/x-opus+ogg;audio/x-speex+ogg;audio/x-vorbis+ogg;audio/x-ape;audio/x-musepack;audio/x-wavpack;audio/x-ms-wma;audio/x-aiff;audio/x-voc;audio/x-wav;" >> /usr/share/applications/AM-$APP.desktop
+MimeType=x-content/audio-cdda;application/x-cue;audio/aac;audio/flac;audio/mpeg;audio/mp2;audio/mp4;audio/x-m4b;audio/ogg;audio/x-flac+ogg;audio/x-opus+ogg;audio/x-speex+ogg;audio/x-vorbis+ogg;audio/x-ape;audio/x-musepack;audio/x-wavpack;audio/x-ms-wma;audio/x-aiff;audio/x-voc;audio/x-wav;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/aarch64/nanosaur
+++ b/programs/aarch64/nanosaur
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,4 +107,4 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop

--- a/programs/aarch64/streamlink
+++ b/programs/aarch64/streamlink
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE

--- a/programs/aarch64/supertuxkart
+++ b/programs/aarch64/supertuxkart
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -68,4 +68,4 @@ mv ./*$app*.png ./icons/$APP 2>/dev/null
 mv ./*128*.png ./icons/$APP 2>/dev/null
 mv ./*256*.png ./icons/$APP 2>/dev/null
 
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop

--- a/programs/aarch64/topgrade
+++ b/programs/aarch64/topgrade
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE

--- a/programs/aarch64/ventoy
+++ b/programs/aarch64/ventoy
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -58,11 +58,11 @@ mkdir icons
 wget https://www.ventoy.net/static/img/ventoy.png -O ./icons/$APP 2> /dev/null
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Ventoy
 Comment=Open source tool to create bootable USB drive for ISO/WIM/IMG/VHD(x)/EFI files. 
 Exec=$APP
 Icon=/opt/$APP/icons/$APP
 Type=Application
-Categories=System;" >> /usr/share/applications/AM-$APP.desktop
+Categories=System;" >> /usr/local/share/applications/AM-$APP.desktop

--- a/programs/aarch64/vivaldi
+++ b/programs/aarch64/vivaldi
@@ -17,7 +17,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 mkdir tmp;
@@ -276,7 +276,7 @@ Name[uk]=Нове приватне вікно
 Name[vi]=Cửa sổ Riêng tư Mới
 Name[zh_CN]=新建隐私窗口
 Name[zh_TW]=新增無痕視窗
-Exec=$APP --incognito" >> /usr/share/applications/AM-$APP.desktop;
+Exec=$APP --incognito" >> /usr/local/share/applications/AM-$APP.desktop;
 
 currentuser=$(who | awk '{print $1}')
 chown -R $currentuser /opt/$APP;;
@@ -289,7 +289,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 mkdir tmp;
@@ -548,4 +548,4 @@ Name[uk]=Нове приватне вікно
 Name[vi]=Cửa sổ Riêng tư Mới
 Name[zh_CN]=新建隐私窗口
 Name[zh_TW]=新增無痕視窗
-Exec=$APP --incognito" >> /usr/share/applications/AM-$APP.desktop;
+Exec=$APP --incognito" >> /usr/local/share/applications/AM-$APP.desktop;

--- a/programs/aarch64/vivaldi-snapshot
+++ b/programs/aarch64/vivaldi-snapshot
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -66,7 +66,7 @@ sed -i '/^  DOWNLOAD/s/ -T[0-9]\+//' ./update-ffmpeg 2> /dev/null
 # LAUNCHER
 sed -i "s#Exec=/usr/bin/#Exec=#g" $APP.desktop
 sed -i "s#Icon=vivaldi-snapshot#Icon=/opt/$APP/icons/$APP#g" $APP.desktop
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop 2> /dev/null
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop 2> /dev/null
 
 # ICON
 mkdir icons

--- a/programs/aarch64/vivaldi-stable
+++ b/programs/aarch64/vivaldi-stable
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -66,7 +66,7 @@ sed -i '/^  DOWNLOAD/s/ -T[0-9]\+//' ./update-ffmpeg 2> /dev/null
 # LAUNCHER
 sed -i "s#Exec=/usr/bin/#Exec=#g" $APP.desktop
 sed -i "s#Icon=vivaldi#Icon=/opt/$APP/icons/$APP#g" $APP.desktop
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop 2> /dev/null
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop 2> /dev/null
 
 # ICON
 mkdir icons

--- a/programs/aarch64/vscodium
+++ b/programs/aarch64/vscodium
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -72,7 +72,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=VSCodium
 Comment=Code Editing. Redefined.
@@ -92,7 +92,7 @@ X-AppImage-Version=1.59.1-1629418630.glibc2.17
 [Desktop Action new-empty-window]
 Name=New Empty Window
 Exec=vscodium --new-window %F
-Icon=/opt/$APP/$APP.svg" >> /usr/share/applications/AM-$APP.desktop
+Icon=/opt/$APP/$APP.svg" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/aarch64/xdg-ninja
+++ b/programs/aarch64/xdg-ninja
@@ -8,7 +8,7 @@ SITE="b3nj5m1n/xdg-ninja"
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
-#printf '\n%s' "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+#printf '\n%s' "rm -f /usr/local/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates

--- a/programs/aarch64/zap
+++ b/programs/aarch64/zap
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE PROGRAM

--- a/programs/aarch64/zmninja
+++ b/programs/aarch64/zmninja
@@ -18,7 +18,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -68,7 +68,7 @@ sed -i s/FUNCTION4/$FILENAMEEXTENTION/g /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -76,7 +76,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=$CATEGORIES;
-Comment=$COMMENT" >> /usr/share/applications/AM-$APP.desktop
+Comment=$COMMENT" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir ./icons

--- a/programs/aarch64/zramen
+++ b/programs/aarch64/zramen
@@ -9,7 +9,7 @@ SITE="atweiden/zramen"
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > "/opt/$APP/remove"
-#printf '\n%s' "rm -f /usr/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
+#printf '\n%s' "rm -f /usr/local/share/applications/AM-$APP.desktop" >> "/opt/$APP/remove"
 chmod a+x "/opt/$APP/remove"
 
 # DOWNLOAD AND PREPARE THE APP

--- a/programs/i686/appimagedl
+++ b/programs/i686/appimagedl
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE PROGRAM

--- a/programs/i686/appimagelauncher
+++ b/programs/i686/appimagelauncher
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,7 +107,7 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/armagetronad
+++ b/programs/i686/armagetronad
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/games/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/games/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE PROGRAM
@@ -72,7 +72,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Type=Application
 Name=Armagetron Advanced
@@ -84,7 +84,7 @@ Terminal=false
 Categories=Game;ActionGame;
 StartupNotify=false
 MimeType=application/x-armagetronad;
-Keywords=tron-like;light;cycle;3D;multiplayer;networked;server;" >> /usr/share/applications/AM-$APP.desktop
+Keywords=tron-like;light;cycle;3D;multiplayer;networked;server;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://upload.wikimedia.org/wikipedia/commons/1/10/Armagetron_Advanced.png

--- a/programs/i686/bovo
+++ b/programs/i686/bovo
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/btop
+++ b/programs/i686/btop
@@ -8,7 +8,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 mkdir tmp;

--- a/programs/i686/chromium
+++ b/programs/i686/chromium
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,7 +107,7 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/cozydrive
+++ b/programs/i686/cozydrive
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,14 +64,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=CozyDrive
 Exec=cozydrive
 Comment=File Synchronisation for Cozy on Desktop and Laptop.
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Network;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Network;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/deployer
+++ b/programs/i686/deployer
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,14 +65,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Deployer
 Exec=deployer
 Comment=Cross-platform application to deploy your applications through Jenkins. 
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Network;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Network;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/dosemu
+++ b/programs/i686/dosemu
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,7 +107,7 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/etcher
+++ b/programs/i686/etcher
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,7 +64,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=balenaEtcher
 Exec=etcher --no-sandbox %U
@@ -74,7 +74,7 @@ Icon=/opt/$APP/$APP.svg
 StartupWMClass=balenaEtcher
 Comment=Flash OS images to SD cards and USB drives, safely and easily.
 MimeType=x-scheme-handler/etcher;
-Categories=Utility;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Utility;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/ffwa-facebook
+++ b/programs/i686/ffwa-facebook
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-github
+++ b/programs/i686/ffwa-github
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Development;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-gmail
+++ b/programs/i686/ffwa-gmail
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-netflix
+++ b/programs/i686/ffwa-netflix
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-reddit
+++ b/programs/i686/ffwa-reddit
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-twitter
+++ b/programs/i686/ffwa-twitter
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-whatsapp
+++ b/programs/i686/ffwa-whatsapp
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/ffwa-youtube
+++ b/programs/i686/ffwa-youtube
@@ -10,7 +10,7 @@ cd /opt/$APP;
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # LINK
@@ -21,7 +21,7 @@ EOF
 chmod a+x /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -29,7 +29,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=Network;
-Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/share/applications/AM-$APP.desktop
+Comment=Web Application & Firefox Profile for $APPNAME" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir /opt/$APP/icons

--- a/programs/i686/filezilla
+++ b/programs/i686/filezilla
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -63,7 +63,7 @@ mkdir icons
 wget https://portable-linux-apps.github.io/icons/filezilla.png -O ./icons/$APP 2> /dev/null
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=FileZilla
 GenericName=FTP client
@@ -79,4 +79,4 @@ Terminal=false
 Icon=/opt/$APP/icons/$APP
 Type=Application
 Categories=Network;FileTransfer;
-Version=1.0" >> /usr/share/applications/AM-$APP.desktop
+Version=1.0" >> /usr/local/share/applications/AM-$APP.desktop

--- a/programs/i686/firefox
+++ b/programs/i686/firefox
@@ -4,7 +4,7 @@ mkdir /opt/firefox
 cd /opt/firefox
 
 echo "#!/bin/sh
-rm -R -f  /opt/firefox /usr/share/applications/AM-firefox-stable.desktop /usr/local/bin/firefox" >> /opt/firefox/remove
+rm -R -f  /opt/firefox /usr/local/share/applications/AM-firefox-stable.desktop /usr/local/bin/firefox" >> /opt/firefox/remove
 chmod a+x /opt/firefox/remove
 
 mkdir tmp;
@@ -24,7 +24,7 @@ chown -R $currentuser /opt/firefox
 
 ln -s /opt/firefox/firefox /usr/local/bin/firefox
 
-rm -R -f  /usr/share/applications/AM-firefox-stable.desktop
+rm -R -f  /usr/local/share/applications/AM-firefox-stable.desktop
 echo "[Desktop Entry]
 [Desktop Entry]
 Version=1.0
@@ -186,7 +186,7 @@ Name[vi]=Cửa sổ riêng tư mới
 Name[wo]=Panlanteeru biir bu bees
 Name[xh]=Ifestile yangasese entsha
 Name[zh-CN]=新建隐私浏览窗口
-Name[zh-TW]=新增隱私視窗"  >> /usr/share/applications/AM-firefox-stable.desktop
+Name[zh-TW]=新增隱私視窗"  >> /usr/local/share/applications/AM-firefox-stable.desktop
 # MESSAGE
 echo "";
 echo " Firefox Stable has been installed! ";

--- a/programs/i686/firefox-beta
+++ b/programs/i686/firefox-beta
@@ -4,7 +4,7 @@ mkdir /opt/firefox-beta
 cd /opt/firefox-beta
 
 echo "#!/bin/sh
-rm -R -f /opt/firefox-beta /usr/share/applications/AM-firefox-beta.desktop /usr/local/bin/firefox-beta" >> /opt/firefox-beta/remove
+rm -R -f /opt/firefox-beta /usr/local/share/applications/AM-firefox-beta.desktop /usr/local/bin/firefox-beta" >> /opt/firefox-beta/remove
 chmod a+x /opt/firefox-beta/remove
 
 mkdir tmp;
@@ -24,7 +24,7 @@ chown -R $currentuser /opt/firefox-beta
 
 ln -s /opt/firefox-beta/firefox /usr/local/bin/firefox-beta
 
-rm -R -f /usr/share/applications/AM-firefox-beta.desktop
+rm -R -f /usr/local/share/applications/AM-firefox-beta.desktop
 echo "[Desktop Entry]
 Name=Firefox Beta
 Comment=Web Browser
@@ -39,7 +39,7 @@ Actions=Private;
 
 [Desktop Action Private]
 Exec=/opt/firefox-beta/firefox --private-window %u
-Name=Open in private mode"  >> /usr/share/applications/AM-firefox-beta.desktop
+Name=Open in private mode"  >> /usr/local/share/applications/AM-firefox-beta.desktop
 # MESSAGE
 echo "";
 echo " Firefox Beta has been installed! ";

--- a/programs/i686/firefox-dev
+++ b/programs/i686/firefox-dev
@@ -4,7 +4,7 @@ mkdir /opt/firefox-dev
 cd /opt/firefox-dev
 
 echo "#!/bin/sh
-rm -R -f /opt/firefox-dev /usr/share/applications/AM-firefox-dev.desktop /usr/local/bin/firefox-dev" >> /opt/firefox-dev/remove
+rm -R -f /opt/firefox-dev /usr/local/share/applications/AM-firefox-dev.desktop /usr/local/bin/firefox-dev" >> /opt/firefox-dev/remove
 chmod a+x /opt/firefox-dev/remove
 
 mkdir tmp;
@@ -24,7 +24,7 @@ chown -R $currentuser /opt/firefox-dev
 
 ln -s /opt/firefox-dev/firefox /usr/local/bin/firefox-dev
 
-rm -R -f /usr/share/applications/AM-firefox-dev.desktop
+rm -R -f /usr/local/share/applications/AM-firefox-dev.desktop
 echo "[Desktop Entry]
 Name=Firefox Developer Edition
 Comment=Web Browser
@@ -39,7 +39,7 @@ Actions=Private;
 
 [Desktop Action Private]
 Exec=/opt/firefox-dev/firefox --private-window %u
-Name=Open in private mode"  >> /usr/share/applications/AM-firefox-dev.desktop
+Name=Open in private mode"  >> /usr/local/share/applications/AM-firefox-dev.desktop
 # MESSAGE
 echo "";
 echo " Firefox Developer Edition has been installed! ";

--- a/programs/i686/firefox-esr
+++ b/programs/i686/firefox-esr
@@ -4,7 +4,7 @@ mkdir /opt/firefox-esr
 cd /opt/firefox-esr
 
 echo "#!/bin/sh
-rm -R -f /opt/firefox-esr /usr/share/applications/AM-firefox-esr.desktop /usr/local/bin/firefox-esr" >> /opt/firefox-esr/remove
+rm -R -f /opt/firefox-esr /usr/local/share/applications/AM-firefox-esr.desktop /usr/local/bin/firefox-esr" >> /opt/firefox-esr/remove
 chmod a+x /opt/firefox-esr/remove
 
 mkdir tmp;
@@ -24,7 +24,7 @@ chown -R $currentuser /opt/firefox-esr
 
 ln -s /opt/firefox-esr/firefox /usr/local/bin/firefox-esr
 
-rm -R -f /usr/share/applications/AM-firefox-esr.desktop
+rm -R -f /usr/local/share/applications/AM-firefox-esr.desktop
 echo "[Desktop Entry]
 Name=Firefox ESR
 Comment=Web Browser
@@ -39,7 +39,7 @@ Actions=Private;
 
 [Desktop Action Private]
 Exec=/opt/firefox-esr/firefox --private-window %u
-Name=Open in private mode"  >> /usr/share/applications/AM-firefox-esr.desktop
+Name=Open in private mode"  >> /usr/local/share/applications/AM-firefox-esr.desktop
 # MESSAGE
 echo "";
 echo " Firefox ESR has been installed! ";

--- a/programs/i686/firefox-nightly
+++ b/programs/i686/firefox-nightly
@@ -4,7 +4,7 @@ mkdir /opt/firefox-nightly
 cd /opt/firefox-nightly
 
 echo "#!/bin/sh
-rm -R -f /opt/firefox-nightly /usr/share/applications/AM-firefox-nightly.desktop /usr/local/bin/firefox-nightly" >> /opt/firefox-nightly/remove
+rm -R -f /opt/firefox-nightly /usr/local/share/applications/AM-firefox-nightly.desktop /usr/local/bin/firefox-nightly" >> /opt/firefox-nightly/remove
 chmod a+x /opt/firefox-nightly/remove
 
 mkdir tmp;
@@ -24,7 +24,7 @@ chown -R $currentuser /opt/firefox-nightly
 
 ln -s /opt/firefox-nightly/firefox /usr/local/bin/firefox-nightly
 
-rm -R -f /usr/share/applications/AM-firefox-nightly.desktop
+rm -R -f /usr/local/share/applications/AM-firefox-nightly.desktop
 echo "[Desktop Entry]
 Name=Firefox Nightly
 Comment=Web Browser
@@ -39,7 +39,7 @@ Actions=Private;
 
 [Desktop Action Private]
 Exec=/opt/firefox-nightly/firefox --private-window %u
-Name=Open in private mode"  >> /usr/share/applications/AM-firefox-nightly.desktop
+Name=Open in private mode"  >> /usr/local/share/applications/AM-firefox-nightly.desktop
 # MESSAGE
 echo "";
 echo " Firefox Nightly has been installed! ";

--- a/programs/i686/freac
+++ b/programs/i686/freac
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,7 +65,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=fre:ac
 Comment=A free audio converter
@@ -74,7 +74,7 @@ Type=Application
 Icon=/opt/$APP/$APP.svg
 Categories=AudioVideo;Audio;
 Keywords=freac;
-MimeType=x-content/audio-cdda;application/x-cue;audio/aac;audio/flac;audio/mpeg;audio/mp2;audio/mp4;audio/x-m4b;audio/ogg;audio/x-flac+ogg;audio/x-opus+ogg;audio/x-speex+ogg;audio/x-vorbis+ogg;audio/x-ape;audio/x-musepack;audio/x-wavpack;audio/x-ms-wma;audio/x-aiff;audio/x-voc;audio/x-wav;" >> /usr/share/applications/AM-$APP.desktop
+MimeType=x-content/audio-cdda;application/x-cue;audio/aac;audio/flac;audio/mpeg;audio/mp2;audio/mp4;audio/x-m4b;audio/ogg;audio/x-flac+ogg;audio/x-opus+ogg;audio/x-speex+ogg;audio/x-vorbis+ogg;audio/x-ape;audio/x-musepack;audio/x-wavpack;audio/x-ms-wma;audio/x-aiff;audio/x-voc;audio/x-wav;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/free-tex-packer
+++ b/programs/i686/free-tex-packer
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,14 +65,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=free-tex-packer
 Exec=free-tex-packer
 Comment=Free texture packer creates sprite sheets for you game or site.
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Graphics;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Graphics;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/gimp
+++ b/programs/i686/gimp
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,7 +107,7 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/gimp-2.10.30
+++ b/programs/i686/gimp-2.10.30
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -29,7 +29,7 @@ rmdir ./tmp
 ln -s /opt/$APP/$APP /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Version=1.0
 Type=Application
@@ -281,7 +281,7 @@ Icon=/opt/$APP/gimp.png
 Terminal=false
 Categories=Graphics;2DGraphics;RasterGraphics;GTK;
 StartupNotify=true
-MimeType=image/bmp;image/g3fax;image/gif;image/x-fits;image/x-pcx;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-psd;image/x-sgi;image/x-tga;image/x-xbitmap;image/x-xwindowdump;image/x-xcf;image/x-compressed-xcf;image/x-gimp-gbr;image/x-gimp-pat;image/x-gimp-gih;image/tiff;image/jpeg;image/x-psp;application/postscript;image/png;image/x-icon;image/x-xpixmap;image/x-exr;image/webp;image/x-webp;image/heif;image/heic;image/avif;image/svg+xml;application/pdf;image/x-wmf;image/jp2;image/x-xcursor;" >> /usr/share/applications/AM-$APP.desktop
+MimeType=image/bmp;image/g3fax;image/gif;image/x-fits;image/x-pcx;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-psd;image/x-sgi;image/x-tga;image/x-xbitmap;image/x-xwindowdump;image/x-xcf;image/x-compressed-xcf;image/x-gimp-gbr;image/x-gimp-pat;image/x-gimp-gih;image/tiff;image/jpeg;image/x-psp;application/postscript;image/png;image/x-icon;image/x-xpixmap;image/x-exr;image/webp;image/x-webp;image/heif;image/heic;image/avif;image/svg+xml;application/pdf;image/x-wmf;image/jp2;image/x-xcursor;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://www.gimp.org/images/frontpage/wilber-big.png && mv ./wilber-big.png ./gimp.png

--- a/programs/i686/hexoeditor
+++ b/programs/i686/hexoeditor
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,7 +65,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=HexoEditor
 Comment=This is markdown editor for Hexo.
@@ -73,7 +73,7 @@ Exec=hexoeditor
 Terminal=false
 Type=Application
 Icon=Icon=/opt/$APP/$APP.svg
-Categories=Utility;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Utility;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/katomic
+++ b/programs/i686/katomic
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kblackbox
+++ b/programs/i686/kblackbox
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kbounce
+++ b/programs/i686/kbounce
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kbreakout
+++ b/programs/i686/kbreakout
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kdegames
+++ b/programs/i686/kdegames
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kdiamond
+++ b/programs/i686/kdiamond
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kfourinline
+++ b/programs/i686/kfourinline
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kgoldrunner
+++ b/programs/i686/kgoldrunner
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kiriki
+++ b/programs/i686/kiriki
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kjumpingcube
+++ b/programs/i686/kjumpingcube
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/klickety
+++ b/programs/i686/klickety
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/klines
+++ b/programs/i686/klines
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kmahjongg
+++ b/programs/i686/kmahjongg
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kmines
+++ b/programs/i686/kmines
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/knavalbattle
+++ b/programs/i686/knavalbattle
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/knetwalk
+++ b/programs/i686/knetwalk
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kolf
+++ b/programs/i686/kolf
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kollision
+++ b/programs/i686/kollision
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/konquest
+++ b/programs/i686/konquest
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kpat
+++ b/programs/i686/kpat
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kreversi
+++ b/programs/i686/kreversi
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kshisen
+++ b/programs/i686/kshisen
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/ksirk
+++ b/programs/i686/ksirk
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/kspaceduel
+++ b/programs/i686/kspaceduel
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/ksquares
+++ b/programs/i686/ksquares
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/ksudoku
+++ b/programs/i686/ksudoku
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/ktuberling
+++ b/programs/i686/ktuberling
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/legendary-kingdoms
+++ b/programs/i686/legendary-kingdoms
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/games/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/games/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,7 +64,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Legendary Kingdoms
 Exec=legendary-kingdoms
@@ -74,7 +74,7 @@ Terminal=false
 Categories=Game;
 Type=Application
 Name[en_DK]=Legendary Kingdoms
-Name[en_US]=Legendary Kingdoms" >> /usr/share/applications/AM-$APP.desktop
+Name[en_US]=Legendary Kingdoms" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/lskat
+++ b/programs/i686/lskat
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/museeks
+++ b/programs/i686/museeks
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,14 +64,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Museeks
 Exec=museeks
 Comment=A simple, clean and cross-platform music player.
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Audio;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Audio;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/musicalypse
+++ b/programs/i686/musicalypse
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,7 +65,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Musicalypse
 Comment=A modern audio player built with Web technologies.
@@ -74,7 +74,7 @@ Terminal=false
 Type=Application
 Icon=/opt/$APP/$APP.svg
 StartupWMClass=Musicalypse
-Categories=AudioVideo;Audio;" >> /usr/share/applications/AM-$APP.desktop
+Categories=AudioVideo;Audio;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/ocenaudio
+++ b/programs/i686/ocenaudio
@@ -4,7 +4,7 @@ mkdir /opt/ocenaudio
 cd /opt/ocenaudio
 
 echo '#!/bin/sh
-rm -R -f /usr/share/applications/AM-ocenaudio.desktop /opt/ocenaudio /usr/local/bin/ocenaudio' >> /opt/ocenaudio/remove
+rm -R -f /usr/local/share/applications/AM-ocenaudio.desktop /opt/ocenaudio /usr/local/bin/ocenaudio' >> /opt/ocenaudio/remove
 chmod a+x /opt/ocenaudio/remove
 
 mkdir tmp
@@ -17,7 +17,7 @@ mv ./tmp/opt/ocenaudio/* ./
 cp ./tmp/usr/share/icons/hicolor/128x128/apps/ocenaudio.png ./
 rm -R -f ./tmp
 
-rm -R -f /usr/share/applications/AM-ocenaudio.desktop
+rm -R -f /usr/local/share/applications/AM-ocenaudio.desktop
 echo "[Desktop Entry]
 Name=ocenaudio
 Name[pt]=ocenaudio
@@ -39,7 +39,7 @@ Categories=AudioVideo;Audio;AudioVideoEditing;
 Exec=/opt/ocenaudio/bin/ocenaudio %F
 StartupNotify=false
 Terminal=false
-MimeType=application/ogg;audio/basic;audio/mpeg;audio/x-aiff;audio/x-mp3;audio/x-wav;application/x-ocenlink;x-scheme-handler/ocenaudio;" >> /usr/share/applications/AM-ocenaudio.desktop
+MimeType=application/ogg;audio/basic;audio/mpeg;audio/x-aiff;audio/x-mp3;audio/x-wav;application/x-ocenlink;x-scheme-handler/ocenaudio;" >> /usr/local/share/applications/AM-ocenaudio.desktop
 
 ln -s /opt/ocenaudio/bin/ocenaudio /usr/local/bin/ocenaudio
 

--- a/programs/i686/pennywise
+++ b/programs/i686/pennywise
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -65,14 +65,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Pennywise
 Exec=pennywise
 Comment=Cross-platform application to open any website or media in a floating window.
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Network;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Network;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/picmi
+++ b/programs/i686/picmi
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP*.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -85,7 +85,7 @@ for file in *; do mv ./$file ./AM-$APP-$file
 done
 sed -i "s#Exec=#Exec=/opt/kdegames/kdegames #g" /opt/$APP/launchers/*.desktop
 sed -i "s#Icon=#Icon=/opt/kdegames/icons/#g" /opt/$APP/launchers/*.desktop
-cp /opt/$APP/launchers/*.desktop /usr/share/applications/
+cp /opt/$APP/launchers/*.desktop /usr/local/share/applications/
 
 rm -R -f /opt/$APP/launchers
 rm -R -f /opt/$APP/squashfs-root

--- a/programs/i686/rambox
+++ b/programs/i686/rambox
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,7 +64,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Rambox
 Exec=rambox %U
@@ -73,7 +73,7 @@ Type=Application
 Icon=/opt/$APP/$APP.svg
 StartupWMClass=Rambox
 Categories=Network;
-Comment=Free and Open Source messaging and emailing app that combines common web applications into one." >> /usr/share/applications/AM-$APP.desktop
+Comment=Free and Open Source messaging and emailing app that combines common web applications into one." >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/rats-search
+++ b/programs/i686/rats-search
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,14 +64,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=rats-search
 Exec=rats-search
 Comment=BitTorrent P2P multi-platform search engine for Desktop and Web servers with integrated torrent client. 
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Network;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Network;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/sabaki
+++ b/programs/i686/sabaki
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/games/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/games/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,7 +64,7 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Sabaki
 Exec=sabaki --no-sandbox %U
@@ -73,7 +73,7 @@ Type=Application
 Icon=/opt/$APP/$APP.svg
 StartupWMClass=Sabaki
 Comment=An elegant Go/Baduk/Weiqi board and SGF editor for a more civilized age.
-Categories=Game;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Game;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/ser-player
+++ b/programs/i686/ser-player
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,14 +64,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=SER Player
 Exec=ser-player
 Comment=A simple video player for playing SER files used for solar, lunar and planetary astronomy-imaging.
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=AudioVideo;" >> /usr/share/applications/AM-$APP.desktop
+Categories=AudioVideo;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/streamlink
+++ b/programs/i686/streamlink
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE

--- a/programs/i686/supertuxkart
+++ b/programs/i686/supertuxkart
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -68,7 +68,7 @@ mv ./*$app*.png ./icons/$APP 2>/dev/null
 mv ./*128*.png ./icons/$APP 2>/dev/null
 mv ./*256*.png ./icons/$APP 2>/dev/null
 
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/synfig-studio
+++ b/programs/i686/synfig-studio
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -26,14 +26,14 @@ rmdir ./tmp
 ln -s /opt/$APP/$APP /usr/local/bin/$APP
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Synfig Studio
 Exec=synfig-studio
 Comment=Open-source 2D Animation Software
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Graphics;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Graphics;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/thunderbird
+++ b/programs/i686/thunderbird
@@ -4,7 +4,7 @@ mkdir /opt/thunderbird
 cd /opt/thunderbird
 
 echo "#!/bin/sh
-rm -R -f  /opt/thunderbird /usr/share/applications/AM-thunderbird.desktop /usr/local/bin/thunderbird" >> /opt/thunderbird/remove
+rm -R -f  /opt/thunderbird /usr/local/share/applications/AM-thunderbird.desktop /usr/local/bin/thunderbird" >> /opt/thunderbird/remove
 chmod a+x /opt/thunderbird/remove
 
 mkdir tmp;
@@ -21,7 +21,7 @@ rm -R ./tmp
 
 ln -s /opt/thunderbird/thunderbird /usr/local/bin/thunderbird
 
-rm -R -f  /usr/share/applications/AM-thunderbird.desktop
+rm -R -f  /usr/local/share/applications/AM-thunderbird.desktop
 echo "[Desktop Entry]
 Name=Thunderbird
 Comment=Send and receive mail with Thunderbird
@@ -86,7 +86,7 @@ Icon=/opt/thunderbird/chrome/icons/default/default128.png
 Categories=Network;Email;
 MimeType=message/rfc822;x-scheme-handler/mailto;application/x-xpinstall;
 StartupNotify=true
-Actions=ComposeMessage;OpenAddressBook;"  >> /usr/share/applications/AM-thunderbird.desktop
+Actions=ComposeMessage;OpenAddressBook;"  >> /usr/local/share/applications/AM-thunderbird.desktop
 
 currentuser=$(who | awk '{print $1}')
 chown -R $currentuser /opt/thunderbird

--- a/programs/i686/thunderbird-beta
+++ b/programs/i686/thunderbird-beta
@@ -4,7 +4,7 @@ mkdir /opt/thunderbird-beta
 cd /opt/thunderbird-beta
 
 echo "#!/bin/sh
-rm -R -f  /opt/thunderbird-beta /usr/share/applications/AM-thunderbird-beta.desktop /usr/local/bin/thunderbird-beta" >> /opt/thunderbird-beta/remove
+rm -R -f  /opt/thunderbird-beta /usr/local/share/applications/AM-thunderbird-beta.desktop /usr/local/bin/thunderbird-beta" >> /opt/thunderbird-beta/remove
 chmod a+x /opt/thunderbird-beta/remove
 
 mkdir tmp;
@@ -21,7 +21,7 @@ rm -R ./tmp
 
 ln -s /opt/thunderbird-beta/thunderbird /usr/local/bin/thunderbird-beta
 
-rm -R -f  /usr/share/applications/AM-thunderbird-beta.desktop
+rm -R -f  /usr/local/share/applications/AM-thunderbird-beta.desktop
 echo "[Desktop Entry]
 Name=Thunderbird Beta
 Comment=Send and receive mail with Thunderbird
@@ -86,7 +86,7 @@ Icon=/opt/thunderbird-beta/chrome/icons/default/default128.png
 Categories=Network;Email;
 MimeType=message/rfc822;x-scheme-handler/mailto;application/x-xpinstall;
 StartupNotify=true
-Actions=ComposeMessage;OpenAddressBook;"  >> /usr/share/applications/AM-thunderbird-beta.desktop
+Actions=ComposeMessage;OpenAddressBook;"  >> /usr/local/share/applications/AM-thunderbird-beta.desktop
 
 currentuser=$(who | awk '{print $1}')
 chown -R $currentuser /opt/thunderbird-beta

--- a/programs/i686/tor-browser
+++ b/programs/i686/tor-browser
@@ -4,7 +4,7 @@ mkdir /opt/tor-browser
 cd /opt/tor-browser
 
 echo "#!/bin/sh
-rm -R -f  /opt/tor-browser /usr/share/applications/AM-tor-browser.desktop /usr/local/bin/tor-browser" >> /opt/tor-browser/remove
+rm -R -f  /opt/tor-browser /usr/local/share/applications/AM-tor-browser.desktop /usr/local/bin/tor-browser" >> /opt/tor-browser/remove
 chmod a+x /opt/tor-browser/remove
 
 mkdir tmp;
@@ -36,7 +36,7 @@ Categories=Network;WebBrowser;Security;
 Exec=sh -c '/opt/tor-browser/start-tor-browser --detach || ([ ! -x /opt/tor-browser/start-tor-browser ] && /opt/tor-browser/start-tor-browser --detach)' dummy %k
 X-TorBrowser-ExecShell=/opt/tor-browser/start-tor-browser --detach
 Icon=/opt/tor-browser/browser/chrome/icons/default/default128.png
-StartupWMClass=Tor Browser"  >> /usr/share/applications/AM-tor-browser.desktop
+StartupWMClass=Tor Browser"  >> /usr/local/share/applications/AM-tor-browser.desktop
 
 echo "
 

--- a/programs/i686/ventoy
+++ b/programs/i686/ventoy
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -58,14 +58,14 @@ mkdir icons
 wget https://www.ventoy.net/static/img/ventoy.png -O ./icons/$APP 2> /dev/null
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=Ventoy
 Comment=Open source tool to create bootable USB drive for ISO/WIM/IMG/VHD(x)/EFI files. 
 Exec=$APP
 Icon=/opt/$APP/icons/$APP
 Type=Application
-Categories=System;" >> /usr/share/applications/AM-$APP.desktop
+Categories=System;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/vk-music-fs
+++ b/programs/i686/vk-music-fs
@@ -8,7 +8,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -64,14 +64,14 @@ fi" >> /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=VK Music FS
 Exec=vk-music-fs
 Comment=Listen to the music from VK using your favorite player and copy songs to your PC.
 Icon=/opt/$APP/$APP.svg
 Type=Application
-Categories=Audio;" >> /usr/share/applications/AM-$APP.desktop
+Categories=Audio;" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/programs/.icons/$APP/$APP.svg

--- a/programs/i686/vlc
+++ b/programs/i686/vlc
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE ARCHIVE
@@ -107,7 +107,7 @@ mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/d
 mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
 
 rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/share/applications/AM-$APP.desktop
+mv ./$APP.desktop /usr/local/share/applications/AM-$APP.desktop
 
 # CHANGE THE PERMISSIONS
 currentuser=$(who | awk '{print $1}')

--- a/programs/i686/vue-calc
+++ b/programs/i686/vue-calc
@@ -18,7 +18,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -68,7 +68,7 @@ sed -i s/FUNCTION4/$FILENAMEEXTENTION/g /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -76,7 +76,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=$CATEGORIES;
-Comment=$COMMENT" >> /usr/share/applications/AM-$APP.desktop
+Comment=$COMMENT" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir ./icons

--- a/programs/i686/windows2usb
+++ b/programs/i686/windows2usb
@@ -13,7 +13,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE

--- a/programs/i686/zap
+++ b/programs/i686/zap
@@ -9,7 +9,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE PROGRAM

--- a/programs/i686/zmninja
+++ b/programs/i686/zmninja
@@ -18,7 +18,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -68,7 +68,7 @@ sed -i s/FUNCTION4/$FILENAMEEXTENTION/g /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -76,7 +76,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=$CATEGORIES;
-Comment=$COMMENT" >> /usr/share/applications/AM-$APP.desktop
+Comment=$COMMENT" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir ./icons

--- a/programs/i686/zsync2
+++ b/programs/i686/zsync2
@@ -18,7 +18,7 @@ cd /opt/$APP
 
 # ADD THE REMOVER
 echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
+echo "rm -R -f /usr/local/share/applications/AM-$APP.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
 chmod a+x /opt/$APP/remove
 
 # DOWNLOAD THE APPIMAGE
@@ -68,7 +68,7 @@ sed -i s/FUNCTION4/$FILENAMEEXTENTION/g /opt/$APP/AM-updater
 chmod a+x /opt/$APP/AM-updater
 
 # LAUNCHER
-rm -f /usr/share/applications/AM-$APP.desktop
+rm -f /usr/local/share/applications/AM-$APP.desktop
 echo "[Desktop Entry]
 Name=$APPNAME
 Exec=$APP
@@ -76,7 +76,7 @@ Icon=/opt/$APP/icons/$APP
 Type=Application
 Terminal=false
 Categories=$CATEGORIES;
-Comment=$COMMENT" >> /usr/share/applications/AM-$APP.desktop
+Comment=$COMMENT" >> /usr/local/share/applications/AM-$APP.desktop
 
 # ICON
 mkdir ./icons


### PR DESCRIPTION
...however, these applications need someone to maintain them:
- I can't test on aarch64 as I don't have a machine with this architecture.
- I might keep i686, assuming there are still systems with this architecture and users willing to use "AM" on these machines.

My constant work is focused on apps for the x86_64 architecture, so much so that the "template.am" module is adapted to the production of these scripts, excluding aarch64 and i686, and other architectures.

Anyone willing to grow the database for other architectures, even those not listed, is welcome.