### PR TITLE
Create AppImages on the fly!

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="7"
+AMVERSION="7.1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/README.md
+++ b/README.md
@@ -1100,15 +1100,9 @@ https://github.com/ivan-hc/AM/assets/88724353/b6513e8a-17ab-4671-baf7-d86183d57c
 #### Option One: "build AppImages on-the-fly"
 This was one of the very first approaches used to create this project. Before I started building AppImage packages myself, they were first compiled just like using any AUR-helper.
 
-The syntax seems simple, but you have to know what you're building.
+From version 7.1, the installation script for the AppImages is used, with the only difference that it points only to the version, while a second script will be downloaded, published separately, at [github.com/ivan-hc/AM/tree/main/appimage-bulder-scripts](https://github.com/ivan-hc/AM/tree/main/appimage-bulder-scripts), which will have the task of assembling the AppImage in the directory on the fly "tmp", during the installation process. When the second script has created the .AppImage file, the first script will continue the installation treating the created AppImage as a ready-made one downloaded from the internet.
 
-You'll need to decide what kind of AppImage you want to build on the fly, whether to include a custom AppRun, "libunionpreload", and detect system libraries.
-
-It will be used as the Debian base, but you can manually modify the script to suit your needs.
-
-In this example I'll create the script for Abiword with "AM" and I'll install it using AppMan:
-
-https://github.com/ivan-hc/AM/assets/88724353/6ae38787-e0e5-4b63-b020-c89c1e975ddd
+Fun fact, up until version 7, this option included a unique template that installed and assembled the AppImage on the fly (see [this video](https://github.com/ivan-hc/AM/assets/88724353/6ae38787-e0e5-4b63-b020-c89c1e975ddd)). This method has been replaced as it is too pretentious for a process, assembly, which may instead require many more steps, too many to be included in both an installation script and an update script (AM-updater).
 
 #### Option Two: "Archives and other programs"
 Option two is very similar to option zero. What changes is the number of questions, which allow you to customize both the application's .desktop file and the way a program should be extracted.

--- a/appimage-bulder-scripts/README.md
+++ b/appimage-bulder-scripts/README.md
@@ -1,0 +1,19 @@
+This directory will contain scripts for building AppImage packages on the fly, where required.
+
+Each script must have the name of the corresponding installation script, but with the ".sh" extension. For example:
+```
+/appimage-bulder-scripts/x86_64/calibre.sh
+```
+is used by
+```
+/programs/x86_64/calibre
+```
+It is assumed that all of the work for these scripts will be done during the installation process, in the "tmp" directory, so the scripts posted here will need to be able to compile and drop the AppImage into the same "tmp" directory. The rest of the installation process will handle the created AppImage as if it had been normally downloaded from the internet ready-made.
+
+If you are a user of my tools, consider using [AppImaGen](https://github.com/ivan-hc/AppImaGen). 
+
+Try not to use [Archimage](https://github.com/ivan-hc/ArchImage), as build times are longer and more resource intensive.
+
+If your AppImage creation script requires specific dependencies, please let me know with a PR.
+
+TIP, creating AppImage on the fly can take time and resources, depending on the complexity of the program being compiled. It is highly suggested to publish the AppImages to a repository, using Github Actions, [as I do](https://github.com/ivan-hc#my-appimage-packages).

--- a/appimage-bulder-scripts/x86_64/calibre.sh
+++ b/appimage-bulder-scripts/x86_64/calibre.sh
@@ -15,10 +15,11 @@ chmod a+x ./appimagetool
 mkdir -p "$APP".AppDir/
 
 # DOWNLOAD THE ARCHIVE
+DOWNLOAD_URL=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "http.*x86_64.txz$" | head -1)
 if wget --version | head -1 | grep -q ' 1.'; then
-	wget -q --no-verbose --show-progress --progress=bar "$version"
+	wget -q --no-verbose --show-progress --progress=bar "$DOWNLOAD_URL"
 else
-	wget "$version"
+	wget "$DOWNLOAD_URL"
 fi
 
 # EXTRACT THE ARCHIVE

--- a/appimage-bulder-scripts/x86_64/calibre.sh
+++ b/appimage-bulder-scripts/x86_64/calibre.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+APP=calibre
+
+# DOWNLOADING THE DEPENDENCES
+if test -f ./appimagetool; then
+	echo " appimagetool already exists" 1> /dev/null
+else
+	echo " Downloading appimagetool..."
+	wget -q "$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')" -O appimagetool
+fi
+chmod a+x ./appimagetool
+
+#CREATE THE APPDIR
+mkdir -p "$APP".AppDir/
+
+# DOWNLOAD THE ARCHIVE
+if wget --version | head -1 | grep -q ' 1.'; then
+	wget -q --no-verbose --show-progress --progress=bar "$version"
+else
+	wget "$version"
+fi
+
+# EXTRACT THE ARCHIVE
+tar fx ./*txz* -C ./"$APP".AppDir/
+
+# CREATE THE LAUNCHER
+cat >> ./"$APP".AppDir/"$APP".desktop << 'EOF'
+[Desktop Entry]
+Categories=Office;
+Comment[en_US]=E-book library management: Convert, view, share, catalogue all your e-books
+Comment=E-book library management: Convert, view, share, catalogue all your e-books
+Exec=AppRun
+GenericName[en_US]=E-book library management
+GenericName=E-book library management
+Icon=calibre
+MimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document;image/vnd.djvu;application/x-mobi8-ebook;application/x-cbr;text/fb2+xml;application/pdf;application/x-cbc;application/vnd.ms-word.document.macroenabled.12;text/rtf;application/epub+zip;application/x-cbz;text/plain;application/x-sony-bbeb;application/oebps-package+xml;application/x-cb7;application/x-mobipocket-ebook;application/ereader;text/html;text/x-markdown;application/xhtml+xml;application/vnd.oasis.opendocument.text;application/x-mobipocket-subscription;x-scheme-handler/calibre;
+Name=calibre
+Type=Application
+X-DBUS-ServiceName=
+X-DBUS-StartupType=
+X-KDE-SubstituteUID=false
+X-KDE-Username=
+EOF
+
+# ADD THE ICON AT THE ROOT OF THA APPDIR
+cp ./"$APP".AppDir/resources/content-server/calibre.png ./"$APP".AppDir/calibre.png
+
+# CREATE THE APPRUN
+cat >> ./"$APP".AppDir/AppRun << 'EOF'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "${0}")")"
+exec "${HERE}"/calibre "$@"
+EOF
+chmod a+x ./"$APP".AppDir/AppRun
+
+# CONVERT THE APPDIR TO AN APPIMAGE
+echo " Converting the AppDir to an AppImage..."
+ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP".AppDir

--- a/appimage-bulder-scripts/x86_64/calibre.sh
+++ b/appimage-bulder-scripts/x86_64/calibre.sh
@@ -56,5 +56,5 @@ EOF
 chmod a+x ./"$APP".AppDir/AppRun
 
 # CONVERT THE APPDIR TO AN APPIMAGE
-echo " Converting the AppDir to an AppImage..."
-ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP".AppDir
+echo "\nConverting the AppDir to an AppImage...\n"
+ARCH=x86_64 VERSION=$(./appimagetool -v | grep -o '[[:digit:]]*') ./appimagetool -s ./"$APP".AppDir 2>&1 | grep "Architecture\|Creating\|====\|Exportable"

--- a/modules/install.am
+++ b/modules/install.am
@@ -132,36 +132,50 @@ function _install_arg() {
 	# Check if the installation script contain a keyword related to a missing dependence
 	if grep -q 'ar.*x .*\.deb' ./"$arg"; then
 		if ! command -v ar 1>/dev/null; then
-			echo ' 💀 ERROR: YOU CANNOT INSTALL '"$(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]')"' WITHOUT INSTALLING "BINUTILS"!'; return 0
+			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"binutils\""; return 0
 		fi
 	fi
 	if grep -q 'ffwa-' ./"$arg"; then
 		ffbrowser=$(find ${PATH//:/ } -maxdepth 1 -name "firefox*" | sort | head -1)
 		if [[ -z "$ffbrowser" ]]; then
-			echo ' 💀 ERROR: YOU CANNOT INSTALL '"$(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]')"' WITHOUT INSTALLING "FIREFOX"!'; return 0
+			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"firefox\""; return 0
 		else
 			sed -i 's#firefox --class#'"$(echo "$ffbrowser" | xargs -L 1 basename)"' --class#g' ./"$arg"
 		fi
 	fi
 	if grep -q 'http.*\.tar' ./"$arg"; then
 		if ! command -v tar 1>/dev/null; then
-			echo ' 💀 ERROR: YOU CANNOT INSTALL '"$(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]')"' WITHOUT INSTALLING "TAR"!'; return 0
+			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"tar\""; return 0
 		fi
 	fi
 	if grep -q 'http.*\.zip' ./"$arg"; then
 		if ! command -v unzip 1>/dev/null; then
-			echo ' 💀 ERROR: YOU CANNOT INSTALL '"$(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]')"' WITHOUT INSTALLING "UNZIP"!'; return 0
+			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"unzip\""; return 0
 		fi
 	fi
 	if grep -q '^wget "$version.zsync"' ./"$arg"; then
 		if ! command -v zsync 1>/dev/null; then
 			optzsync=$(grep -F 'if test -f /opt/$APP/*.zsync' ./"$arg" | wc -l)
 			if [ "$optzsync" == 0 ]; then
-				echo ' 💀 ERROR: YOU CANNOT INSTALL '"$(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]')"' WITHOUT INSTALLING "ZSYNC"!'; return 0
+				echo " 💀 ERROR: you cannot install \"$arg\" without installing \"zsync\""; return 0
 			else
-				echo -e ' ⚠️ WARNING: '"$(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]')"' MAY NOT BE UPDATABLE WITHOUT "ZSYNC".\n\n THE APP WILL STILL BE INSTALLED, BUT INSTALLING "ZSYNC" IS RECOMMENDED!\n'
+				echo -e " ⚠️ WARNING: \"$arg\" may not be updatable without \"zsync\".\n\n The app will still be installed, but installing \"zsync\" is recommended! \n"
 			fi
 		fi
+	fi
+	if grep -q 'appimage-bulder-scripts' ./"$arg"; then
+		appimage_build_deps="ar convert glib-compile-schemas tar unzip"
+		for name in $appimage_build_deps; do
+			if ! command -v "$name" &>/dev/null; then
+				if [ "$name" == "ar" ]; then
+					echo " 💀 ERROR: cannot create \"$arg\" without \"binutils\""; return 0
+				elif [ "$name" == "convert" ]; then
+					echo " 💀 ERROR: cannot create \"$arg\" without \"$name\" (from \"imagemagick\")"; return 0
+				else
+					echo " 💀 ERROR: cannot create \"$arg\" without \"$name\""; return 0
+				fi
+			fi
+		done
 	fi
 	# Check if you are installing an app or a library
 	echo -e "◆ $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]'): starting installation script" &&

--- a/modules/install.am
+++ b/modules/install.am
@@ -134,26 +134,22 @@ function _install_arg() {
 		if ! command -v ar 1>/dev/null; then
 			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"binutils\""; return 0
 		fi
-	fi
-	if grep -q 'ffwa-' ./"$arg"; then
+	elif grep -q 'ffwa-' ./"$arg"; then
 		ffbrowser=$(find ${PATH//:/ } -maxdepth 1 -name "firefox*" | sort | head -1)
 		if [[ -z "$ffbrowser" ]]; then
 			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"firefox\""; return 0
 		else
 			sed -i 's#firefox --class#'"$(echo "$ffbrowser" | xargs -L 1 basename)"' --class#g' ./"$arg"
 		fi
-	fi
-	if grep -q 'http.*\.tar' ./"$arg"; then
+	elif grep -q 'http.*\.tar' ./"$arg"; then
 		if ! command -v tar 1>/dev/null; then
 			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"tar\""; return 0
 		fi
-	fi
-	if grep -q 'http.*\.zip' ./"$arg"; then
+	elif grep -q 'http.*\.zip' ./"$arg"; then
 		if ! command -v unzip 1>/dev/null; then
 			echo " 💀 ERROR: you cannot install \"$arg\" without installing \"unzip\""; return 0
 		fi
-	fi
-	if grep -q '^wget "$version.zsync"' ./"$arg"; then
+	elif grep -q '^wget "$version.zsync"' ./"$arg"; then
 		if ! command -v zsync 1>/dev/null; then
 			optzsync=$(grep -F 'if test -f /opt/$APP/*.zsync' ./"$arg" | wc -l)
 			if [ "$optzsync" == 0 ]; then
@@ -162,8 +158,7 @@ function _install_arg() {
 				echo -e " ⚠️ WARNING: \"$arg\" may not be updatable without \"zsync\".\n\n The app will still be installed, but installing \"zsync\" is recommended! \n"
 			fi
 		fi
-	fi
-	if grep -q 'appimage-bulder-scripts' ./"$arg"; then
+	elif grep -q 'appimage-bulder-scripts' ./"$arg"; then
 		appimage_build_deps="ar convert glib-compile-schemas tar unzip"
 		for name in $appimage_build_deps; do
 			if ! command -v "$name" &>/dev/null; then
@@ -178,8 +173,10 @@ function _install_arg() {
 		done
 	fi
 	# Check if you are installing an app or a library
-	echo -e "◆ $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]'): starting installation script" &&
-	if grep -q "/usr/local/lib" ./"$arg"; then
+	echo -e "◆ $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]'): starting installation script"
+	if grep -q 'appimage-bulder-scripts' ./"$arg"; then
+		echo -e "\n This script will create an AppImage on the fly, please wait..."
+	elif grep -q "/usr/local/lib" ./"$arg"; then
 		echo -e '\n ⚠️ This script installs a system library in /usr/local/lib, cancel it if:\n'
 		echo ' - it is already installed in the system;'
 		echo -e ' - its already present in your repositories (so install it from there).\n'

--- a/modules/template.am
+++ b/modules/template.am
@@ -333,15 +333,21 @@ while [ -n "$1" ]; do
 			case $arg in
 			*)
 				cd "$SCRIPTDIR" || return
-				echo "##############################################################"; echo ""
-				echo -e " Create a template for \"$arg\"\n	" | tr '[:lower:]' '[:upper:]'
-				echo "--------------------------------------------------------------"; echo "" 
-				echo -e " EACH MODEL IS BASED ON A DIFFERENT METHOD OF BUILDING/UPDATING THE PROGRAM.\n"
-				echo -e " PLEASE, SELECT A TEMPLATE FOR \"$(echo "$arg" | tr '[:lower:]' '[:upper:]')\": \n"
+				echo "##############################################################"
+				echo ""
+				echo " Create a template for \"$arg\"" | tr '[:lower:]' '[:upper:]'
+				echo ""
+				echo "--------------------------------------------------------------"
+				echo "" 
+				echo " EACH MODEL IS BASED ON A DIFFERENT METHOD OF BUILDING/UPDATING THE PROGRAM."
+				echo ""
+				echo " PLEASE, SELECT A TEMPLATE FOR \"$(echo "$arg" | tr '[:lower:]' '[:upper:]')\":"
+				echo ""
 				echo "  0) APPIMAGE, FROM ANY WEBSITE (BETTER IF FROM GITHUB.COM)"
-				echo "  1) APPIMAGE, BUILD YOUR OWN WITH PKG2APPIMAGE"
+				echo "  1) APPIMAGE ON-THE-FLY, USING A DEDICATED SCRIPT"
 				echo "  2) ANY ARCHIVE/BINARY/SCRIPT FROM ANY WEBSITE"
-				echo -e '  3) WEBAPP BASED ON A FIREFOX PROFILE (REQUIRES "FIREFOX" IN $PATH)"\n'
+				echo '  3) WEBAPP BASED ON A FIREFOX PROFILE (REQUIRES "FIREFOX" IN $PATH)'
+				echo ""
 				read -r -p " WHAT KIND OF PROGRAM DO YOU WANT TO WRITE A SCRIPT FOR? : " templatetype
 				case "$templatetype" in
 
@@ -370,62 +376,22 @@ while [ -n "$1" ]; do
 
 				1) # CREATE AN APPIMAGE ON-THE-FLY
 					mkdir -p ./am-scripts ./am-scripts/"$arch" ./am-scripts/portable-linux-apps.github.io/apps ./am-scripts/portable-linux-apps.github.io/icons
-					# CUSTOMEZE THE APPRUN, THE CORE SCRIPT OF THE APPIMAGE
-					read -r -p ' Do you wish to use a custom AppRun script (y,N)?' yn
-					case $yn in
-					'Y'|'y')
-						# DOWNLOAD THE TEMPLATE AND CONVERT THE ARGUMENT INTO A COMMAND
-						wget -q "$AMREPO"/templates/AM-SAMPLE-pkg2appimage-custom -O ./am-scripts/"$arch"/"$arg" &&
-						sed -i "s/SAMPLE/$arg/g" ./am-scripts/"$arch"/"$arg" &&
-						# LIBUNIONPRELOAD
-						read -r -p ' Do you wish to add libunionpreload (y,N)?' yn
-						case $yn in
-						'Y'|'y')
-							sed -i 's/#export LD_PRELOAD/export LD_PRELOAD/g' ./am-scripts/"$arch"/"$arg"
-							sed -i 's/#chmod/chmod/g' ./am-scripts/"$arch"/"$arg"
-							sed -i 's/#mv ./mv ./g' ./am-scripts/"$arch"/"$arg"
-							sed -i 's/#wget/wget/g' ./am-scripts/"$arch"/"$arg"
-							;;
-						'N'|'n'|*)
-							;;
-						esac
-						# SYSTEM LIBRARIES
-						read -r -p ' Do you wish to include system libraries (Y,n)?' yn
-						case $yn in
-						'N'|'n')
-							sed -i 's/##export LD_LIBRARY_PATH/export LD_LIBRARY_PATH/g' ./am-scripts/"$arch"/"$arg"
-							;;
-						'Y'|'y'|*)
-							sed -i 's/#export LD_LIBRARY_PATH/export LD_LIBRARY_PATH/g' ./am-scripts/"$arch"/"$arg"
-							;;
-						esac
-						# BINARY PATH
-						read -r -p ' Do you wish to specify the binary`s path manually (y,N)?' yn
-						case $yn in 
-						'Y'|'y')
-							read -r -ep " ◆ ADD THE PATH (EXAMPLE \"/usr/lib.../$arg\") $(echo -e '\n: ')" RESPONSE
-							case "$RESPONSE" in
-							*)
-								sed -i "s/#exec/exec/g" ./am-scripts/"$arch"/"$arg"
-								sed -i "s#CUSTOMPATH#$RESPONSE#g" ./am-scripts/"$arch"/"$arg"
-							esac
-							;;
-						'N'|'n'|*)
-							sed -i "s/##exec/exec/g" ./am-scripts/"$arch"/"$arg"
-							;;
-						esac
-						;;
-					'N'|'n'|*)
-						# DOWNLOAD THE TEMPLATE AND CONVERT THE ARGUMENT INTO A COMMAND
-						wget -q "$AMREPO"/templates/AM-SAMPLE-pkg2appimage -O ./am-scripts/"$arch"/"$arg" &&
-						sed -i "s/SAMPLE/$arg/g" ./am-scripts/"$arch"/"$arg"
-						;;
+					# DOWNLOAD THE TEMPLATE AND CONVERT THE ARGUMENT INTO A COMMAND
+					wget -q "$AMREPO"/templates/AM-SAMPLE-AppImage -O ./am-scripts/"$arch"/"$arg"
+					sed -i "s/SAMPLE/$arg/g" ./am-scripts/"$arch"/"$arg"
+
+					_template_if_hosted_elsewhere
+
+					# ADD A LINEAR DOWNLOAD URL
+					read -r -ep " ◆ ADD A LINEAR DOWNLOAD URL FOR THE SCRIPT OR LEAVE BLANK $(echo -e '\n : ')" dlurl
+					case "$dlurl" in
+					'')
+						sed -i 's#wget "$version"#wget "'"$AMREPO"'/appimage-bulder-scripts/'"$arch"'/$APP.sh" \&\& chmod a+x "$APP".sh \&\& ./"$APP".sh#g' ./am-scripts/"$arch"/"$arg"
+					;;
+					*)
+						sed -i 's#wget "$version"#wget "'"$dlurl"'" -O '"$arg"'.sh && chmod '"$arg"'.sh && ./'"$arg"'.sh#g' ./am-scripts/"$arch"/"$arg"
+					;;
 					esac
-					# CREATE A WEBPAGE FOR https://portable-linux-apps.github.io CONTAINING ALL THE INFO ABOUT THIS APP
-					echo "# $(echo "$arg" | tr '[:lower:]' '[:upper:]')" >> ./am-scripts/portable-linux-apps.github.io/apps/"$arg".md
-					echo -e "\n $COMMENT\n\n SITE: \n\n | [Applications](https://portable-linux-apps.github.io/apps.html) | [Home](https://portable-linux-apps.github.io)\n | --- | --- |" >> ./am-scripts/portable-linux-apps.github.io/apps/"$arg".md &&
-					# CREATE A NEW LINE FOR THE APPLICATION'S LIST
-					echo "◆ $arg : $COMMENT" >> ./am-scripts/list; echo ""
 					# END OF THIS FUNCTION
 					echo -e "\n All files are saved in $SCRIPTDIR/am-scripts\n"
 					;;

--- a/programs/x86_64/calibre
+++ b/programs/x86_64/calibre
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64.txz$" | head -1)
+version=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "http.*x86_64.txz$" | head -1)
 wget "https://raw.githubusercontent.com/ivan-hc/AM/main/appimage-bulder-scripts/x86_64/$APP.sh" && chmod a+x "$APP".sh && ./"$APP".sh || exit 1
 #wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -33,7 +33,7 @@ set -u
 APP=calibre
 SITE=""
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64.txz$" | head -1)
+version=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "http.*x86_64.txz$" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1

--- a/programs/x86_64/calibre
+++ b/programs/x86_64/calibre
@@ -1,175 +1,74 @@
 #!/bin/sh
 
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
 APP=calibre
-REPO="kovidgoyal/calibre"
+SITE=""
 
-# CREATING THE FOLDER
-mkdir /opt/$APP
-cd /opt/$APP;
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
 
-# ADD THE REMOVER
-echo '#!/bin/sh' >> /opt/$APP/remove
-echo "rm -R -f /usr/local/share/applications/$APP-AM.desktop /opt/$APP /usr/local/bin/$APP" >> /opt/$APP/remove
-chmod a+x /opt/$APP/remove
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64.txz$" | head -1)
+wget "https://raw.githubusercontent.com/ivan-hc/AM/main/appimage-bulder-scripts/x86_64/$APP.sh" && chmod a+x "$APP".sh && ./"$APP".sh || exit 1
+#wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
 
-mkdir /opt/$APP/tmp
-cd /opt/$APP/tmp
-
-
-# DOWNLOADING THE DEPENDENCIES
-wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(uname -m).AppImage -O appimagetool
-#wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
-# wget https://github.com/ivan-hc/pkg2appimage-32bit/releases/download/continuous/pkg2appimage-i386.AppImage -O pkg2appimage # 32 BIT ONLY (uncomment to enable)
-chmod a+x ./appimagetool
-# DOWNLOAD THE ARCHIVE
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "x86_64.txz" | cut -d '"' -f 4 | head -1)
-wget $version
-echo "$version" >> /opt/$APP/version
-
-
-# CREATING THE APPIMAGE
-mkdir $APP.AppDir/
-tar fx ./*txz* -C ./$APP.AppDir/
-echo "[Desktop Entry]
-Categories=Office;
-Comment[en_US]=E-book library management: Convert, view, share, catalogue all your e-books
-Comment=E-book library management: Convert, view, share, catalogue all your e-books
-Exec=AppRun
-GenericName[en_US]=E-book library management
-GenericName=E-book library management
-Icon=calibre
-MimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document;image/vnd.djvu;application/x-mobi8-ebook;application/x-cbr;text/fb2+xml;application/pdf;application/x-cbc;application/vnd.ms-word.document.macroenabled.12;text/rtf;application/epub+zip;application/x-cbz;text/plain;application/x-sony-bbeb;application/oebps-package+xml;application/x-cb7;application/x-mobipocket-ebook;application/ereader;text/html;text/x-markdown;application/xhtml+xml;application/vnd.oasis.opendocument.text;application/x-mobipocket-subscription;x-scheme-handler/calibre;
-Name=calibre
-Type=Application
-X-DBUS-ServiceName=
-X-DBUS-StartupType=
-X-KDE-SubstituteUID=false
-X-KDE-Username=" >> ./$APP.AppDir/$APP.desktop
-cp ./$APP.AppDir/resources/content-server/calibre.png ./$APP.AppDir/calibre.png
-
-cat >> ./$APP.AppDir/AppRun << 'EOF'
-#!/bin/sh
-HERE="$(dirname "$(readlink -f "${0}")")"
-exec "${HERE}"/calibre "$@"
-EOF
-
-chmod a+x ./$APP.AppDir/AppRun
-
-ARCH=x86_64 ./appimagetool -n ./$APP.AppDir;
-
-cd ..;
-mv ./tmp/*.AppImage ./$APP;
-chmod a+x ./$APP
-
-rm -R -f ./tmp
-
-# LINK
-ln -s /opt/$APP/$APP /usr/local/bin/$APP
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 
 # SCRIPT TO UPDATE THE PROGRAM
-cat >> /opt/$APP/AM-updater << 'EOF'
+cat >> ./AM-updater << 'EOF'
 #!/bin/sh
+set -u
 APP=calibre
-REPO="kovidgoyal/calibre"
-version0=$(cat /opt/$APP/version)
-version=$(curl -Ls https://api.github.com/repos/$REPO/releases | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "x86_64.txz" | cut -d '"' -f 4 | head -1)
-if [ $version = $version0 ]; then
-  echo "Update not needed, exit!"
+SITE=""
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/kovidgoyal/calibre/releases | sed 's/[()",{} ]/\n/g' | grep -v "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64.txz$" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	[ -e ../*.zsync ] || notify-send "A new version of $APP is available, please wait"
+	[ -e ../*.zsync ] && wget "$version.zsync" 2>/dev/null || { wget "https://raw.githubusercontent.com/ivan-hc/AM/main/appimage-bulder-scripts/x86_64/$APP.sh" && chmod a+x "$APP".sh && ./"$APP".sh || exit 1; }
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
+	[ -e ./*.zsync ] && { zsync ./"$APP".zsync || notify-send -u critical "zsync failed to update $APP"; }
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
 else
-  notify-send "A new version of $APP is available, please wait!"
-  
-  mkdir /opt/$APP/tmp
-  cd /opt/$APP/tmp
-
-  # DOWNLOADING THE DEPENDENCIES
-  wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(uname -m).AppImage -O appimagetool
-  #wget https://raw.githubusercontent.com/ivan-hc/AM-application-manager/main/tools/pkg2appimage # 64 BIT ONLY (comment to disable)
-  # wget https://github.com/ivan-hc/pkg2appimage-32bit/releases/download/continuous/pkg2appimage-i386.AppImage -O pkg2appimage # 32 BIT ONLY (uncomment to enable)
-  chmod a+x ./appimagetool
-  # DOWNLOAD THE ARCHIVE
-  version=$(curl -Ls https://api.github.com/repos/$REPO/releases | grep -w -v i386 | grep -w -v i686 | grep -w -v aarch64 | grep -w -v arm64 | grep -w -v armv7l | grep browser_download_url | grep -i "x86_64.txz" | cut -d '"' -f 4 | head -1)
-  wget $version
-  
-  # CREATING THE APPIMAGE
-  mkdir $APP.AppDir/
-  tar fx ./*txz* -C ./$APP.AppDir/
-  /opt/$APP/$APP --appimage-extract AppRun 1> /dev/null
-  /opt/$APP/$APP --appimage-extract $APP.desktop 1> /dev/null
-  mv ./squashfs-root/$APP.desktop ./$APP.AppDir/$APP.desktop
-  mv ./squashfs-root/AppRun ./$APP.AppDir/AppRun
-  cp ./$APP.AppDir/resources/content-server/calibre.png ./$APP.AppDir/calibre.png
-  chmod a+x ./$APP.AppDir/AppRun
-
-  ARCH=x86_64 ./appimagetool -n ./$APP.AppDir;
-
-  if ls ./ | grep mage; then
-  cd ..
-  rm ./version
-  echo $version >> ./version
-  mv --backup=t ./tmp/*.AppImage ./$APP; 
-  chmod a+x /opt/$APP/${APP}
-  rm -R -f ./tmp ./*~
-  fi
-
-  notify-send "$APP is updated!"
+	echo "Update not needed!"
 fi
 EOF
-chmod a+x /opt/$APP/AM-updater
+chmod a+x ./AM-updater || exit 1
 
 # LAUNCHER & ICON
-app=$(echo $APP | cut -c -3)
-cd /opt/$APP
-./$APP --appimage-extract $APP.desktop 1>/dev/null
-./$APP --appimage-extract share/applications/*.desktop 1>/dev/null
-./$APP --appimage-extract usr/share/applications/*.desktop 1>/dev/null
-mv squashfs-root/*.desktop ./$APP.desktop
-mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract usr/share/applications/*$app*.desktop 
-	mv squashfs-root/usr/share/applications/*.desktop ./$APP.desktop
-fi
-if [ ! -e ./$APP.desktop ]; then 
-	rm ./$APP.desktop; ./$APP --appimage-extract share/applications/*$app*.desktop 1>/dev/null
-	mv squashfs-root/share/applications/*.desktop ./$APP.desktop
-fi
-CHANGEEXEC=$(cat ./$APP.desktop | grep Exec= | tr ' ' '\n' | tr '=' '\n' | tr '/' '\n' | grep $app | head -1)
-sed -i "s#$CHANGEEXEC#$APP#g" ./$APP.desktop
-sed -i "s#AppRun#$APP#g" ./$APP.desktop
-sed -i "s#Exec=/bin/#Exec=#g" ./$APP.desktop
-sed -i "s#Exec=/usr/bin/#Exec=#g" ./$APP.desktop
-CHANGEICON=$(cat ./$APP.desktop | grep Icon= | head -1)
-sed -i "s#$CHANGEICON#Icon=/opt/$APP/icons/$APP#g" ./$APP.desktop
-
-mkdir icons
-./$APP --appimage-extract *.png 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
-./$APP --appimage-extract *.svg 2>&1 | grep -v "squashfs-root"; mv ./squashfs-root/*$app* ./icons/$APP 2>/dev/null
-./$APP --appimage-extract share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/* 1>/dev/null
-./$APP --appimage-extract share/icons/*/*/*/* 1>/dev/null
-./$APP --appimage-extract usr/share/icons/*/*/*/* 1>/dev/null
-mv ./squashfs-root/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/22x22/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/24x24/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/32x32/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/48x48/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/64x64/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/128x128/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/256x256/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/512x512/apps/*$app* ./icons/$APP 2>/dev/null
-mv ./squashfs-root/usr/share/icons/hicolor/scalable/apps/*$app* ./icons/$APP 2>/dev/null
-
-rm -R -f /opt/$APP/squashfs-root
-mv ./$APP.desktop /usr/local/share/applications/$APP-AM.desktop
-
-
-
-
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
The script to install the AppImages is patched to download another script from this repository which is intended to create the AppImage on the fly.

In this example, "calibre"


https://github.com/ivan-hc/AM/assets/88724353/05d7146b-853a-44d4-ac39-35c26a06895c

NOTE, the scripts points on main, I had to adit it to dev because this is still in the dev branch

@Samueru-sama 