### PR TITLE
Add initial doas support

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -59,7 +59,7 @@ function _am() {
 	elif command -v doas >/dev/null 2>&1; then
 		SUDOCOMMAND="doas"
 	else
-		printf 'ERROR: No sudo or doas found'
+		echo 'ERROR: No sudo or doas found'
 		exit 1
 	fi
 	COMPLETIONPATH="/etc/bash_completion.d"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -54,7 +54,14 @@ _no_sudo
 function _am() {
 	AMCLI="am"
 	AMCLIPATH="$AMCLI"
-	SUDOCOMMAND="sudo"
+	if command -v sudo >/dev/null 2>&1; then
+		SUDOCOMMAND="sudo"
+	elif command -v doas >/dev/null 2>&1; then
+		SUDOCOMMAND="doas"
+	else
+		printf 'ERROR: No sudo or doas found'
+		exit 1
+	fi
 	COMPLETIONPATH="/etc/bash_completion.d"
 	COMPLETIONFILE="am-completion.sh"
 	APPSPATH="/opt"


### PR DESCRIPTION
Btw Ivan I noticed this and I think there is an error in this function: 

```
function _no_sudo() {
	if [ -n "$SUDO_COMMAND" ]; then
		printf '\n Please do not use "sudo" to execute "'"$CLI"'", try again.\n\n'
		exit 1
	fi
}
```

What is `$SUDO_COMMAND`? I don't see it being defined anywhere, instead there is `$SUDOCOMMAND`

