### PR TITLE
Remove version check in .zsync files

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.3"
+AMVERSION="8.3-1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -337,11 +337,6 @@ function _check_version_if_any_version_reference_is_somewhere() {
 	APPVERSION=$(grep -i "version=" "$APPSPATH"/"$arg"/* 2>/dev/null | _check_version_grep_numbers)
 }
 
-function _check_version_if_zsync_file_exists() {
-	APPVERSION=$(strings -d ./"$arg"/*.zsync | grep -i "$(echo "$arg" | sed 's/-appimage//g')" | _check_version_grep_numbers)
-	[ -z "$APPVERSION" ] && APPVERSION=$(date -r ./"$arg"/*.zsync "+%Y.%m.%d")
-}
-
 function _check_version_if_version_file_exists() {
 	APPVERSION=$(sort "$APPSPATH"/"$arg"/version | head -1 | sed 's:.*/::' | _check_version_filters)
 	if [ -z "$APPVERSION" ]; then
@@ -384,9 +379,7 @@ function _check_version() {
 	sort -rh | sed 's@.*	@@')
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/remove 2>/dev/null; then
-			if test -f ./"$arg"/*.zsync 2>/dev/null; then
-				_check_version_if_zsync_file_exists
-			elif test -f ./"$arg"/version 2>/dev/null; then
+			if test -f ./"$arg"/version 2>/dev/null; then
 				_check_version_if_version_file_exists
 			elif test -f ./"$arg"/updater 2>/dev/null; then
 				_check_version_if_an_updater_exists


### PR DESCRIPTION
The .zsync file based version checking is often incorrect, so from now on the "version" file will be used as the primary method.

If you have any issues getting a version for any app, please report it in the issues.