### PR TITLE
Add a blacklist for files that may cause issues to "AM"/"AppMan"

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -221,6 +221,22 @@ function _online_check() {
 	fi
 }
 
+# BLACKLIST FILES
+function _blacklisted_file() {
+	echo ""
+	echo -e " ${RED}💀WARNING! Detected \"$blacklisted_file\"\033[0m"
+	echo ""
+	echo "It will prevent \"$AMCLIUPPER\" from working correctly with AppImages, especially when extracting, integrating and updating them." | fold -sw 77 | sed 's/^/ /g'
+	echo ""
+	echo " Please remove \"$blacklisted_file\", reboot and retry!"
+	echo ""
+	exit 0
+}
+
+if command -v appimaged &>/dev/null; then
+	blacklisted_file=$(command -v appimaged) _blacklisted_file
+fi
+
 ################################################################################
 #				3RD PARTY
 ################################################################################

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -222,19 +222,31 @@ function _online_check() {
 }
 
 # BLACKLIST FILES
+appimagelauncher_msg="Your installation of AppImageLauncher may have been done via DEB, RPM, or AUR, which interrupts the \
+natural operation of \"systemd-binfmt\" in addition to launching the aforementioned daemon. To avoid problems with "$AMCLIUPPER" \
+and any other AppImages helper, it's preferable to use \"only\" the standalone AppImage of AppImageLauncher, whose official \
+updated release can also be installed via \"$AMCLIUPPER\". But as long as you have the currently installed version, you can't use this CLI."
+
 function _blacklisted_file() {
 	echo ""
 	echo -e " ${RED}💀WARNING! Detected \"$blacklisted_file\"\033[0m"
 	echo ""
 	echo "It will prevent \"$AMCLIUPPER\" from working correctly with AppImages, especially when extracting, integrating and updating them." | fold -sw 77 | sed 's/^/ /g'
 	echo ""
-	echo " Please remove \"$blacklisted_file\", reboot and retry!"
+	if echo "$blacklisted_file" | grep -q appimagelauncherd; then
+		echo "$appimagelauncher_msg" | fold -sw 77 | sed 's/^/ /g'
+		echo "" && echo " Please remove \"AppImageLauncher\", reboot and retry!"
+	else
+		echo " Please remove \"$blacklisted_file\", reboot and retry!"
+	fi
 	echo ""
 	exit 0
 }
 
 if command -v appimaged &>/dev/null; then
 	blacklisted_file=$(command -v appimaged) _blacklisted_file
+elif command -v appimagelauncherd &>/dev/null; then
+	blacklisted_file=$(command -v appimagelauncherd) _blacklisted_file
 fi
 
 ################################################################################

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.3-2"
+AMVERSION="8.3.1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -223,7 +223,7 @@ function _online_check() {
 
 # BLACKLIST FILES
 appimagelauncher_msg="Your installation of AppImageLauncher may have been done via DEB, RPM, or AUR, which interrupts the \
-natural operation of \"systemd-binfmt\" in addition to launching the aforementioned daemon. To avoid problems with "$AMCLIUPPER" \
+natural operation of \"systemd-binfmt\" in addition to launching the aforementioned daemon. To avoid problems with \"$AMCLIUPPER\" \
 and any other AppImages helper, it's preferable to use \"only\" the standalone AppImage of AppImageLauncher, whose official \
 updated release can also be installed via \"$AMCLIUPPER\". But as long as you have the currently installed version, you can't use this CLI."
 


### PR DESCRIPTION
fix https://github.com/ivan-hc/AM/issues/988

The cataloging of programs, daemons, libraries and services that could compromise the functioning of "AM" begins.

It often happens that some AppImage package manager in the form of a service or system daemon, takes control of such packages, preventing other managers, such as "AM", from being able to manage them as well.

For example, it could prevent the extraction of the package (to obtain the launcher and the icon), the cataloging of installed apps based on the format, even the updating of them. All this can appear in the form of error messages like this:
```
❯ appman install evince baobab-gtk3
============================================================================

                  START OF ALL INSTALLATION PROCESSES

============================================================================

 ◆ "EVINCE": starting installation script

Document-Viewer_46.3.1-2- 100%[===================================>]  55.69M  6.23MB/s    in 9.1s    
This doesn't look like a squashfs image.
Failed to open squashfs image
This doesn't look like a squashfs image.
Failed to open squashfs image
sed: can't read ./evince.desktop: No such file or directory
mv: cannot stat './evince.desktop': No such file or directory

 "EVINCE" INSTALLED (56 MB OF DISK SPACE)
____________________________________________________________________________

 ◆ "BAOBAB-GTK3": starting installation script

Disk_Usage_Analyzer-3.38. 100%[===================================>]   3.74M  3.83MB/s    in 1.0s    
This doesn't look like a squashfs image.
Failed to open squashfs image
This doesn't look like a squashfs image.
Failed to open squashfs image
sed: can't read ./baobab-gtk3.desktop: No such file or directory
mv: cannot stat './baobab-gtk3.desktop': No such file or directory

 "BAOBAB-GTK3" INSTALLED (4 MB OF DISK SPACE)
____________________________________________________________________________
============================================================================
```
and the user who doesn't know where the problem is, will blame the new AppImage manager for this failure.

We don't want this to happen again!

------------------------------

# 1. appimaged
The first blacklisted file is the program and system daemon "**appimaged**", guilty of recognizing all AppImage files in the system to integrate them, causing the addition of more entries in the application menu (sometimes broken and not well patched), and managing updates differently from the one supported by "AM", compromising its scheme.

From now on, its presence will be reported, preventing the use of "AM" and explaining the reason via message.

![Istantanea_2024-10-11_02-13-03 png](https://github.com/user-attachments/assets/65039385-b81e-40a8-bad6-b5b56e50d42f)
