### PR TITLE
Add option "-e" or "extra" to install third-party apps, out of the database

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -970,7 +970,6 @@ case "$1" in
 		MODULE="install.am"
 		_online_check
 		_if_appman_mode_enabled
-		_betatester_message_on
 		_use_module "$@"
 		;;
 	'-t'|'template')

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="7.1.1"
+AMVERSION="7.2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -446,6 +446,7 @@ function _generate_options_list() {
 		clean
 		downgrade
 		download
+		extra
 		files
 		install
 		list
@@ -964,7 +965,8 @@ case "$1" in
 		MODULE="sandboxes.am"
 		_use_module "$@"
 		;;
-	'-i'|'install')
+	'-i'|'install'|\
+	'-e'|'extra')
 		MODULE="install.am"
 		_online_check
 		_if_appman_mode_enabled

--- a/README.md
+++ b/README.md
@@ -823,11 +823,15 @@ https://github.com/user-attachments/assets/aa546905-38da-48b5-bb10-658426e8372b
 
 You can give whatever name you want to the apps (as long as they does not overlap with commands already existing on your system, be careful).
 
-In this other example, I'll install an obsolete version of WINE AppImage, fro ma repo that lists more versions of the same app. The first attempt is withyout a a keyword, so the script picks the first AppImage in the list (for Debian Buster), then in the second attempt I'll use the keyword "arch" to pick the Arch-based AppImage:
+In this other example, I'll install an obsolete version of WINE AppImage, from a repo that lists more versions of the same app:
+1. the first attempt is without a keyword, so that the script picks the first AppImage in the list (for Debian Buster)
+2. in the second attempt I'll use the keyword "arch" to pick the Arch-based AppImage
 
 https://github.com/user-attachments/assets/af00a5f2-f3fe-4616-899a-155cb31d2acd
 
-Apps installed this way will enjoy the same benefits as those that can already be installed from the database with the "`-i`" or "`install`" option [mentioned above](#install-applications).
+As you can see, there are all the files needed by any app listed in this database, also if an installation script for them does not exists.
+
+Apps installed this way will enjoy the same benefits as those that can already be installed from the database with the "`-i`" or "`install`" option [mentioned above](#install-applications), including updates and sandboxing.
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -423,9 +423,20 @@ See also "[How to update or remove apps manually](#how-to-update-or-remove-apps-
 
  `-d {PROGRAM}`
 
-  `-d --convert {PROGRAM}`
+ `-d --convert {PROGRAM}`
 
  DESCRIPTION:	Download one or more installation scripts to your desktop. With the option "--convert" its converted to a standalone local installer, but AM requires AppMan to be installed to add custom directory settings.
+ ___________________________________________________________________________
+
+ `-e`, `extra`
+
+ SYNOPSIS:
+
+ `-e {USER}/{PROJECT} {PROGRAM}`
+
+ `-e {USER}/{PROJECT} {PROGRAM} {KEYWORD}`
+
+ DESCRIPTION:	Install AppImages from github.com, outside the database. This allows you to install, update and manage them all like the others. Where "user/project" can be the whole URL to the github repository, give a name to the program so that it can be used from the command line. Optionally, add an "univoque" keyword if multiple AppImages are listed.
  ___________________________________________________________________________
 
  `-f`, `files`

--- a/README.md
+++ b/README.md
@@ -804,17 +804,11 @@ Optionally, you can add a "keyword" if more AppImages are listed in the same rep
 Usage:
 ```
 am -e $USER/$PROJECT $PROGRAM
-```
-or
-```
 am -e $USER/$PROJECT $PROGRAM $KEYWORD
 ```
 or
 ```
 appman -e $USER/$PROJECT $PROGRAM
-```
-or
-```
 appman -e $USER/$PROJECT $PROGRAM $KEYWORD
 ```
 in this video I'll install AnyDesk as "remote-desktop-client":

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can consult the entire **list of managed apps** at [**portable-linux-apps.gi
 
 [Guides and tutorials](#guides-and-tutorials)
 - [Install applications](#install-applications)
+- [Install AppImages not listed in this database but available in other github repos](#install-appimages-not-listed-in-this-database-but-available-in-other-github-repos)
 - [List the installed applications](#list-the-installed-applications)
 - [List and query all the applications available on the database](#list-and-query-all-the-applications-available-on-the-database)
 - [Update all](#update-all)
@@ -731,6 +732,7 @@ See also "[How to update or remove apps manually](#how-to-update-or-remove-apps-
 This section is committed to giving small demonstrations of each available option, with videos:
 
   - [Install applications](#install-applications)
+  - [Install AppImages not listed in this database but available in other github repos](#install-appimages-not-listed-in-this-database-but-available-in-other-github-repos)
   - [List the installed applications](#list-the-installed-applications)
   - [List and query all the applications available on the database](#list-and-query-all-the-applications-available-on-the-database)
   - [Update all](#update-all)
@@ -772,6 +774,45 @@ appman -i $PROGRAM
 in this video I'll install AnyDesk and LXtask:
 
 https://github.com/ivan-hc/AM/assets/88724353/c2e8b654-29d3-4ded-8877-f77ef11d58fc
+
+------------------------------------------------------------------------
+
+| [Back to "Guides and tutorials"](#guides-and-tutorials) | [Back to "Main Index"](#main-index) |
+| - | - |
+
+------------------------------------------------------------------------
+
+__________________________________________________________________________
+### Install AppImages not listed in this database but available in other github repos
+From [version 7.2](https://github.com/ivan-hc/AM/releases/tag/7.2) its possible to install AppImages not listed in this database, thanks to the option `-e` or `extra`.
+
+You need to add the URL to the github repo before the name you want to give to the AppImage (for command line usage, for example).
+
+Optionally, you can add a "keyword" if more AppImages are listed in the same repo.
+
+Usage:
+```
+am -e $USER/$PROJECT $PROGRAM
+```
+or
+```
+am -e $USER/$PROJECT $PROGRAM $KEYWORD
+```
+or
+```
+appman -e $USER/$PROJECT $PROGRAM
+```
+or
+```
+appman -e $USER/$PROJECT $PROGRAM $KEYWORD
+```
+in this video I'll install AnyDesk as "remote-desktop-client":
+
+https://github.com/user-attachments/assets/aa546905-38da-48b5-bb10-658426e8372b
+
+You can give whatever name you want to the apps (as long as they does not overlap with commands already existing on your system, be careful).
+
+Apps installed this way will enjoy the same benefits as those that can already be installed from the database with the "`-i`" or "`install`" option [mentioned above](#install-applications).
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ https://github.com/ivan-hc/AM/assets/88724353/c2e8b654-29d3-4ded-8877-f77ef11d58
 
 __________________________________________________________________________
 ### Install AppImages not listed in this database but available in other github repos
-From [version 7.2](https://github.com/ivan-hc/AM/releases/tag/7.2) its possible to install AppImages not listed in this database, thanks to the option `-e` or `extra`.
+From version 7.2 its possible to install AppImages not listed in this database, thanks to the option `-e` or `extra`.
 
 You need to add the URL to the github repo before the name you want to give to the AppImage (for command line usage, for example).
 
@@ -822,6 +822,10 @@ in this video I'll install AnyDesk as "remote-desktop-client":
 https://github.com/user-attachments/assets/aa546905-38da-48b5-bb10-658426e8372b
 
 You can give whatever name you want to the apps (as long as they does not overlap with commands already existing on your system, be careful).
+
+In this other example, I'll install an obsolete version of WINE AppImage, fro ma repo that lists more versions of the same app. The first attempt is withyout a a keyword, so the script picks the first AppImage in the list (for Debian Buster), then in the second attempt I'll use the keyword "arch" to pick the Arch-based AppImage:
+
+https://github.com/user-attachments/assets/af00a5f2-f3fe-4616-899a-155cb31d2acd
 
 Apps installed this way will enjoy the same benefits as those that can already be installed from the database with the "`-i`" or "`install`" option [mentioned above](#install-applications).
 

--- a/modules/help.am
+++ b/modules/help.am
@@ -90,6 +90,22 @@ function _help_body() {
  but AM requires AppMan to be installed to add custom directory settings.
  __________________________________________________________________________
 
+ -e, extra
+
+ SYNOPSIS:	-e user/project {APPNAME}
+ 		-e user/project {APPNAME} {KEYWORD}
+
+ DESCRIPTION:	Install AppImages from github.com, outside the database.
+
+ This allows you to install, update and manage them all like the others.
+
+ Where "user/project" can be the whole URL to the github repository,
+
+ give a name to the program so that it can be used from the command line.
+
+ Optionally, add an "univoque" keyword if multiple AppImages are listed.
+ __________________________________________________________________________
+
  -f, files
 
  SYNOPSIS:	-f

--- a/modules/install.am
+++ b/modules/install.am
@@ -344,26 +344,57 @@ while [ -n "$1" ]; do
 	'-e'|'extra')
 		case $2 in
 		'')
-			echo " USAGE: $AMCLI $1 'https://github.com/user/project' [ARGUMENT]"; exit
+			echo " USAGE: $AMCLI $1 user/project [ARGUMENT]"
+			echo " USAGE: $AMCLI $1 https://github.com/user/project [ARGUMENT]"; exit
 			;;
 		esac
 		case $3 in
 		'')
-			echo " USAGE: $AMCLI $1 'https://github.com/user/project' [ARGUMENT]"; exit
+			echo " USAGE: $AMCLI $1 user/project [ARGUMENT]"
+			echo " USAGE: $AMCLI $1 https://github.com/user/project [ARGUMENT]"; exit
 			;;
 		esac
 
 		mkdir -p "$CACHEDIR/extra"
+		if test -f "$CACHEDIR/extra/$3"; then
+			rm -f "$CACHEDIR/extra/$3"
+		fi
 		wget -q "$AMREPO"/templates/AM-SAMPLE-AppImage -O "$CACHEDIR/extra/$3" || exit 1
 		sed -i "s#APP=SAMPLE#APP=$3#g" "$CACHEDIR/extra/$3"
 		CUSTOMREPO=$(echo "$2" | sed 's#https://github.com/##g' | cut -f1,2 -d'/')
 		sed -i "s#REPLACETHIS#$CUSTOMREPO#g" "$CACHEDIR/extra/$3"
 		q="'"
-		FUNCTION='curl -Ls https://api.github.com/repos/'"$CUSTOMREPO"'/releases | sed '"$q"'s/[()",{} ]/\\n/g'"$q"' | grep -oi "https.*mage$" | grep -vi "i386\\|i686\\|aarch64\\|arm64\\|armv7l" | head -1'
+		if [ "$arch" == "x86_64" ]; then
+			if curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "x86_64" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "x86_64" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "x64" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "x64" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "amd64" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "amd64" '
+			else
+				FILTER=' | grep -vi "i386\\|i686\\|aarch64\\|arm64\\|armv7l"'
+			fi
+		elif [ "$arch" == "i686" ]; then
+			if curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "i386" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "i386" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "i686" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "i686" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "i586" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "i586" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "i486" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "i486" '
+			fi
+		elif [ "$arch" == "aarch64" ]; then
+			if curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "aarch64" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "aarch64" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "amd64" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "amd64" '
+			fi
+		fi
+		FUNCTION='curl -Ls https://api.github.com/repos/'"$CUSTOMREPO"'/releases | sed '"$q"'s/[()",{} ]/\\n/g'"$q"' | grep -oi "https.*mage$"'"$FILTER"' | head -1'
 		sed -i "s#FUNCTION)#$FUNCTION)#g" "$CACHEDIR/extra/$3"
 		chmod a+x "$CACHEDIR/extra/$3"
 		"$AMCLIPATH" -i "$CACHEDIR/extra/$3"
-		rm -f "$CACHEDIR/extra/$3"
 		exit 1
 		;;
 	esac

--- a/modules/install.am
+++ b/modules/install.am
@@ -345,13 +345,13 @@ while [ -n "$1" ]; do
 		case $2 in
 		'')
 			echo " USAGE: $AMCLI $1 user/project [ARGUMENT]"
-			echo " USAGE: $AMCLI $1 https://github.com/user/project [ARGUMENT]"; exit
+			echo " USAGE: $AMCLI $1 user/project [ARGUMENT] [KEYWORD]"; exit
 			;;
 		esac
 		case $3 in
 		'')
 			echo " USAGE: $AMCLI $1 user/project [ARGUMENT]"
-			echo " USAGE: $AMCLI $1 https://github.com/user/project [ARGUMENT]"; exit
+			echo " USAGE: $AMCLI $1 user/project [ARGUMENT] [KEYWORD]"; exit
 			;;
 		esac
 
@@ -387,12 +387,15 @@ while [ -n "$1" ]; do
 		elif [ "$arch" == "aarch64" ]; then
 			if curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "aarch64" | head -1 1>/dev/null; then
 				FILTER=' | grep -i "aarch64" '
-			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "amd64" | head -1 1>/dev/null; then
-				FILTER=' | grep -i "amd64" '
+			elif curl --output /dev/null --silent --head --fail "https://api.github.com/repos/$CUSTOMREPO/releases" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "arm64" | head -1 1>/dev/null; then
+				FILTER=' | grep -i "arm64" '
 			fi
 		fi
 		FUNCTION='curl -Ls https://api.github.com/repos/'"$CUSTOMREPO"'/releases | sed '"$q"'s/[()",{} ]/\\n/g'"$q"' | grep -oi "https.*mage$"'"$FILTER"' | head -1'
 		sed -i "s#FUNCTION)#$FUNCTION)#g" "$CACHEDIR/extra/$3"
+		if [ -n "$4" ]; then
+			sed -i "s# head -1# grep -i \"$4\" | head -1#g" "$CACHEDIR/extra/$3"
+		fi
 		chmod a+x "$CACHEDIR/extra/$3"
 		"$AMCLIPATH" -i "$CACHEDIR/extra/$3"
 		exit 1

--- a/modules/install.am
+++ b/modules/install.am
@@ -211,110 +211,118 @@ function _install_arg() {
 
 while [ -n "$1" ]; do
 
-	case $2 in
-	'')
-		echo " USAGE: $AMCLI $1 [ARGUMENT]"
-		echo " USAGE: $AMCLI $1 --debug [ARGUMENT]"
-		echo " USAGE: $AMCLI $1 --force-latest [ARGUMENT]"; exit
-		;;
-	'--debug'|'--force-latest')
-		case $3 in
-			'')	echo " USAGE: $AMCLI $1 --debug [ARGUMENT]"
-				echo " USAGE: $AMCLI $1 --force-latest [ARGUMENT]"; exit;;
+	case "$1" in
+	'-i'|'install')
+		case $2 in
+		'')
+			echo " USAGE: $AMCLI $1 [ARGUMENT]"
+			echo " USAGE: $AMCLI $1 --debug [ARGUMENT]"
+			echo " USAGE: $AMCLI $1 --force-latest [ARGUMENT]"; exit
+			;;
+		'--debug'|'--force-latest')
+			case $3 in
+				'')	echo " USAGE: $AMCLI $1 --debug [ARGUMENT]"
+					echo " USAGE: $AMCLI $1 --force-latest [ARGUMENT]"; exit;;
+			esac
 		esac
-	esac
 
-	if [ "$AMCLI" == am ] 2>/dev/null; then
-  		$SUDOCOMMAND echo -ne "\r"
-  		if ! $SUDOCOMMAND -n true 2>/dev/null; then
-			exit
-  		fi
-  	fi
-
-	echo "############################################################################"
-	echo "##                                                                        ##"
-	echo "##                  START OF ALL INSTALLATION PROCESSES                   ##"
-	echo "##                                                                        ##"
-	echo "############################################################################"
-	_clean_amcachedir
-	echo "$@" | tr ' ' '\n' >> "$AMCACHEDIR"/install-args 
-	echo STOP >> "$AMCACHEDIR"/install-args
-	ARGS=$(tail -n +2 "$AMCACHEDIR"/install-args)
-	METAPACKAGES="kdegames kdeutils libreoffice nodejs platform-tools"
-
-	for arg in $ARGS; do
-
-		if [ "$arg" == STOP ]; then
-			if test -f "$AMCACHEDIR"/installed; then
-				echo "############################################################################"
-				echo -e "\n                  END OF ALL INSTALLATION PROCESSES\n"
-				echo -e "             The following new programs have been installed:\n"
-				grep -w -v "◆ am" 0<"$AMCACHEDIR"/installed
-				echo -e "\n############################################################################"
+		if [ "$AMCLI" == am ] 2>/dev/null; then
+	  		$SUDOCOMMAND echo -ne "\r"
+	  		if ! $SUDOCOMMAND -n true 2>/dev/null; then
 				exit
-			else
-				exit
-			fi
-		else
-			echo ""
-			case $arg in
+	  		fi
+	  	fi
 
-			'--debug')
-				echo " You have decided to read the complete messages to debug the installation"
-				echo "____________________________________________________________________________"
-				;;
-			'--force-latest')
-				echo " You have decided to force downloads for the latest version (if it exists)"
-				echo "____________________________________________________________________________"
-				;;
-			*)
-				# If the "tmp" directory is not removed, the installation failed, so remove the app
-				if test -d "$APPSPATH"/"$arg"/tmp; then
-					$SUDOCOMMAND "$APPSPATH"/"$arg"/remove 2> /dev/null
-				fi
+		echo "############################################################################"
+		echo "##                                                                        ##"
+		echo "##                  START OF ALL INSTALLATION PROCESSES                   ##"
+		echo "##                                                                        ##"
+		echo "############################################################################"
+		_clean_amcachedir
+		echo "$@" | tr ' ' '\n' >> "$AMCACHEDIR"/install-args 
+		echo STOP >> "$AMCACHEDIR"/install-args
+		ARGS=$(tail -n +2 "$AMCACHEDIR"/install-args)
+		METAPACKAGES="kdegames kdeutils libreoffice nodejs platform-tools"
 
-				# Various cases that may occur during installation (for example if you use a third-party repository)
-				if test -f "$APPSPATH"/"$arg"/remove; then
-					echo " ◆ $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]'): app already installed previously! Try removing it."
+		for arg in $ARGS; do
+
+			if [ "$arg" == STOP ]; then
+				if test -f "$AMCACHEDIR"/installed; then
+					echo "############################################################################"
+					echo -e "\n                  END OF ALL INSTALLATION PROCESSES\n"
+					echo -e "             The following new programs have been installed:\n"
+					grep -w -v "◆ am" 0<"$AMCACHEDIR"/installed
+					echo -e "\n############################################################################"
+					exit
 				else
-					if test -f ./"$arg" 2> /dev/null; then
-						mkdir -p "$AMCACHEDIR"/tmp; cp ./"$arg" "$AMCACHEDIR"/tmp/"$arg"; cd "$AMCACHEDIR" || return; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
-						_install_arg
-					elif test -f "$arg" 2> /dev/null; then
-						path2arg=$(echo "$arg")
-						arg=$(echo "$path2arg" | sed 's:.*/::')
-						cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; cp "$path2arg" ./"$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
-						_install_arg
-					elif test -f "$AMPATH/neodb"; then
-						rm -R -f "$AMCACHEDIR/multirepo-args"
-						MULTIREPO=$(cat "$AMPATH/neodb" | grep "Source=" | sed 's/Source=//g')
-						for anyrepo in $MULTIREPO; do
-							if curl --output /dev/null --silent --head --fail "$anyrepo"/"$arg"  1>/dev/null; then
-								echo "$anyrepo" >> "$AMCACHEDIR/multirepo-args"
-							fi
-						done
-						if test -f "$AMCACHEDIR/multirepo-args"; then
-							anyrepoargs=$(cat "$AMCACHEDIR/multirepo-args" 2>/dev/null | wc -l)
-							if [ "$anyrepoargs" -gt 0 ]; then
-								if curl --output /dev/null --silent --head --fail "$APPSDB"/"$arg"  1>/dev/null; then
-									echo "$APPSDB" >> "$AMCACHEDIR/multirepo-args"
+					exit
+				fi
+			else
+				echo ""
+				case $arg in
+
+				'--debug')
+					echo " You have decided to read the complete messages to debug the installation"
+					echo "____________________________________________________________________________"
+					;;
+				'--force-latest')
+					echo " You have decided to force downloads for the latest version (if it exists)"
+					echo "____________________________________________________________________________"
+					;;
+				*)
+					# If the "tmp" directory is not removed, the installation failed, so remove the app
+					if test -d "$APPSPATH"/"$arg"/tmp; then
+						$SUDOCOMMAND "$APPSPATH"/"$arg"/remove 2> /dev/null
+					fi
+
+					# Various cases that may occur during installation (for example if you use a third-party repository)
+					if test -f "$APPSPATH"/"$arg"/remove; then
+						echo " ◆ $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]'): app already installed previously! Try removing it."
+					else
+						if test -f ./"$arg" 2> /dev/null; then
+							mkdir -p "$AMCACHEDIR"/tmp; cp ./"$arg" "$AMCACHEDIR"/tmp/"$arg"; cd "$AMCACHEDIR" || return; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
+							_install_arg
+						elif test -f "$arg" 2> /dev/null; then
+							path2arg=$(echo "$arg")
+							arg=$(echo "$path2arg" | sed 's:.*/::')
+							cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; cp "$path2arg" ./"$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
+							_install_arg
+						elif test -f "$AMPATH/neodb"; then
+							rm -R -f "$AMCACHEDIR/multirepo-args"
+							MULTIREPO=$(cat "$AMPATH/neodb" | grep "Source=" | sed 's/Source=//g')
+							for anyrepo in $MULTIREPO; do
+								if curl --output /dev/null --silent --head --fail "$anyrepo"/"$arg"  1>/dev/null; then
+									echo "$anyrepo" >> "$AMCACHEDIR/multirepo-args"
 								fi
-								anyrepoargall=$(cat "$AMCACHEDIR/multirepo-args" 2>/dev/null | wc -l)
-								if [ "$anyrepoargall" == 1 ]; then
-									cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$(cat "$AMCACHEDIR/multirepo-args" | head -1)/$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
+							done
+							if test -f "$AMCACHEDIR/multirepo-args"; then
+								anyrepoargs=$(cat "$AMCACHEDIR/multirepo-args" 2>/dev/null | wc -l)
+								if [ "$anyrepoargs" -gt 0 ]; then
+									if curl --output /dev/null --silent --head --fail "$APPSDB"/"$arg"  1>/dev/null; then
+										echo "$APPSDB" >> "$AMCACHEDIR/multirepo-args"
+									fi
+									anyrepoargall=$(cat "$AMCACHEDIR/multirepo-args" 2>/dev/null | wc -l)
+									if [ "$anyrepoargall" == 1 ]; then
+										cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$(cat "$AMCACHEDIR/multirepo-args" | head -1)/$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
+										rm -R -f "$AMCACHEDIR/multirepo-args"
+										_install_arg
+									else
+										printf '\n%s\n' " ◆ FOUND $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]') FROM MULTIPLE SOURCES:"
+										printf '%s\n\n' " Select a URL from this menu (read carefully) or press CTRL+C to abort:"; sleep 1
+										select d in $(cat "$AMCACHEDIR/multirepo-args"); do test -n "$d" && break; echo ">>> Invalid Selection"; done
+										cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$d/$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
+										rm -R -f "$AMCACHEDIR/multirepo-args"
+										_install_arg
+									fi
+								elif curl --output /dev/null --silent --head --fail "$APPSDB"/"$arg"  1>/dev/null; then
+									cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$APPSDB"/"$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
 									rm -R -f "$AMCACHEDIR/multirepo-args"
 									_install_arg
 								else
-									printf '\n%s\n' " ◆ FOUND $(echo "\"$arg\"" | tr '[:lower:]' '[:upper:]') FROM MULTIPLE SOURCES:"
-									printf '%s\n\n' " Select a URL from this menu (read carefully) or press CTRL+C to abort:"; sleep 1
-									select d in $(cat "$AMCACHEDIR/multirepo-args"); do test -n "$d" && break; echo ">>> Invalid Selection"; done
-									cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$d/$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
-									rm -R -f "$AMCACHEDIR/multirepo-args"
-									_install_arg
+									echo " 💀 ERROR: \"$arg\" does NOT exist in the database, see \"$AMCLI -l\""
 								fi
 							elif curl --output /dev/null --silent --head --fail "$APPSDB"/"$arg"  1>/dev/null; then
 								cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$APPSDB"/"$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
-								rm -R -f "$AMCACHEDIR/multirepo-args"
 								_install_arg
 							else
 								echo " 💀 ERROR: \"$arg\" does NOT exist in the database, see \"$AMCLI -l\""
@@ -325,18 +333,40 @@ while [ -n "$1" ]; do
 						else
 							echo " 💀 ERROR: \"$arg\" does NOT exist in the database, see \"$AMCLI -l\""
 						fi
-					elif curl --output /dev/null --silent --head --fail "$APPSDB"/"$arg"  1>/dev/null; then
-						cd "$AMCACHEDIR" || return; mkdir -p tmp; cd tmp || return; wget -q "$APPSDB"/"$arg"; cd ..; mv ./tmp/"$arg" ./"$arg"; rmdir ./tmp
-						_install_arg
-					else
-						echo " 💀 ERROR: \"$arg\" does NOT exist in the database, see \"$AMCLI -l\""
 					fi
-				fi
-				echo "____________________________________________________________________________"
-				;;
-			esac
-		fi
-	done
+					echo "____________________________________________________________________________"
+					;;
+				esac
+			fi
+		done
+		;;
+
+	'-e'|'extra')
+		case $2 in
+		'')
+			echo " USAGE: $AMCLI $1 'https://github.com/user/project' [ARGUMENT]"; exit
+			;;
+		esac
+		case $3 in
+		'')
+			echo " USAGE: $AMCLI $1 'https://github.com/user/project' [ARGUMENT]"; exit
+			;;
+		esac
+
+		mkdir -p "$CACHEDIR/extra"
+		wget -q "$AMREPO"/templates/AM-SAMPLE-AppImage -O "$CACHEDIR/extra/$3" || exit 1
+		sed -i "s#APP=SAMPLE#APP=$3#g" "$CACHEDIR/extra/$3"
+		CUSTOMREPO=$(echo "$2" | sed 's#https://github.com/##g' | cut -f1,2 -d'/')
+		sed -i "s#REPLACETHIS#$CUSTOMREPO#g" "$CACHEDIR/extra/$3"
+		q="'"
+		FUNCTION='curl -Ls https://api.github.com/repos/'"$CUSTOMREPO"'/releases | sed '"$q"'s/[()",{} ]/\\n/g'"$q"' | grep -oi "https.*mage$" | grep -vi "i386\\|i686\\|aarch64\\|arm64\\|armv7l" | head -1'
+		sed -i "s#FUNCTION)#$FUNCTION)#g" "$CACHEDIR/extra/$3"
+		chmod a+x "$CACHEDIR/extra/$3"
+		"$AMCLIPATH" -i "$CACHEDIR/extra/$3"
+		rm -f "$CACHEDIR/extra/$3"
+		exit 1
+		;;
+	esac
 done
 
 shift


### PR DESCRIPTION
This is a new option based on the workflow of the option "-t" or "template" and that uses the option "-i" or "install".

SYNTAX:
```
am -e 'https://github.com/user/project' [ARGUMENT]
```
where the URL is related to a github project and [ARGUMENT] is the name you give to the app.

Once launched the command, a new script based on an existing template wil be created in ~/.cahe/extra and then executed with the option "-i".

Once installed, the application will gain all advantages of any app listed in the database, including updates.

In this video, I want to install "Anydesk" as "Anydesktop"

https://github.com/ivan-hc/AM/assets/88724353/b7a06e6f-2b48-46a6-a35b-8f14c06ccd67



