### PR TITLE
Change ryujinx appimage to hard-fork

### DIFF
--- a/programs/x86_64/ryujinx
+++ b/programs/x86_64/ryujinx
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=ryujinx
-SITE="Samueru-sama/Ryujinx-AppImage"
+SITE="ryujinx-mirror/ryujinx"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/Samueru-sama/Ryujinx-AppImage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "https.*ryujinx.*appimage$" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ryujinx-mirror/ryujinx/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -31,10 +31,14 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=ryujinx
-SITE="Samueru-sama/Ryujinx-AppImage"
+SITE="ryujinx-mirror/ryujinx"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/Samueru-sama/Ryujinx-AppImage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "https.*ryujinx.*appimage$" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ryujinx-mirror/ryujinx/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	notify-send "A new version of $APP is available, please wait"


### PR DESCRIPTION
I will archive my repo now that the main fork of Ryu has working [appimage builds](https://github.com/ryujinx-mirror/ryujinx/releases/tag/r.dc545c3).

Also unless there are so big changes, this fork seems to be what will be the "official" ryujinx, so the unofficial on the description of the appimage will be dropped soon as well.