### PR TITLE
"AM" 8.2: added an option to remove icon path and allow the use of custom icon themes

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.1.1-2"
+AMVERSION="8.2-beta1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -287,7 +287,7 @@ _am_newrepo_check "$@"
 
 # COMPLETION LIST
 available_options="about add apikey backup clean config disable downgrade download enable extra files \
-	home info install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite \
+	home icon-theme info install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite \
 	purge query remove sandbox select sync template test unlock update --appimages --apps --byname \
 	--config --convert --debug --devmode-disable --devmode-enable --force-latest --home --launcher \
 	--less --pkg --rollback --disable-sandbox --sandbox --system --user"
@@ -1095,6 +1095,7 @@ case "$1" in
 		;;
 	'backup'|'-b'|\
 	'downgrade'|'--rollback'|\
+	'icon-theme'|\
 	'launcher'|'--launcher'|\
 	'lock'|'unlock'|\
 	'nolibfuse'|\

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.2-beta1"
+AMVERSION="8.2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -288,9 +288,9 @@ _am_newrepo_check "$@"
 
 # COMPLETION LIST
 available_options="about add apikey backup clean config disable downgrade download enable extra files \
-	home icon-theme info install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite \
-	purge query remove sandbox select sync template test unlock update --appimages --apps --byname \
-	--config --convert --debug --devmode-disable --devmode-enable --force-latest --home --launcher \
+	home icons info install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite \
+	purge query remove sandbox select sync template test unlock update --all --appimages --apps --byname \
+	--config --convert --debug --devmode-disable --devmode-enable --force-latest --home --icons --launcher \
 	--less --pkg --rollback --disable-sandbox --sandbox --system --user"
 
 function _completion_lists() {
@@ -716,6 +716,17 @@ ${Gold}home, -H, --home\033[0m
 
 Description: Set a dedicated \$HOME directory for one or more AppImages.
 
+${Gold}icons, --icons\033[0m
+
+		${LightBlue}$AMCLI --icons {PROGRAM}
+		${LightBlue}$AMCLI --icons --all\033[0m
+
+Description: Allow installed apps to use system icon themes. You can specify \
+the name of the apps to change or use the \"--all\" flag to change all of them \
+at once. This will remove the icon path from the .desktop file and add the \
+symbolic link of all available icons in the $DATADIR/icons/hicolor/scalable/apps \
+directory.
+
 ${Gold}install, -i\033[0m
 
 		${LightBlue}$AMCLI -i {PROGRAM}
@@ -1096,7 +1107,7 @@ case "$1" in
 		;;
 	'backup'|'-b'|\
 	'downgrade'|'--rollback'|\
-	'icon-theme'|\
+	'icons'|'--icons'|\
 	'launcher'|'--launcher'|\
 	'lock'|'unlock'|\
 	'nolibfuse'|\

--- a/README.md
+++ b/README.md
@@ -483,6 +483,13 @@ Description: Prints this message.
 
 Description: Set a dedicated $HOME directory for one or more AppImages.
 
+### `icons, --icons`
+ 
+                --icons {PROGRAM}
+                --icons --all
+ 
+Description: Allow installed apps to use system icon themes. You can specify the name of the apps to change or use the "--all" flag to change all of them at once. This will remove the icon path from the .desktop file and add the symbolic link of all available icons in the $HOME/.local/share/icons/hicolor/scalable/apps directory.
+
 ### `install, -i`
 
 		-i {PROGRAM}

--- a/modules/management.am
+++ b/modules/management.am
@@ -106,12 +106,18 @@ function _downgrade() {
 }
 
 # ICON THEME CHANGER
+function _icon_theme_export_to_datadir() {
+	[ -d "$APPSPATH/$arg/icons" ] && mkdir -p "$DATADIR"/icons && rsync -avq "$APPSPATH"/"$arg"/icons/* "$DATADIR"/icons/ \
+	&& find "$DATADIR"/icons -type f ! -name "*.*" -exec mv {} {}.png \;
+}
+
 function _icon_theme() {
 	if [ "$AMCLI" = am ]; then
 		$SUDOCMD sed -i "s#Icon=$APPSPATH/$arg/icons/#Icon=#g" /usr/local/share/applications/"$arg"*AM.desktop 2>/dev/null
 	else
 		sed -i "s#Icon=$APPSPATH/$arg/icons/#Icon=#g" "$DATADIR"/applications/"$arg"*AM.desktop 2>/dev/null
 	fi
+	_icon_theme_export_to_datadir
 }
 
 # LAUNCHER

--- a/modules/management.am
+++ b/modules/management.am
@@ -105,6 +105,15 @@ function _downgrade() {
 	echo "ROLLBACK SUCCESSFUL!"
 }
 
+# ICON THEME CHANGER
+function _icon_theme() {
+	if [ "$AMCLI" = am ]; then
+		$SUDOCMD sed -i "s#Icon=$APPSPATH/$arg/icons/#Icon=#g" /usr/local/share/applications/"$arg"*AM.desktop 2>/dev/null
+	else
+		sed -i "s#Icon=$APPSPATH/$arg/icons/#Icon=#g" "$DATADIR"/applications/"$arg"*AM.desktop 2>/dev/null
+	fi
+}
+
 # LAUNCHER
 function _launcher_appimage_extract() {
 	"$arg" --appimage-extract share/icons/*/*/* 1>/dev/null
@@ -329,6 +338,18 @@ case "$1" in
 			_clean_amcachedir
 			_list_updatable_apps
 			shift
+		done
+		;;
+
+	'icon-theme')
+		# Place local AppImages into the menu by dragging and dropping them into the terminal
+		if [ "$2" = "--all" ]; then
+			ARGS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null | sort -rh | sed 's@.*	@@')
+		else
+			ARGS="$(echo "$@" | cut -f2- -d ' ')"
+		fi
+		for arg in $ARGS; do
+			_icon_theme "${@}"
 		done
 		;;
 

--- a/modules/management.am
+++ b/modules/management.am
@@ -107,8 +107,9 @@ function _downgrade() {
 
 # ICON THEME CHANGER
 function _icon_theme_export_to_datadir() {
-	[ -d "$APPSPATH/$arg/icons" ] && mkdir -p "$DATADIR"/icons && rsync -avq "$APPSPATH"/"$arg"/icons/* "$DATADIR"/icons/ \
-	&& find "$DATADIR"/icons -type f ! -name "*.*" -exec mv {} {}.png \;
+	[ -d "$APPSPATH/$arg/icons" ] && mkdir -p "$DATADIR"/icons \
+	&& find "$APPSPATH"/"$arg"/icons -type f ! -name "*.*" -exec cp {} {}.png \; \
+	&& rsync -avq "$APPSPATH"/"$arg"/icons/*.png "$DATADIR"/icons/ && rm -f "$APPSPATH"/"$arg"/icons/*.png
 }
 
 function _icon_theme() {

--- a/modules/management.am
+++ b/modules/management.am
@@ -358,7 +358,7 @@ case "$1" in
 		done
 		;;
 
-	'icon-theme')
+	'icons'|'--icons')
 		# Place local AppImages into the menu by dragging and dropping them into the terminal
 		if [ "$2" = "--all" ]; then
 			ARGS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null | sort -rh | sed 's@.*	@@')

--- a/modules/management.am
+++ b/modules/management.am
@@ -362,12 +362,19 @@ case "$1" in
 		# Place local AppImages into the menu by dragging and dropping them into the terminal
 		if [ "$2" = "--all" ]; then
 			ARGS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2>/dev/null | sort -rh | sed 's@.*	@@')
+			read -r -p " ◆ Do you wish to allow custom icon theming for ALL the apps? (y,N) " yn
 		else
 			ARGS="$(echo "$@" | cut -f2- -d ' ')"
+			read -r -p " ◆ Do you wish to allow custom icon theming for the selected apps? (y,N) " yn
 		fi
-		for arg in $ARGS; do
-			_icon_theme "${@}"
-		done
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			for arg in $ARGS; do
+				_icon_theme "${@}"
+			done
+			echo " ✔ Success!"
+		else
+			echo " ✖ Aborted!"
+		fi
 		;;
 
 	'launcher'|'--launcher')

--- a/programs/x86_64/mcpelauncher
+++ b/programs/x86_64/mcpelauncher
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=mcpelauncher
-SITE="minecraft-linux/mcpelauncher-manifest"
+SITE="minecraft-linux/appimage-builder"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,13 +12,13 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | sed 's/[()",{} ]/\n/g' | grep -oi 'https.*minecraft.*x86_64.*mage$' | head -1)
-wget "$version" || exit 1
-#wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync
+version=$(curl -Ls https://api.github.com/repos/minecraft-linux/appimage-builder/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*launcher-x86_64.*mage$" | head -1 | tr '/' '\n' | grep "[[:digit:]]$" | sed 's/-/./g')
+wget "$(curl -Ls https://api.github.com/repos/minecraft-linux/appimage-builder/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*launcher-x86_64.*mage$" | head -1)" || exit 1
+# Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
-mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
+# Keep this space in sync with other installation scripts
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
 chmod a+x ./"$APP" || exit 1
@@ -31,18 +31,17 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=mcpelauncher
-SITE="minecraft-linux/mcpelauncher-manifest"
+SITE="minecraft-linux/appimage-builder"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/"$SITE"/releases | sed 's/[()",{} ]/\n/g' | grep -oi 'https.*minecraft.*x86_64.*mage$' | head -1)
+version=$(curl -Ls https://api.github.com/repos/minecraft-linux/appimage-builder/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*launcher-x86_64.*mage$" | head -1 | tr '/' '\n' | grep "[[:digit:]]$" | sed 's/-/./g')
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
+if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
-	[ -e /opt/"$APP"/*.zsync [ -e ../*.zsync ] || notify-send "A new version of $APP is available, please wait"
-	[ -e /opt/"$APP"/*.zsync ] && wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
+	notify-send "A new version of $APP is available, please wait"
+	wget "$(curl -Ls https://api.github.com/repos/minecraft-linux/appimage-builder/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*launcher-x86_64.*mage$" | head -1)" || exit 1
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
-	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
-	[ -e /opt/"$APP"/*.zsync ] && { zsync "/opt/$APP/$APP.zsync" || notify-send -u critical "zsync failed to update $APP"; }
+	mv --backup=t ./tmp/*mage ./"$APP"
 	chmod a+x ./"$APP" || exit 1
 	echo "$version" > ./version
 	rm -R -f ./*zs-old ./*.part ./tmp ./*~
@@ -54,17 +53,16 @@ EOF
 chmod a+x ./AM-updater || exit 1
 
 # LAUNCHER & ICON
-cd "/opt/$APP" || exit 1
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
 	if [ -L ./"$APP".desktop ]; then
-		LINKPATH=$(readlink ./"$APP".desktop)
+		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
 	fi
 	if [ -L ./DirIcon ]; then
-		LINKPATH=$(readlink ./DirIcon)
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
 	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break


### PR DESCRIPTION
All it does is use "`sed`" to remove the "$APPSPATH"/"$arg"/icons path from the launcher, at the "Icon=" entry in the .desktop file.

It is intended to be used both for single/multiple applications (adding the name/names) and for all of them at once.

Syntax (temporary):
```
am icon-theme $APP
am icon-theme --all
```
or
```
appman icon-theme $APP
appman icon-theme --all
```

"AM" requires a password, while "AppMan" always works without special permissions (as always).

To reverse this option, you need to remove/reinstall the app, or add the path manually to the .desktop file.

Fix https://github.com/ivan-hc/AM/issues/922