### PR TITLE
Add "less" among core dependences

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.2-1"
+AMVERSION="8.2-2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -190,7 +190,7 @@ APPSLISTDB="$AMREPO/programs/$arch-apps"
 function _am_dependences_check() {
 	# Check for essential commands required by the application
 	missing_deps=()
-	AMDEPENDENCES="cat chmod chown curl grep sed wget"
+	AMDEPENDENCES="cat chmod chown curl grep less sed wget"
 	for name in $AMDEPENDENCES; do
 		if ! command -v "$name" &>/dev/null; then
 			missing_deps+=("$name")

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Below are the **essential system dependencies** that you must install before pro
 - "`coreutils`" (contains "`cat`", "`chmod`", "`chown`"...);
 - "`curl`", to check URLs;
 - "`grep`", to check files;
+- "`less`", to read the ever-longer lists;
 - "`sed`", to edit/adapt installed files;
 - "`wget`" to download all programs and update "AM"/"AppMan" itself.
 


### PR DESCRIPTION
Given the repeated reading errors of many users without "less", the latter is now a core dependency.

Having "less" installed guarantees the reading of the (increasingly long) application lists and the help message, as well as the newly introduced text colorization. In fact, the "`less`" command is used by both `-l`/`list` and `-h`/`help`.