### PR TITLE
fix missing var and export PATH

### DIFF
--- a/AM-INSTALLER
+++ b/AM-INSTALLER
@@ -50,12 +50,12 @@ _install_appman() {
 		if [ -e ~/.bashrc ] && ! grep 'PATH="$PATH:$BINDIR"' ~/.bashrc >/dev/null 2>&1; then
 			printf '\n%s\n' 'BINDIR="${XDG_BIN_HOME:-$HOME/.local/bin}"' >> ~/.bashrc
 			printf '\n%s\n' 'if ! echo $PATH | grep "$BINDIR" >/dev/null 2>&1; then' >> ~/.bashrc
-			printf '	PATH="$PATH:$BINDIR"\nfi\n' >> ~/.bashrc
+			printf '	export PATH="$PATH:$BINDIR"\nfi\n' >> ~/.bashrc
 		fi
-		if [ -e "$ZPROFILE" ] && ! grep 'PATH="$PATH:$BINDIR"' "$ZSHRC" >/dev/null 2>&1; then
+		if [ -e "$ZSHRC" ] && ! grep 'PATH="$PATH:$BINDIR"' "$ZSHRC" >/dev/null 2>&1; then
 			printf '\n%s\n' 'BINDIR="${XDG_BIN_HOME:-$HOME/.local/bin}"' >> "$ZSHRC"
 			printf '\n%s\n' 'if ! echo $PATH | grep "$BINDIR" >/dev/null 2>&1; then' >> "$ZSHRC"
-			printf '	PATH="$PATH:$BINDIR"\nfi\n' >> "$ZSHRC"
+			printf '	export PATH="$PATH:$BINDIR"\nfi\n' >> "$ZSHRC"
 		fi
 	fi
 	wget -q https://raw.githubusercontent.com/ivan-hc/AM/main/APP-MANAGER -O "$BINDIR"/appman && chmod a+x "$BINDIR"/appman


### PR DESCRIPTION
ZPROFILE no longer exists since now it is the zshrc that gets patched.

And exported PATH to make sure everything has access to BINDIR, because right now without the export apps launched after login not on the terminal may fail to find other apps in BINDIR.