### PR TITLE
Option "-e", filter all common non x86_64 results for x86_64 apps

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -400,11 +400,7 @@ while [ -n "$1" ]; do
 		sed -i "s#REPLACETHIS#$USER_PROJECT#g" "$CACHEDIR/extra/$3"
 		q="'"
 		if [ "$arch" == "x86_64" ]; then
-			if curl --output /dev/null --silent --head --fail "$API_GITHUB_REPO" | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -ie "x86_64\|x64\|amd64" | head -1 1>/dev/null; then
-				FILTER=' | grep -ie "x86_64\\|x64\\|amd64" '
-			else
-				FILTER=' | grep -vi "i386\\|i686\\|aarch64\\|arm64\\|armv7l"'
-			fi
+			FILTER=' | grep -vi "i386\\|i686\\|i586\\|i486\\|aarch64\\|arm64\\|armv7l"'
 		elif [ "$arch" == "i686" ]; then
 			FILTER=' | grep -ie "i386\\|i686\\|i586\\|i486" '
 		elif [ "$arch" == "aarch64" ]; then


### PR DESCRIPTION
...this will help when a x86_64 app have not a keyword for its architecture.

Fix https://github.com/ivan-hc/AM/issues/815