### PR TITLE
Added install script for pcsx-redux

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1415,6 +1415,7 @@
 ◆ pb-for-desktop : Pushbullet Desktop app.
 ◆ pboy : A small .pdf management tool with a command-line UI.
 ◆ pcloud : Europe's most secure cloud storage trusted by 20 million people.
+◆ pcsx-redux : The PCSX-Redux project is a collection of tools, research, hardware design, and libraries aiming at development and reverse engineering on the PlayStation 1. The core product itself, PCSX-Redux, is yet another fork of the Playstation emulator, PCSX.
 ◆ pcsx2 : The Playstation 2 Emulator.
 ◆ pdf2htmlex : Convert PDF to HTML without losing text or format.
 ◆ pdf4qt : Open source PDF editor.

--- a/programs/x86_64/pcsx-redux
+++ b/programs/x86_64/pcsx-redux
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=pcsx-redux
+SITE="grumpycoders/pcsx-redux"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+buildid=$(curl -Ls  https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest.json | sed -nr 's/.*"id": ([0-9]+).*/\1/p' | head -1)
+version="https://distrib.app"$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest-${buildid}.json | sed -nr 's/.*"path": "(.*)".*/\1/p')
+wget "$version" || exit 1
+# Keep this space in sync with other installation scripts
+unzip *.zip
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=pcsx-redux
+SITE="grumpycoders/pcsx-redux"
+version0=$(cat "/opt/$APP/version")
+buildid=$(curl -Ls  https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest.json | sed -nr 's/.*"id": ([0-9]+).*/\1/p' | head -1)
+version="https://distrib.app"$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest-${buildid}.json | sed -nr 's/.*"path": "(.*)".*/\1/p')
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	unzip *.zip
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root

--- a/programs/x86_64/pcsx-redux
+++ b/programs/x86_64/pcsx-redux
@@ -12,11 +12,10 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-buildid=$(curl -Ls  https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest.json | sed -nr 's/.*"id": ([0-9]+).*/\1/p' | head -1)
-version="https://distrib.app"$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest-${buildid}.json | sed -nr 's/.*"path": "(.*)".*/\1/p')
+version=$(echo "https://distrib.app$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest-$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest.json | grep id | head -1 | grep -o '[[:digit:]]*').json | tr '"' '\n' | grep -i "linux.*.zip")")
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
-unzip *.zip
+unzip -qq ./*.zip
 cd ..
 mv ./tmp/*mage ./"$APP"
 # Keep this space in sync with other installation scripts
@@ -34,15 +33,13 @@ set -u
 APP=pcsx-redux
 SITE="grumpycoders/pcsx-redux"
 version0=$(cat "/opt/$APP/version")
-buildid=$(curl -Ls  https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest.json | sed -nr 's/.*"id": ([0-9]+).*/\1/p' | head -1)
-version="https://distrib.app"$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest-${buildid}.json | sed -nr 's/.*"path": "(.*)".*/\1/p')
+version=$(echo "https://distrib.app$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest-$(curl -Ls https://distrib.app/storage/manifests/pcsx-redux/dev-linux-x64/manifest.json | grep id | head -1 | grep -o '[[:digit:]]*').json | tr '"' '\n' | grep -i "linux.*.zip")")
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	notify-send "A new version of $APP is available, please wait"
 	wget "$version" || exit 1
-	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
-	unzip *.zip
+	unzip -qq ./*.zip
 	cd ..
 	mv --backup=t ./tmp/*mage ./"$APP"
 	chmod a+x ./"$APP" || exit 1


### PR DESCRIPTION
This pull request attempts to add an install script for the pcsx-redux emulator.

It looked simple enough that I decided to give it a shot :).

This pull request is associated with the pull request here: https://github.com/Portable-Linux-Apps/Portable-Linux-Apps.github.io/pull/17

Let me know in case I missed something.

~~P.S. I tried testing to uninstall the app, and appman says that the app has not been removed. I am not sure whether this has to do with the fact that I used my script not included in the db, or whether there is an error in how I prepared the script. However, running the "remove" script manually works as expected.~~
Nevermind, I was not indicating Y as an answer to the request of deleting the app. However, usually when the answer in parentheses is specified in uppercase, like Y, it means it will be the default. It does not seem to be the case here.