### PR TITLE
Add `keepassxc-devel`

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1066,6 +1066,7 @@
 ◆ kdiskmark : A simple open-source disk benchmark tool for Linux distros.
 ◆ keditbookmarks : Unofficial, Bookmarks editor. This script installs the full "kdeutils" suite.
 ◆ keepassxc : Port of the Windows application “Keepass Password Safe”.
+◆ keepassxc-devel : Port of the Windows application “Keepass Password Safe”, dev-edition.
 ◆ keeweb : Free cross-platform password manager compatible with KeePass.
 ◆ keibo-moneytracker-x86-64 : Track your income and expenses easily.
 ◆ kettleclient : Client for Kettle REST service.

--- a/programs/x86_64/keepassxc-devel
+++ b/programs/x86_64/keepassxc-devel
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=keepassxc-devel
+SITE="https://snapshot.keepassxc.org/latest/"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -qfsSL "$SITE" | grep -o 'href="[^"]*"' | sed 's/href="//; s/.DIGEST//; s/"//g' | grep -i ".*x86_64.*appimage$" | head -1)
+wget "https://snapshot.keepassxc.org/latest/$version" || exit 1
+# Keep this space in sync with other installation scripts
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=keepassxc-devel
+SITE="https://snapshot.keepassxc.org/latest/"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -qfsSL "$SITE" | grep -o 'href="[^"]*"' | sed 's/href="//; s/.DIGEST//; s/"//g' | grep -i ".*x86_64.*appimage$" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "https://snapshot.keepassxc.org/latest/$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root

--- a/programs/x86_64/keepassxc-devel
+++ b/programs/x86_64/keepassxc-devel
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -qfsSL "$SITE" | grep -o 'href="[^"]*"' | sed 's/href="//; s/.DIGEST//; s/"//g' | grep -i ".*x86_64.*appimage$" | head -1)
+version=$(curl -Ls "$SITE" | tr '"><' '\n' | grep -i ".*x86_64.*appimage$" | head -1)
 wget "https://snapshot.keepassxc.org/latest/$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -33,7 +33,7 @@ set -u
 APP=keepassxc-devel
 SITE="https://snapshot.keepassxc.org/latest/"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -qfsSL "$SITE" | grep -o 'href="[^"]*"' | sed 's/href="//; s/.DIGEST//; s/"//g' | grep -i ".*x86_64.*appimage$" | head -1)
+version=$(curl -Ls "$SITE" | tr '"><' '\n' | grep -i ".*x86_64.*appimage$" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1


### PR DESCRIPTION
[Fixes this comment](https://github.com/topgrade-rs/topgrade/issues/906#issuecomment-2380552826)

Note I had to disable the `appimageupdatetool` check because keepassxc would be updated to the github release otherwise, as the update info it has points to github, so this app will update using the version comparison method instead.

![image](https://github.com/user-attachments/assets/87ab3a74-c648-489a-bd1e-c50f43d3a4e3)

[kesspassxc-devel.md](https://github.com/user-attachments/files/17173811/kesspassxc-devel.md)

