### PR TITLE
"AM": made "sudo" and "doas" optional (default is "root")

### DIFF
--- a/AM-INSTALLER
+++ b/AM-INSTALLER
@@ -27,12 +27,14 @@ _install_am() {
 	mkdir -p "$CACHEDIR" || true
 	rm -f "$CACHEDIR"/INSTALL-AM.sh || true
 	wget -q https://raw.githubusercontent.com/ivan-hc/AM/main/INSTALL -O "$CACHEDIR"/INSTALL-AM.sh && chmod a+x "$CACHEDIR"/INSTALL-AM.sh
-	if command -v sudo >/dev/null 2>&1; then
+	if [ "$(id -u)" = 0 ]; then
+		SUDOCOMMAND=""
+	elif command -v sudo >/dev/null 2>&1; then
 		SUDOCOMMAND="sudo"
 	elif command -v doas >/dev/null 2>&1; then
 		SUDOCOMMAND="doas"
 	else
-		echo 'ERROR: No sudo or doas found'
+		echo "ERROR: you need to be \"root\" to use \"AM\""
 		exit 1
 	fi
 	$SUDOCOMMAND "$CACHEDIR"/INSTALL-AM.sh && rm -f "$CACHEDIR"/INSTALL-AM.sh

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -54,12 +54,14 @@ _no_sudo
 function _am() {
 	AMCLI="am"
 	AMCLIPATH="$AMCLI"
-	if command -v sudo >/dev/null 2>&1; then
+	if [ "$(id -u)" = 0 ]; then
+		SUDOCOMMAND=""
+	elif command -v sudo >/dev/null 2>&1; then
 		SUDOCOMMAND="sudo"
 	elif command -v doas >/dev/null 2>&1; then
 		SUDOCOMMAND="doas"
 	else
-		echo 'ERROR: No sudo or doas found'
+		echo "ERROR: you need to be \"root\" to use \"AM\""
 		exit 1
 	fi
 	COMPLETIONPATH="/etc/bash_completion.d"


### PR DESCRIPTION
fix https://github.com/ivan-hc/AM/issues/826

This is the common code in APP-MANAGER and AM-INSTALLER added in this pull request
```
	if [ "$(id -u)" = 0 ]; then
		SUDOCOMMAND=""
	elif command -v sudo >/dev/null 2>&1; then
		SUDOCOMMAND="sudo"
	elif command -v doas >/dev/null 2>&1; then
		SUDOCOMMAND="doas"
	else
		echo "ERROR: you need to be \"root\" to use \"AM\""
		exit 1
	fi
```

1. all the function above does is to check if the user that is running AM is "root"
2. if not, check if the "sudo" command exists, so you can use it
3. alternativelly, use "doas"
4. if none of the options above is satified, you cannot use AM at all

so the new command added here is
```
if [ "$(id -u)" = 0 ]; then
	SUDOCOMMAND=""
```

all others were already been added by @Samueru-sama and available from the "AM" 7.6 [release](https://github.com/ivan-hc/AM/releases/tag/7.6)

----------------------------

## Test 1: install and use "AM" as the "root" user
Tests to be done (at least in a Virtual Machine):
- login as root and install AM using the AM-INSTALLER script, option 1
- once AM is installed, do not run it!
- in first you must change the content of /opt/am/APP-MANAGER (this is the one from "main") with the one from this PR, in "dev"
- use "AM" normally, still using the "root" session

tests to do after:
- try to use AM also with other admins, "AM" should not work at all
- using other admins, open a root shell and use "AM"

NOTE: in this test, the owner of /opt/am is "root"

----------------------------

## Test 2: install and use "AM" as regular user
Tests to be done (at least in a Virtual Machine):
- install AM using AM-INSTALLER, option 1, as a regular user, and enter the password normally
- once AM is installed, do not run it!
- in first you must change the content of /opt/am/APP-MANAGER (this is the one from "main") with the one from this PR, in "dev"
- use "AM" normally

tests to be done after:
- try to use AM as "root", also by login the "root" account
- try the same with other users