### PR TITLE
Move completions file to ~/.local/share/bash-completion/completions

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -303,7 +303,8 @@ function _completion_lists() {
 }
 
 # BASH AND ZSH COMPLETION
-completion_file="${ZDOTDIR:-$HOME}"/.bash_completion
+mkdir -p "$DATADIR/bash-completion/completions"
+completion_file="${ZDOTDIR:-$DATADIR}/bash-completion/completions/am"
 if ! grep -qo " $AMCLI$" "$completion_file" >/dev/null 2>&1; then
 	echo "complete -W \"\$(cat $AMDATADIR/list 2>/dev/null)\" $AMCLI" >> "$completion_file"
 	if [ -f "${ZDOTDIR:-$HOME}"/.zshrc ] && echo "$SHELL" | grep -q "zsh"; then

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -303,10 +303,10 @@ function _completion_lists() {
 }
 
 # BASH AND ZSH COMPLETION
-mkdir -p "$DATADIR/bash-completion/completions"
-completion_file="${ZDOTDIR:-$DATADIR}/bash-completion/completions/am"
-[ -f "${ZDOTDIR:-$HOME}"/.bash_completion ] && sed -i "/ $AMCLI$/d" "${ZDOTDIR:-$HOME}"/.bash_completion
-if ! grep -qo " $AMCLI$" "$completion_file" >/dev/null 2>&1; then
+completion_file="$DATADIR/bash-completion/completions/am"
+mkdir -p "$DATADIR/bash-completion/completions" || exit 1
+[ -f "$HOME"/.bash_completion ] && sed -i "/ $AMCLI$/d" "$HOME"/.bash_completion
+if ! grep -o " $AMCLI$" "$completion_file" >/dev/null 2>&1; then
 	echo "complete -W \"\$(cat $AMDATADIR/list 2>/dev/null)\" $AMCLI" >> "$completion_file"
 	if [ -f "${ZDOTDIR:-$HOME}"/.zshrc ] && echo "$SHELL" | grep -q "zsh"; then
 		cat <<-HEREDOC >> "${ZDOTDIR:-$HOME}"/.zshrc

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -305,6 +305,7 @@ function _completion_lists() {
 # BASH AND ZSH COMPLETION
 mkdir -p "$DATADIR/bash-completion/completions"
 completion_file="${ZDOTDIR:-$DATADIR}/bash-completion/completions/am"
+[ -f "${ZDOTDIR:-$HOME}"/.bash_completion ] && sed -i "/ $AMCLI$/d" "${ZDOTDIR:-$HOME}"/.bash_completion
 if ! grep -qo " $AMCLI$" "$completion_file" >/dev/null 2>&1; then
 	echo "complete -W \"\$(cat $AMDATADIR/list 2>/dev/null)\" $AMCLI" >> "$completion_file"
 	if [ -f "${ZDOTDIR:-$HOME}"/.zshrc ] && echo "$SHELL" | grep -q "zsh"; then

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.1"
+AMVERSION="8.1.1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/README.md
+++ b/README.md
@@ -1040,9 +1040,7 @@ EXTRA: The behavior of this option can be tested in a completely standalone way 
 
 __________________________________________________________________________
 ### How to enable bash completion
-From version 8, BASH/ZSH completion is enabled in "AM" and "AppMan" by default.
-
-A file $HOME/.bash_completion will be created, or if it exists, it will be patched to allow the command `am` or `appman` to read arguments from the related "list" of arguments, or other lists, to made it more extensible.
+**From version 8**, BASH/ZSH completion is enabled in "AM" and "AppMan" by default. and **from version 8.1.1** a file $HOME/.local/share/bash-completion/completions/am (and no more $HOME/.bash_completion) will be created and shared by both `am` and `appman` to read arguments from the related "list" of arguments, or other lists, to made it more extensible.
 
 Before version 8, in "AM" were created a "/etc/bash_completion.d/am-completion.sh" using a dedicated option.
 


### PR DESCRIPTION
Fix https://github.com/ivan-hc/AM/issues/903

Change completion file name and path, from `~/.bash_completion` to `~/.local/share/bash-completion/completions/am`