### PR TITLE
allow appman to work outside `$HOME` APP-MANAGER

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -27,6 +27,9 @@ export CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 
 export APPMANCONFIG="$CONFIGDIR/appman"
 export SCRIPTDIR="$(xdg-user-dir DESKTOP 2>/dev/null || echo "$HOME")"
+APPMANCONFIG="$CONFIGDIR/appman"
+SCRIPTDIR="$(xdg-user-dir DESKTOP 2>/dev/null || echo "$HOME")"
+export SCRIPTDIR
 
 # Colors
 RED='\033[0;31m' 
@@ -36,14 +39,7 @@ LightBlue='\033[1;34m'
 DIVIDING_LINE="-----------------------------------------------------------------------------"
 
 # Prevent the use of "sudo" ("AM")
-if [ -n "$SUDO_COMMAND" ]; then 
-	echo " Please do not use \"sudo\" to execute \"$CLI\", try again."  
-	exit 1
-fi
-
-################################################################################
-#				AM/APPMAN
-################################################################################
+[ -n "$SUDO_COMMAND" ] && echo -e "\n Please do not use \"sudo\" to execute \"$CLI\", try again.\n" && exit 1
 
 function _create_cache_dir() {
 	AMCACHEDIR="$CACHEDIR/$AMCLI"
@@ -55,26 +51,49 @@ function _clean_amcachedir() {
 	rm -f "$AMCACHEDIR"/*
 }
 
-
-# "AM" CORE VARIABLES
-function _am() {
-	AMCLI="am"
-	AMCLIPATH="$AMCLI"
-	if command -v sudo >/dev/null 2>&1; then
-		SUDOCMD="sudo"
-	elif command -v doas >/dev/null 2>&1; then
-		SUDOCMD="doas"
-	else
-		echo 'ERROR: No sudo or doas found'
-		exit 1
-	fi
-	APPSPATH="/opt"
-	AMPATH="$APPSPATH/$AMCLI"
-	_create_cache_dir
-	mkdir -p "$AMPATH"/modules
-}
+################################################################################
+#				AM/APPMAN
+################################################################################
 
 # "APPMAN" CORE VARIABLES AND FUNCTIONS
+function _appman_check() {
+	if [ ! -f "$APPMANCONFIG"/appman-config ]; then
+		echo "$DIVIDING_LINE" 
+		echo ">>> Thank you for choosing AppMan!"
+		echo "$DIVIDING_LINE"
+		echo " Before proceeding with any task, where do you want to install apps?"
+		printf '\n%s\n' " SYNTAX: /PATH/TO/DIRNAME"
+		printf '%s\n\n' " EXAMPLE: $HOME/My-apps"
+		echo " NOTE: Any spaces in the path will be replaced for dashes"
+		echo " NOTE: If no input is given then \"~/Applications\" will be used as default"
+		echo ""
+		echo " if you wish to later change the location, first remove all the programs"
+		echo " and then edit the "$APPMANCONFIG"/appman-config file."
+		echo "$DIVIDING_LINE"
+		read -rp " Write the path or just press enter to use default: " location
+		location="$(echo "$location" | sed 's/[ \t]/-/g; s|/$||g')"
+		[ -z "$location" ] && location="$HOME/Applications"
+		if [ "$location" = "$BINDIR" ]; then
+			echo "$DIVIDING_LINE"
+			echo " 💀 ERROR, you can't install applications in \"$BINDIR\""
+			echo " $BINDIR is normally used for executables, Please choose a different path and retry!" 
+			echo "$DIVIDING_LINE"
+			exit  1
+		fi
+		if ! mkdir -p "$location" >/dev/null 2>&1; then
+			echo "ERROR: You don't have write access to $location or it is invalid" 
+			exit 1
+		fi
+		mkdir -p "$APPMANCONFIG" || exit 1
+		echo "$location" > "$APPMANCONFIG"/appman-config || exit 1
+		echo "$DIVIDING_LINE"
+		echo " You are ready! Start installing your favorite apps locally!"
+		echo " All apps will be installed in $location"
+		echo " In case of problems, use the option \"-h\"."
+		echo "$DIVIDING_LINE"
+	fi
+}
+
 function _appman() {
 	APPSDIR="$(cat "$APPMANCONFIG"/appman-config | head -1)"
 	mkdir -p "$APPSDIR"/appman/modules || exit 1
@@ -95,42 +114,22 @@ function _appman() {
 	fi
 }
 
-function _appman_check() {
-	if [ ! -f "$APPMANCONFIG"/appman-config ]; then
-		echo "$DIVIDING_LINE" 
-		echo ">>> Thank you for choosing AppMan!"
-		echo "$DIVIDING_LINE"
-		echo " Before proceeding with any task, where do you want to install apps?"
-		printf '\n%s\n' " SYNTAX: /PATH/TO/DIRNAME"
-		printf '%s\n\n' " EXAMPLE: $HOME/My-apps"
-		echo " NOTE: Any spaces in the path will be replaced for dashes"
-		echo " NOTE: If no input is given then \"~/Applications\" will be used as default"
-		echo ""
-		echo " if you wish to later change the location, first remove all the programs"
-		echo " and then edit the "$APPMANCONFIG"/appman-config file."
-		echo "$DIVIDING_LINE"
-		read -rp " Write the path or just press enter to use default: " location
-		[ -z "$location" ] && location="$HOME/Applications"
-		if [ "$location" = "$BINDIR" ]; then
-			echo "$DIVIDING_LINE"
-			echo " 💀 ERROR, you can't install applications in \"$BINDIR\""
-			echo " $BINDIR is normally used for executables, Please choose a different path and retry!" 
-			echo "$DIVIDING_LINE"
-			exit  1
-		fi
-		location="$(echo "$location" | sed 's/[ \t]/-/g; s|/$||g')"
-		if ! mkdir -p "$location" >/dev/null 2>&1; then
-			echo "ERROR: You don't have write access to $location or it is invalid" 
-			exit 1
-		fi
-		mkdir -p "$APPMANCONFIG" || exit 1
-		echo "$location" > "$APPMANCONFIG"/appman-config || exit 1
-		echo "$DIVIDING_LINE"
-		echo " You are ready! Start installing your favorite apps locally!"
-		echo " All apps will be installed in $location"
-		echo " In case of problems, use the option \"-h\"."
-		echo "$DIVIDING_LINE"
+# "AM" CORE VARIABLES
+function _am() {
+	AMCLI="am"
+	AMCLIPATH="$AMCLI"
+	if command -v sudo >/dev/null 2>&1; then
+		SUDOCMD="sudo"
+	elif command -v doas >/dev/null 2>&1; then
+		SUDOCMD="doas"
+	else
+		echo 'ERROR: No sudo or doas found'
+		exit 1
 	fi
+	APPSPATH="/opt"
+	AMPATH="$APPSPATH/$AMCLI"
+	_create_cache_dir
+	mkdir -p "$AMPATH"/modules
 }
 
 # DETERMINE WHEN TO USE "AM" OR "APPMAN"
@@ -142,6 +141,11 @@ else
 	_appman_check
 	_appman
 fi
+
+################################################################################
+#				FINALIZE
+################################################################################
+
 AMCLIUPPER=$(echo "$AMCLI" | tr '[:lower:]' '[:upper:]')
 
 # Create new data directory and move important files there
@@ -366,7 +370,7 @@ function _check_version_if_binary_in_place() {
 function _check_version() {
 	rm -f "$AMCACHEDIR"/version-args
 	cd "$APPSPATH" &&
-	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null |\
+	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null |\
 	sort -rh | sed 's@.*	@@')
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/remove 2>/dev/null; then
@@ -382,7 +386,7 @@ function _check_version() {
 				_check_version_if_any_version_reference_is_somewhere
 			elif echo "$arg" | grep -q "ffwa-"; then
 				APPVERSION="WebApp"
-			elif grep -q "usr/local/lib" "$APPSPATH"/"$arg"/remove 2> /dev/null; then
+			elif grep -q "usr/local/lib" "$APPSPATH"/"$arg"/remove 2>/dev/null; then
 				_check_version_if_library
 			else
 				APPVERSION="unknown"
@@ -397,7 +401,7 @@ function _check_version() {
 
 function _check_version_for_auto_updatable_apps() {
 	cd "$APPSPATH" &&
-	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null | sort -rh | sed 's@.*	@@')
+	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null | sort -rh | sed 's@.*	@@')
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/updater 2>/dev/null; then
 			_check_version_if_an_updater_exists
@@ -473,32 +477,19 @@ function _if_appman_mode_enabled() {
 function _use_appman() {
 	_online_check
 	[ "$CLI" = appman ] && echo " This function only works for AM" && exit
-	if test -f "$APPMANCONFIG"/appman-mode; then
-		_appman && echo -e "$APPMAN_MSG"
-	else
-		mkdir -p "$APPMANCONFIG" && touch "$APPMANCONFIG"/appman-mode
-		_appman && echo -e "$APPMAN_MSG"
-	fi
+	[ ! -f "$APPMANCONFIG"/appman-mode ] && mkdir -p "$APPMANCONFIG" && touch "$APPMANCONFIG"/appman-mode
+	_appman && echo -e "$APPMAN_MSG"
 }
 
-function _back_to_am() {
-	if test -f "$APPMANCONFIG"/appman-mode; then
-		rm -f "$APPMANCONFIG"/appman-mode && echo -e "$APPMAN_MSG_OFF"
-	fi
+function _use_am_again() {
+	[ -f "$APPMANCONFIG"/appman-mode ] && rm -f "$APPMANCONFIG"/appman-mode && echo -e "$APPMAN_MSG_OFF"
 }
 
 if [ "$AMCLI" = am ]; then
 	if test -f "$APPMANCONFIG"/appman-mode; then
-		case "$1" in
-		'--system')
-			_back_to_am
-			;;
-		''|*)
-			[ ! -f "$APPMANCONFIG"/appman-config ] && echo -e "$APPMAN_MSG"
-			_appman
-			AMCLIPATH="/opt/am/APP-MANAGER"
-			;;
-		esac
+		[ ! -f "$APPMANCONFIG"/appman-config ] && echo -e "$APPMAN_MSG"
+		_appman
+		AMCLIPATH="/opt/am/APP-MANAGER"
 	elif [ ! -w /opt/am ]; then
 		read -r -p " \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
@@ -512,12 +503,8 @@ fi
 
 # BETA TESTER
 function _use_beta_tester() {
-	if [ "$1" = "--devmode-disable" ]; then
-		rm -f "$AMDATADIR"/betatester
-	else
-		touch "$AMDATADIR"/betatester
-		_betatester_message_on
-	fi
+	[ "$1" = "--devmode-disable" ] && rm -f "$AMDATADIR"/betatester \
+	|| touch "$AMDATADIR"/betatester && _betatester_message_on
 }
 
 # CLEAN UNNEEDED FILES
@@ -527,22 +514,22 @@ function _clean_amcachedir_message() {
 }
 
 function _clean_all_home_cache_directories_of_appimages() {
-	if test -d "$APPSPATH"/*/*.home/.cache 2> /dev/null; then
+	if test -d "$APPSPATH"/*/*.home/.cache 2>/dev/null; then
 		rm -Rf "$APPSPATH"/*/*.home/.cache/* &&
 		echo " ✔ Clear the contents of all *.home/.cache AppImages directories"
 	fi
 }
 
 function _clean_all_tmp_directories_from_appspath() {
-	if test -d "$APPSPATH"/*/tmp 2> /dev/null; then
+	if test -d "$APPSPATH"/*/tmp 2>/dev/null; then
 		rm -Rf "$APPSPATH"/*/tmp &&
 		echo ' ✔ Removed all '"$APPSPATH"'/*/tmp directories'
 	fi
 }
 
 function _clean_determine_removable_launchers() {
-	if ! test -f "$APPIMAGENAME" 2> /dev/null; then
-		if ! test -d "$MOUNTPOINTS" 2> /dev/null; then
+	if ! test -f "$APPIMAGENAME" 2>/dev/null; then
+		if ! test -d "$MOUNTPOINTS" 2>/dev/null; then
 			if echo "$MOUNTPOINTS" | grep -q "/media/"; then
 				unmounted_poin="/media"
 			elif echo "$MOUNTPOINTS" | grep -q "/mnt/"; then
@@ -559,7 +546,7 @@ function _clean_determine_removable_launchers() {
 }
 
 function _clean_launchers() {
-	if test -d "$DATADIR"/applications/AppImages 2> /dev/null; then
+	if test -d "$DATADIR"/applications/AppImages 2>/dev/null; then
 		for var in "$DATADIR"/applications/AppImages/*.desktop; do
 			APPIMAGENAME=$(grep "Exec=" 0<"$var" 2>/dev/null | head -1 | cut -c 6- | sed 's/\s.*$//')
 			launcher2del=$(basename -- "$(echo "$APPIMAGENAME" | tr '[:upper:]' '[:lower:]')")
@@ -601,7 +588,7 @@ function _use_clean() {
 	_clean_amcachedir_message
 	_clean_all_home_cache_directories_of_appimages
 	_clean_all_tmp_directories_from_appspath
-	_clean_launchers 2> /dev/null
+	_clean_launchers 2>/dev/null
 	_clean_old_modules
 	_clean_and_remove_old_am_cache_directory
 }
@@ -896,7 +883,7 @@ function _sync_installation_scripts() {
 			CURRENT=$(cat "$APPSPATH"/"$arg"/.am-installer/"$scriptname")
 			SOURCE=$(curl -Ls "$APPSDB"/"$scriptname")
 			if [ "$CURRENT" = "$SOURCE" ]; then
-				echo -ne "\r" 2> /dev/null
+				echo -ne "\r" 2>/dev/null
 			else
 				echo -e " ◆ Changed https://github.com/ivan-hc/AM/blob/main/programs/$arch/$scriptname"
 			fi
@@ -917,16 +904,16 @@ function _sync_modules() {
 		cd "$AMPATH"/modules || return
 		if ! test -f ./"$module_name"; then
 			echo " ◆ Downloading $module_name (not previously installed)..."
-			curl -Os "$AMREPO/modules/$module_name" 2> /dev/null
+			curl -Os "$AMREPO/modules/$module_name" 2>/dev/null
 			chmod a+x ./"$MODULENAME"
 		fi
 		CURRENT=$(cat ./"$module_name" 2>/dev/null)
 		SOURCE=$(curl -Ls "$AMREPO/modules/$module_name")
 		if [ "$CURRENT" = "$SOURCE" ]; then
-			echo -ne "\r" 2> /dev/null
+			echo -ne "\r" 2>/dev/null
 		else
 			echo " ◆ Updating $module_name..."
-			curl -Ls "$AMREPO/modules/$module_name" > ./"$module_name" 2> /dev/null
+			curl -Ls "$AMREPO/modules/$module_name" > ./"$module_name" 2>/dev/null
 		fi
 	done
 	_clean_old_modules
@@ -994,14 +981,14 @@ function _update_all_apps() {
 			APPNAME=$(echo "$appname" | tr '[:lower:]' '[:upper:]')
 			if [ -w ./AM-updater ]; then
 				start=$(date +%s) &&
-				sh -x ./AM-updater > /dev/null 2>&1 | echo -ne ' Updating "'"$APPNAME"'"...\r' &&
+				sh -x ./AM-updater >/dev/null 2>&1 | echo -ne ' Updating "'"$APPNAME"'"...\r' &&
 				end=$(date +%s) &&
 				echo " ◆ $APPNAME is updated, $((end - start)) seconds elapsed!" &
 			else
 				echo " ✖ $APPNAME is read-only, cannot update it!"
 			fi
 		else
-			echo ""  > /dev/null 2>&1
+			echo ""  >/dev/null 2>&1
 		fi
 	done
 	wait
@@ -1048,7 +1035,7 @@ function _use_update() {
 			if test -f "$APPSPATH"/"$arg"/AM-updater; then
 				if [ -w "$APPSPATH"/"$arg"/AM-updater ]; then
 					start=$(date +%s)
-					"$APPSPATH"/"$arg"/AM-updater > /dev/null 2>&1 | echo -ne " UPDATING $arg_upper\r"
+					"$APPSPATH"/"$arg"/AM-updater >/dev/null 2>&1 | echo -ne " UPDATING $arg_upper\r"
 					end=$(date +%s)
 					echo " ◆ $arg_upper is updated, $((end - start)) seconds elapsed!"
 					_clean_amcachedir
@@ -1134,7 +1121,7 @@ case "$1" in
 		_use_force_latest "$@"
 		;;
 	'--system')
-		_back_to_am
+		_use_am_again
 		;;
 	'apikey')
 		_use_apikey "$@"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -25,110 +25,36 @@ export DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 export CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 export CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 
+export APPMANCONFIG="$CONFIGDIR/appman"
+export SCRIPTDIR="$(xdg-user-dir DESKTOP 2>/dev/null || echo "$HOME")"
+
+# Colors
+RED='\033[0;31m' 
+Gold='\033[0;33m' 
+Green='\033[0;32m' 
+LightBlue='\033[1;34m'
+DIVIDING_LINE="-----------------------------------------------------------------------------"
+
+# Prevent the use of "sudo" ("AM")
+if [ -n "$SUDO_COMMAND" ]; then 
+	echo " Please do not use \"sudo\" to execute \"$CLI\", try again."  
+	exit 1
+fi
+
+################################################################################
+#				AM/APPMAN
+################################################################################
+
 function _create_cache_dir() {
 	AMCACHEDIR="$CACHEDIR/$AMCLI"
 	mkdir -p "$AMCACHEDIR"
 }
 
 function _clean_amcachedir() {
-	[ -z "$AMCACHEDIR" ] && exit 1 || rm -f "$AMCACHEDIR"/*
+	[ -z "$AMCACHEDIR" ] && exit 1
+	rm -f "$AMCACHEDIR"/*
 }
 
-APPMANCONFIG="$CONFIGDIR/appman"
-SCRIPTDIR="$(xdg-user-dir DESKTOP 2>/dev/null || echo "$HOME")"
-export SCRIPTDIR
-
-# Colors
-RED='\033[0;31m'; Gold='\033[0;33m'; Green='\033[0;32m'; LightBlue='\033[1;34m'
-DIVIDING_LINE="--------------------\
----------------------------------------------------------"
-
-# Prevent the use of "sudo" ("AM")
-[ -n "$SUDO_COMMAND" ] && echo -e "\n Please do not use \"sudo\" to execute \"$CLI\", try again.\n" && exit 1
-
-################################################################################
-#				PREPARE APPMAN
-################################################################################
-
-# AppMan messages
-function _appman_error_local_bin_message() {
-	echo -e "$DIVIDING_LINE\n 💀 ERROR, you can't install applications into a \"\$PATH\""
-	echo -e " The ~/.local/bin directory is normally used for executables.\n Please, choose a different path and retry! \n$DIVIDING_LINE"
-}
-
-function _appman_startup_message() {
-	echo -e "$DIVIDING_LINE\n >>> Thank you for choosing AppMan! \n$DIVIDING_LINE"
-	echo " Before proceeding with any task, write the name of the directory in which"
-	echo " you will install the apps, for example \"Programs\" or \"My-apps\", you can"
-	echo " also choose a subfolder, for example \".local/My-apps\" or a deeper path."
-	echo -e "\n The destination folder will be created in $HOME\n"
-	echo -e " SYNTAX: PATH/TO/DIRNAME\n"
-	echo " NOTE, any spaces or \"/\" at the beginning and end will be removed. If you"
-	echo " decide to change your choice in the future, first remove all the programs"
-	echo -e " and then edit the ~/.config/appman/appman-config text file.\n$DIVIDING_LINE\n"
-}
-
-function _appman_ready_message() {
-	echo -e "$DIVIDING_LINE\n You are ready! Start installing your favorite apps locally!"
-	echo " All apps will be installed in $HOME/$validated_location"
-	echo -e "\n In case of problems, use the option \"-h\".\n$DIVIDING_LINE"
-}
-
-# AppMan directories checks
-function _appman_prompt_for_directory() {
-	local location
-	read -r -ep " Please, write the name or the path of your custom application's folder: $(echo -e '\n\n '"$HOME"'/')" location
-	echo "$location"
-}
-
-function _appman_validate_directory() {
-	location=$1
-	if [ "$location" = "" ]; then
-		echo -e "$DIVIDING_LINE\nOPERATION ABORTED!"
-		exit  1
-	elif [ "$location" = ".local/bin" ]; then
-		_appman_error_local_bin_message
-		exit  1
-	else
-		location_appman="${location/#$HOME}"
-		location_appman="${location_appman// /-}"
-		location_appman="${location_appman#/}"
-		location_appman="${location_appman%/}"
-		echo "$location_appman"
-	fi
-}
-
-################################################################################
-#				AM/APPMAN
-################################################################################
-
-# "APPMAN" CORE VARIABLES AND FUNCTIONS
-function _appman_initialize() {
-	APPSDIR=$1
-	mkdir -p ~/"$APPSDIR"/appman/modules
-	mkdir -p "$BINDIR" "$DATADIR"/applications "$DATADIR"/icons
-	AMCLI="appman"
-	AMCLIPATH="$DIR/$AMCLI"
-	SUDOCMD=""
-	APPSPATH="$HOME/$APPSDIR"
-	AMPATH="$HOME/$APPSDIR/$AMCLI"
-	_create_cache_dir
-}
-
-function _appman() {
-	if [ ! -f "$APPMANCONFIG"/appman-config ]; then
-		_appman_startup_message
-		location=$(_appman_prompt_for_directory)
-		validated_location=$(_appman_validate_directory "$location")
-		mkdir -p "$APPMANCONFIG"
-		echo "$validated_location" >> "$APPMANCONFIG"/appman-config
-		_appman_ready_message
-	fi
-	_appman_initialize "$(<"$APPMANCONFIG"/appman-config)"
-	if ! echo "$PATH" | grep -q "$BINDIR"; then
-		echo -e "$DIVIDING_LINE\n ⚠️ WARNING: \"$BINDIR\" is not in PATH, apps may not run.\n$DIVIDING_LINE"
-	fi
-}
 
 # "AM" CORE VARIABLES
 function _am() {
@@ -148,19 +74,74 @@ function _am() {
 	mkdir -p "$AMPATH"/modules
 }
 
+# "APPMAN" CORE VARIABLES AND FUNCTIONS
+function _appman() {
+	APPSDIR="$(cat "$APPMANCONFIG"/appman-config | head -1)"
+	mkdir -p "$APPSDIR"/appman/modules || exit 1
+	mkdir -p "$BINDIR" "$DATADIR"/applications "$DATADIR"/icons || exit 1
+	AMCLI="appman"
+	AMCLIPATH="$DIR/$AMCLI"
+	SUDOCMD=""
+	APPSPATH="$APPSDIR"
+	AMPATH="$APPSDIR/$AMCLI"
+	_create_cache_dir
+	if [ ! -w "$APPSPATH" ]; then
+		echo " ERROR: You don't have write access to $APPSPATH"
+		exit 1
+	elif ! echo "$PATH" | grep "$BINDIR" >/dev/null 2>&1; then
+		echo "$DIVIDING_LINE"
+		echo " ⚠️ WARNING: \"$BINDIR\" is not in PATH, apps may not run."
+		echo "$DIVIDING_LINE"
+	fi
+}
+
+function _appman_check() {
+	if [ ! -f "$APPMANCONFIG"/appman-config ]; then
+		echo "$DIVIDING_LINE" 
+		echo ">>> Thank you for choosing AppMan!"
+		echo "$DIVIDING_LINE"
+		echo " Before proceeding with any task, where do you want to install apps?"
+		printf '\n%s\n' " SYNTAX: /PATH/TO/DIRNAME"
+		printf '%s\n\n' " EXAMPLE: $HOME/My-apps"
+		echo " NOTE: Any spaces in the path will be replaced for dashes"
+		echo " NOTE: If no input is given then \"~/Applications\" will be used as default"
+		echo ""
+		echo " if you wish to later change the location, first remove all the programs"
+		echo " and then edit the "$APPMANCONFIG"/appman-config file."
+		echo "$DIVIDING_LINE"
+		read -rp " Write the path or just press enter to use default: " location
+		[ -z "$location" ] && location="$HOME/Applications"
+		if [ "$location" = "$BINDIR" ]; then
+			echo "$DIVIDING_LINE"
+			echo " 💀 ERROR, you can't install applications in \"$BINDIR\""
+			echo " $BINDIR is normally used for executables, Please choose a different path and retry!" 
+			echo "$DIVIDING_LINE"
+			exit  1
+		fi
+		location="$(echo "$location" | sed 's/[ \t]/-/g; s|/$||g')"
+		if ! mkdir -p "$location" >/dev/null 2>&1; then
+			echo "ERROR: You don't have write access to $location or it is invalid" 
+			exit 1
+		fi
+		mkdir -p "$APPMANCONFIG" || exit 1
+		echo "$location" > "$APPMANCONFIG"/appman-config || exit 1
+		echo "$DIVIDING_LINE"
+		echo " You are ready! Start installing your favorite apps locally!"
+		echo " All apps will be installed in $location"
+		echo " In case of problems, use the option \"-h\"."
+		echo "$DIVIDING_LINE"
+	fi
+}
+
 # DETERMINE WHEN TO USE "AM" OR "APPMAN"
 if [ "$(realpath "$0")" = "/opt/am/APP-MANAGER" ]; then
 	_am
 elif [ "$(realpath "$0")" = "/usr/bin/am" ]; then
 	_am
 else
+	_appman_check
 	_appman
 fi
-
-################################################################################
-#				FINALIZE
-################################################################################
-
 AMCLIUPPER=$(echo "$AMCLI" | tr '[:lower:]' '[:upper:]')
 
 # Create new data directory and move important files there
@@ -385,7 +366,7 @@ function _check_version_if_binary_in_place() {
 function _check_version() {
 	rm -f "$AMCACHEDIR"/version-args
 	cd "$APPSPATH" &&
-	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null |\
+	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null |\
 	sort -rh | sed 's@.*	@@')
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/remove 2>/dev/null; then
@@ -401,7 +382,7 @@ function _check_version() {
 				_check_version_if_any_version_reference_is_somewhere
 			elif echo "$arg" | grep -q "ffwa-"; then
 				APPVERSION="WebApp"
-			elif grep -q "usr/local/lib" "$APPSPATH"/"$arg"/remove 2>/dev/null; then
+			elif grep -q "usr/local/lib" "$APPSPATH"/"$arg"/remove 2> /dev/null; then
 				_check_version_if_library
 			else
 				APPVERSION="unknown"
@@ -416,7 +397,7 @@ function _check_version() {
 
 function _check_version_for_auto_updatable_apps() {
 	cd "$APPSPATH" &&
-	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null | sort -rh | sed 's@.*	@@')
+	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null | sort -rh | sed 's@.*	@@')
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/updater 2>/dev/null; then
 			_check_version_if_an_updater_exists
@@ -492,19 +473,32 @@ function _if_appman_mode_enabled() {
 function _use_appman() {
 	_online_check
 	[ "$CLI" = appman ] && echo " This function only works for AM" && exit
-	[ ! -f "$APPMANCONFIG"/appman-mode ] && mkdir -p "$APPMANCONFIG" && touch "$APPMANCONFIG"/appman-mode
-	_appman && echo -e "$APPMAN_MSG"
+	if test -f "$APPMANCONFIG"/appman-mode; then
+		_appman && echo -e "$APPMAN_MSG"
+	else
+		mkdir -p "$APPMANCONFIG" && touch "$APPMANCONFIG"/appman-mode
+		_appman && echo -e "$APPMAN_MSG"
+	fi
 }
 
-function _use_am_again() {
-	[ -f "$APPMANCONFIG"/appman-mode ] && rm -f "$APPMANCONFIG"/appman-mode && echo -e "$APPMAN_MSG_OFF"
+function _back_to_am() {
+	if test -f "$APPMANCONFIG"/appman-mode; then
+		rm -f "$APPMANCONFIG"/appman-mode && echo -e "$APPMAN_MSG_OFF"
+	fi
 }
 
 if [ "$AMCLI" = am ]; then
 	if test -f "$APPMANCONFIG"/appman-mode; then
-		[ ! -f "$APPMANCONFIG"/appman-config ] && echo -e "$APPMAN_MSG"
-		_appman
-		AMCLIPATH="/opt/am/APP-MANAGER"
+		case "$1" in
+		'--system')
+			_back_to_am
+			;;
+		''|*)
+			[ ! -f "$APPMANCONFIG"/appman-config ] && echo -e "$APPMAN_MSG"
+			_appman
+			AMCLIPATH="/opt/am/APP-MANAGER"
+			;;
+		esac
 	elif [ ! -w /opt/am ]; then
 		read -r -p " \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
@@ -518,8 +512,12 @@ fi
 
 # BETA TESTER
 function _use_beta_tester() {
-	[ "$1" = "--devmode-disable" ] && rm -f "$AMDATADIR"/betatester \
-	|| touch "$AMDATADIR"/betatester && _betatester_message_on
+	if [ "$1" = "--devmode-disable" ]; then
+		rm -f "$AMDATADIR"/betatester
+	else
+		touch "$AMDATADIR"/betatester
+		_betatester_message_on
+	fi
 }
 
 # CLEAN UNNEEDED FILES
@@ -529,22 +527,22 @@ function _clean_amcachedir_message() {
 }
 
 function _clean_all_home_cache_directories_of_appimages() {
-	if test -d "$APPSPATH"/*/*.home/.cache 2>/dev/null; then
+	if test -d "$APPSPATH"/*/*.home/.cache 2> /dev/null; then
 		rm -Rf "$APPSPATH"/*/*.home/.cache/* &&
 		echo " ✔ Clear the contents of all *.home/.cache AppImages directories"
 	fi
 }
 
 function _clean_all_tmp_directories_from_appspath() {
-	if test -d "$APPSPATH"/*/tmp 2>/dev/null; then
+	if test -d "$APPSPATH"/*/tmp 2> /dev/null; then
 		rm -Rf "$APPSPATH"/*/tmp &&
 		echo ' ✔ Removed all '"$APPSPATH"'/*/tmp directories'
 	fi
 }
 
 function _clean_determine_removable_launchers() {
-	if ! test -f "$APPIMAGENAME" 2>/dev/null; then
-		if ! test -d "$MOUNTPOINTS" 2>/dev/null; then
+	if ! test -f "$APPIMAGENAME" 2> /dev/null; then
+		if ! test -d "$MOUNTPOINTS" 2> /dev/null; then
 			if echo "$MOUNTPOINTS" | grep -q "/media/"; then
 				unmounted_poin="/media"
 			elif echo "$MOUNTPOINTS" | grep -q "/mnt/"; then
@@ -561,7 +559,7 @@ function _clean_determine_removable_launchers() {
 }
 
 function _clean_launchers() {
-	if test -d "$DATADIR"/applications/AppImages 2>/dev/null; then
+	if test -d "$DATADIR"/applications/AppImages 2> /dev/null; then
 		for var in "$DATADIR"/applications/AppImages/*.desktop; do
 			APPIMAGENAME=$(grep "Exec=" 0<"$var" 2>/dev/null | head -1 | cut -c 6- | sed 's/\s.*$//')
 			launcher2del=$(basename -- "$(echo "$APPIMAGENAME" | tr '[:upper:]' '[:lower:]')")
@@ -603,7 +601,7 @@ function _use_clean() {
 	_clean_amcachedir_message
 	_clean_all_home_cache_directories_of_appimages
 	_clean_all_tmp_directories_from_appspath
-	_clean_launchers 2>/dev/null
+	_clean_launchers 2> /dev/null
 	_clean_old_modules
 	_clean_and_remove_old_am_cache_directory
 }
@@ -898,7 +896,7 @@ function _sync_installation_scripts() {
 			CURRENT=$(cat "$APPSPATH"/"$arg"/.am-installer/"$scriptname")
 			SOURCE=$(curl -Ls "$APPSDB"/"$scriptname")
 			if [ "$CURRENT" = "$SOURCE" ]; then
-				echo -ne "\r" 2>/dev/null
+				echo -ne "\r" 2> /dev/null
 			else
 				echo -e " ◆ Changed https://github.com/ivan-hc/AM/blob/main/programs/$arch/$scriptname"
 			fi
@@ -919,16 +917,16 @@ function _sync_modules() {
 		cd "$AMPATH"/modules || return
 		if ! test -f ./"$module_name"; then
 			echo " ◆ Downloading $module_name (not previously installed)..."
-			curl -Os "$AMREPO/modules/$module_name" 2>/dev/null
+			curl -Os "$AMREPO/modules/$module_name" 2> /dev/null
 			chmod a+x ./"$MODULENAME"
 		fi
 		CURRENT=$(cat ./"$module_name" 2>/dev/null)
 		SOURCE=$(curl -Ls "$AMREPO/modules/$module_name")
 		if [ "$CURRENT" = "$SOURCE" ]; then
-			echo -ne "\r" 2>/dev/null
+			echo -ne "\r" 2> /dev/null
 		else
 			echo " ◆ Updating $module_name..."
-			curl -Ls "$AMREPO/modules/$module_name" > ./"$module_name" 2>/dev/null
+			curl -Ls "$AMREPO/modules/$module_name" > ./"$module_name" 2> /dev/null
 		fi
 	done
 	_clean_old_modules
@@ -996,14 +994,14 @@ function _update_all_apps() {
 			APPNAME=$(echo "$appname" | tr '[:lower:]' '[:upper:]')
 			if [ -w ./AM-updater ]; then
 				start=$(date +%s) &&
-				sh -x ./AM-updater >/dev/null 2>&1 | echo -ne ' Updating "'"$APPNAME"'"...\r' &&
+				sh -x ./AM-updater > /dev/null 2>&1 | echo -ne ' Updating "'"$APPNAME"'"...\r' &&
 				end=$(date +%s) &&
 				echo " ◆ $APPNAME is updated, $((end - start)) seconds elapsed!" &
 			else
 				echo " ✖ $APPNAME is read-only, cannot update it!"
 			fi
 		else
-			echo ""  >/dev/null 2>&1
+			echo ""  > /dev/null 2>&1
 		fi
 	done
 	wait
@@ -1050,7 +1048,7 @@ function _use_update() {
 			if test -f "$APPSPATH"/"$arg"/AM-updater; then
 				if [ -w "$APPSPATH"/"$arg"/AM-updater ]; then
 					start=$(date +%s)
-					"$APPSPATH"/"$arg"/AM-updater >/dev/null 2>&1 | echo -ne " UPDATING $arg_upper\r"
+					"$APPSPATH"/"$arg"/AM-updater > /dev/null 2>&1 | echo -ne " UPDATING $arg_upper\r"
 					end=$(date +%s)
 					echo " ◆ $arg_upper is updated, $((end - start)) seconds elapsed!"
 					_clean_amcachedir
@@ -1136,7 +1134,7 @@ case "$1" in
 		_use_force_latest "$@"
 		;;
 	'--system')
-		_use_am_again
+		_back_to_am
 		;;
 	'apikey')
 		_use_apikey "$@"


### PR DESCRIPTION
Also defaults to using `~/Applications` if no path is given by the user.

It has the necesary checks to make sure that the user has read access to the location before continuing.