### PR TITLE
Create lists of AppImages from the related page of the catalogue

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.2"
+AMVERSION="8.2-1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/modules/database.am
+++ b/modules/database.am
@@ -302,7 +302,7 @@ _list_appimages() {
 	if ! test -f "$AMCACHEDIR/$ARCH-appimages"; then
 		_online_check
 		for appimage in $APPIMAGE_NAMES; do
-			grep "◆ $appimage :" ~/.local/share/AM/"$ARCH"-apps >> "$AMCACHEDIR/$ARCH-appimages" &
+			grep "◆ $appimage :" "$AMDATADIR/$ARCH-apps" >> "$AMCACHEDIR/$ARCH-appimages" &
 		done
 	fi
 	AVAILABLE_APPIMAGES_NUMBER=$(grep -e "$" -c "$AMCACHEDIR/$ARCH-appimages")

--- a/modules/database.am
+++ b/modules/database.am
@@ -298,12 +298,12 @@ _list() {
 
 _list_appimages() {
 	# Determine the number of available apps
-	APPIMAGES_ARGS=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g')
+	APPIMAGE_NAMES=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g')
 	if ! test -f "$AMCACHEDIR/$ARCH-appimages"; then
 		_online_check
-		for appimage in $APPIMAGES_ARGS; do
+		for appimage in $APPIMAGE_NAMES; do
 			grep "◆ $appimage :" ~/.local/share/AM/"$ARCH"-apps >> "$AMCACHEDIR/$ARCH-appimages" &
-		done 
+		done
 	fi
 	AVAILABLE_APPIMAGES_NUMBER=$(grep -e "$" -c "$AMCACHEDIR/$ARCH-appimages")
 }

--- a/modules/database.am
+++ b/modules/database.am
@@ -298,8 +298,12 @@ _list() {
 
 _list_appimages() {
 	# Determine the number of available apps
+	APPIMAGES_ARGS=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g')
 	if ! test -f "$AMCACHEDIR/$ARCH-appimages"; then
-		_online_check && curl -Ls "$AMREPO/programs/$ARCH-appimages" > "$AMCACHEDIR/$ARCH-appimages"
+		_online_check
+		for appimage in $APPIMAGES_ARGS; do
+			grep "◆ $appimage :" ~/.local/share/AM/"$ARCH"-apps >> "$AMCACHEDIR/$ARCH-appimages" &
+		done 
 	fi
 	AVAILABLE_APPIMAGES_NUMBER=$(grep -e "$" -c "$AMCACHEDIR/$ARCH-appimages")
 }
@@ -385,10 +389,7 @@ case "$1" in
 			ARGS="$(echo "$@" | cut -f3- -d ' ')"
 			printf "\n Search results for \"%s\":\n\n"  "$ARGS" | tr '[:lower:]' '[:upper:]'
 			PATTERN="$(echo "$ARGS" | sed 's/ /(?=.*/g; s/$/)/g; s/(/)(/g; s/^/(?=.*/g;')"
-			if ! test -f "$AMCACHEDIR/$ARCH-appimages"; then
-				_online_check
-				curl -Ls "$AMREPO/programs/$ARCH-appimages" > "$AMCACHEDIR/$ARCH-appimages"
-			fi
+			_list_appimages
 			grep -Pi "$PATTERN" "$AMCACHEDIR/$ARCH-appimages" | _pretty_list_compat
 		else
 			ARGS="$(echo "$@" | cut -f2- -d ' ')"

--- a/modules/install.am
+++ b/modules/install.am
@@ -377,8 +377,12 @@ case "$1" in
 			rm -f "$AMCACHEDIR"/install-args
 			ARGS="$(echo "$@" | cut -f2- -d ' ' | tr ' ' '\n' | grep -v -- "--")"
 		fi
+		APPIMAGE_NAMES=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g')
+		rm -f "$AMCACHEDIR/$ARCH-appimages"
+		for appimage in $APPIMAGE_NAMES; do
+			grep "◆ $appimage :" "$AMDATADIR/$ARCH-apps" >> "$AMCACHEDIR/$ARCH-appimages" &
+		done
 		for arg in $ARGS; do
-			curl -Ls "$AMREPO/programs/$ARCH-appimages" > "$AMCACHEDIR/$ARCH-appimages"
 			if grep -q "^◆ $arg : " "$AMCACHEDIR/$ARCH-appimages"; then
 				echo "$arg" >> "$AMCACHEDIR"/install-args
 			else

--- a/tools/am2pla-site
+++ b/tools/am2pla-site
@@ -211,6 +211,7 @@ _appimages_listing
 _appimages_list_header
 _appimages_list_body
 _footer_categories >> appimages.md
+rm -f ./"$arch-appimages"
 
 ##################
 # OTHER CATEGORIES


### PR DESCRIPTION
This change aims to remove the AppImages lists from this repo to get it from the related page of the catalogue, at https://portable-linux-apps.github.io/appimages.md

Affected options: `-l`, `-q` and `-ia`

The variable to get the names of the AppImages is
```
APPIMAGE_NAMES=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g')
```
used in
```
for appimage in $APPIMAGE_NAMES; do
	grep "◆ $appimage :" "$AMDATADIR/$ARCH-apps" >> "$AMCACHEDIR/$ARCH-appimages" &
done
```
options `-l` and `-q` can still read the available list offline, while `-ia` or `install-appimage` will create a new one.

This change will also ease my workflow when I need to update the catalog, after working on "AM", by reducing commits.