### PR TITLE
added apps

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -105,6 +105,7 @@
 ◆ archipel : Decentralized archiving and media library system.
 ◆ arduino-ide : Open-source electronics platform.
 ◆ arena-tracker : Deck Tracker for Hearthstone game with arena in focus.
+◆ aretext : Minimalist text editor with vim-compatible key bindings.
 ◆ arkaway : Another Arkanoid clone and make with Pyxel.
 ◆ ark.desktop.wallet : Ark Ecosystem Desktop Wallet.
 ◆ ark : Unofficial. Archiving tool for .zip/.tar/.rar and more. This script installs the full "kdeutils" suite.
@@ -181,6 +182,7 @@
 ◆ billyfrontier : Pangea Software’s Billy Frontier for modern systems.
 ◆ binclock : Binary clock in terminal.
 ◆ bin : Effortless binary manager.
+◆ binfinder : Find binary files not installed through package manager.
 ◆ bingada : Bingo application in GTKAda.
 ◆ binglite : A lightweight new Bing (AI chat) desktop application based on Tauri.
 ◆ bioanimation : CCNY Electrochemical Gradient Simulator.
@@ -233,6 +235,7 @@
 ◆ bottles : Unofficial. Manage wine prefixes and run Windows software & games in a new way.
 ◆ bottom : Yet another cross-platform graphical process/system monitor.
 ◆ bovo : Unofficial. Five in a row game from. This script installs the full "kdegames" suite.
+◆ boxxy : Put bad Linux applications in a box with only their files.
 ◆ brackets : Brackets-Electron.
 ◆ brainverse : Electronic Lab Notebook for Reproducible Neuro Imaging Research.
 ◆ brainwaves : EEG Desktop Application.
@@ -249,6 +252,7 @@
 ◆ brisqi : Offline-first Personal Kanban app.
 ◆ brs-emu-app : BrightScript Emulator, runs on browsers and Electron apps.
 ◆ bruno : An Opensource API Collection Collaboration Suite.
+◆ brutespray : Bruteforcing from various scanner output. Automatically attempts default creds on found services.
 ◆ bscanfftwebcam : FDOCT tool.
 ◆ btop : A command line utility to monitor system resources, like Htop.
 ◆ bts-ce-lite : Telecommunication network management application.
@@ -405,6 +409,7 @@
 ◆ coreuniverse : Shows releated information of apps from CuboCore App Suite.
 ◆ cosmic-comics : Web Server based Comics / Manga Collectionner & viewer.
 ◆ cosmonium : 3D astronomy and space exploration program.
+◆ cowitness : A powerful web app testing tool that enhances the accuracy and efficiency of your testing efforts.
 ◆ cozydrive : File Synchronisation for Cozy, cloud.
 ◆ cpeditor : Code editor specially designed for competitive programming.
 ◆ cpod : A simple, beautiful podcast app.
@@ -458,6 +463,7 @@
 ◆ dbee : Fast & Minimalistic Database Browser.
 ◆ dbet-wallet : DBET Wallet.
 ◆ dbgate : Opensource database administration tool
+◆ dbin : Poor man's package manager. About 3000 statically linked binaries in the repos!
 ◆ deadbeef : A modular cross-platform audio player.
 ◆ deadbeef-appimage : Unofficial AppImage of the DeaDBeeF music player. Stable build.
 ◆ deadbeef-nightly : A modular cross-platform audio player. Nightly build.
@@ -800,20 +806,24 @@
 ◆ ghrel : Download and verify GitHub release.
 ◆ giada : Hardcore audio music production tool and drum machine for DJs.
 ◆ gibs : Generally In-source Build System, build C++ projects without a project.
+◆ gickup : Backup your Git repositories with ease.
 ◆ gifcurry : The open-source, Haskell-built video editor for GIF makers.
 ◆ gimp-dev : Unofficial, Cross-platform image and photo editor, Developer Edition.
 ◆ gimp-git : Unofficial, Cross-platform image and photo editor, built from GIT.
 ◆ gimp-hybrid : Unofficial, GIMP including third-party plugins and python2 support.
 ◆ gimp : Unofficial, GNU Image Manipulation Program, cross-platform image and photo editor.
 ◆ gingko : Gingko client rewritten in Elm.
+◆ git-cliff : A highly customizable Changelog Generator that follows Conventional Commit specifications.
 ◆ git-good : Just a simple git client using electron and nodegit.
 ◆ githoard : Hoard git repositories with ease.
 ◆ github-desktop : Electron-based GitHub app.
 ◆ gitify : GitHub notifications on your menu bar.
 ◆ gitjournal : Mobile first Note Taking integrated with Git.
 ◆ gitkraken : GitKraken Client including an intuitive GUI & powerful CLI.
+◆ gitleaks : Protect and discover secrets using Gitleaks.
 ◆ gitlight : GitHub & GitLab notifications on your desktop.
 ◆ gitnote : A modern note taking app based on GIT.
+◆ gitql : A git query language.
 ◆ gitqlient : Multi-platform Git client written with Qt.
 ◆ gitui : Blazing fast terminal-ui for git written in rust.
 ◆ glab : A GitLab CLI tool bringing GitLab to your command line.
@@ -833,6 +843,7 @@
 ◆ gnome-system-monitor3 : Unofficial, Version 3.38.0, for all those who hate GNOME4+ UIs.
 ◆ gnome-tweaks : Unofficial, Experimental AppImage port of advanced GNOME 3 settings GUI.
 ◆ gnumeric : Unofficial. An open-source spreadsheet program.
+◆ godmode : AI Chat Browser fast, full webapp access to ChatGPT/Claude/Bard/Bing/Llama2.
 ◆ godot : Multi-platform 2D and 3D game engine with a feature-rich editor.
 ◆ gojq : Pure Go implementation of jq.
 ◆ gokey : A simple vaultless password manager in Go.
@@ -850,15 +861,16 @@
 ◆ google-task-tauri : An Unofficial Desktop Client for Google Tasks.
 ◆ gooseberry : A command line utility to generate a knowledge base from Hypothesis annotations.
 ◆ gopass : The slightly more awesome standard unix password manager for teams.
-◆ goverlay : An opensource project that aims to create a Graphical UI to help manage Linux overlays.
 ◆ go-pd : A free easy to use pixeldrain.com go client pkg and CLI upload tool.
 ◆ go-pd-gui : DRAINY is a free easy to use cross plattform upload tool for pixeldrain.com.
 ◆ gopeed : A modern download manager that supports all platforms.
 ◆ gospel : Poppler based fast pdf viewer written in PyQt5.
 ◆ go-spotify-cli : Control Spotify with CLI commands.
+◆ gost-shred : GOST R 50739-95 Data Sanitization Method (2 passes).
 ◆ gotimer : A simple terminal based digital timer for Pomodoro.
 ◆ goto : A simple terminal SSH manager that lists favorite SSH servers.
 ◆ got : Simple golang package and CLI tool to download large files faster than cURL and Wget!
+◆ goverlay : An opensource project that aims to create a Graphical UI to help manage Linux overlays.
 ◆ gpgfrontend : A Cross-Platform OpenPGP Frontend Software.
 ◆ gpg-tui : CLI, manage your GnuPG keys with ease!
 ◆ gping : Ping, but with a graph.
@@ -919,6 +931,7 @@
 ◆ hide.me : Hide.me CLI VPN client for Linux.
 ◆ hidpi-fixer : Fractional scaling configuration on X11 desktops.
 ◆ hilbish : The Moon-powered shell! A comfy and extensible shell for Lua fans!
+◆ himalaya : CLI to manage emails.
 ◆ hoptodesk : Allows users to share their screens and remotely control access.
 ◆ hotspot : The Linux perf GUI for performance analysis.
 ◆ houdoku : Manga reader and library manager for the desktop.
@@ -983,6 +996,7 @@
 ◆ invoice-generator : Invoice Generator in Electron.
 ◆ iota1k : IOTA based messenging app.
 ◆ ipfs-desktop : An unobtrusive and user-friendly app for IPFS on Linux.
+◆ iptracker : Desktop tool to keep track of your IP address and update you when it changes.
 ◆ iptvnator : IPTV player application.
 ◆ ipuissance-4d : Connect Four video game with a 3-Dimentional rendering.
 ◆ iqpuzzle : A diverting I.Q. challenging pentomino puzzle.
@@ -1074,6 +1088,7 @@
 ◆ keditbookmarks : Unofficial, Bookmarks editor. This script installs the full "kdeutils" suite.
 ◆ keepassxc-devel : Port of the Windows application “Keepass Password Safe”, dev-edition.
 ◆ keepassxc : Port of the Windows application “Keepass Password Safe”.
+◆ keep : Desktop app for Google Keep.
 ◆ keeweb : Free cross-platform password manager compatible with KeePass.
 ◆ keibo-moneytracker-x86-64 : Track your income and expenses easily.
 ◆ kettleclient : Client for Kettle REST service.
@@ -1164,6 +1179,7 @@
 ◆ lcedit : Editor, unknown.
 ◆ ldtk : Modern and efficient 2D level editor.
 ◆ ldview : LDraw Model Viewer.
+◆ leaflet : POSP official notes application, written in flutter, beautiful, fast and secure.
 ◆ leapp : The DevTool to access your cloud.
 ◆ led.custom.palette : Design the lights on your Model01 with an ease.
 ◆ ledger-live-desktop : Wallet desktop app for multiple cryptocurrencies.
@@ -1362,8 +1378,8 @@
 ◆ mqtt-explorer : Explore your message queues.
 ◆ mqttx : MQTT 5.0 Desktop, CLI, and WebSocket client tools.
 ◆ mrcode : An opinionated editor based on VSCodium / VSCode.
-◆ mrwriter : Notetaking and blackboard replacement application. Inspired by Xournal. Written in C++/Qt.
 ◆ mr.dclutterer : Minimal App To Aggregate And Rename Files In Bulk.
+◆ mrwriter : Notetaking and blackboard replacement application. Inspired by Xournal. Written in C++/Qt.
 ◆ ms-365-electron : Unofficial Microsoft 365 Desktop Wrapper made with Electron.
 ◆ mtcelledit : Lightweight spreadsheet program.
 ◆ mudita-center : Mudita Center Electron App.
@@ -1618,6 +1634,7 @@
 ◆ pfetch-rs : A rewrite of the pfetch system information tool in Rust.
 ◆ pget : The fastest, resumable file download CLI client.
 ◆ phinch : Phinch is a framework for visualizing biological data.
+◆ pho : The AppImage Manager that Linux always deserved.
 ◆ photocrea : Unofficial Photopea wrapper, image editor that includes all the familiar features like layers, filters, magic wand selection, etc.
 ◆ photoflare : A simple but featureful image editor.
 ◆ photoflow : Edit images from digital cameras.
@@ -1890,6 +1907,7 @@
 ◆ running-dinner-tool : Running Dinner Tool.
 ◆ rustdesk : Virtual/remote desktop infrastructure, like TeamViewer/Citrix.
 ◆ rustdict : A dictionary CLI tool in Rust inspired by BetaPictoris's dict.
+◆ rustypaste : A minimal file upload/pastebin service.
 ◆ rusty-rain : CLI, a cross platform matrix rain made with Rust. 
 ◆ rx-bin : A modern and extensible pixel editor implemented in Rust.
 ◆ ryowallet : Modern GUI interface for Ryo Currency.
@@ -2038,6 +2056,7 @@
 ◆ speed-dreams : A Torcs fork, 3d motorsport simulation and race cars game.
 ◆ speedyloader : Speeduino universal firmware loader.
 ◆ speek : Privacy focused messenger.
+◆ sphia : A Proxy Handling Intuitive Application.
 ◆ spicy-launcher : Cross-platform launcher for Spicy Lobster games.
 ◆ spiritfarer : Spiritfarer, AppImage version.
 ◆ spivak : Karaoke player based on GStreamer and Qt5.
@@ -2075,6 +2094,7 @@
 ◆ stele : Kiosk app wrapper for museum media exhibits.
 ◆ stellarium : Planetarium that shows a realistic sky in 3D.
 ◆ stereophotoview : 3d stereoscopic photo/video viewer and editor.
+◆ stew : An independent package manager for compiled binaries.
 ◆ sticker-convert : Convert animated stickers.
 ◆ stockstalk : Your stocks on your desktop.
 ◆ stoplight : The kickass API platform.
@@ -2303,6 +2323,7 @@
 ◆ valeronoi : Companion app for Valetudo for generating WiFi heat maps.
 ◆ vcloudcam : Solution for the camera systems of gas and fuel stations.
 ◆ vechain : A browser that empowers DApps on VeChain.
+◆ vegeta : HTTP load testing tool and library. It's over 9000!
 ◆ ventoy : Tool to create bootable USB drive for ISO/WIM/IMG/VHDx/EFI files.
 ◆ verto : A multi-currency crypto wallet with support for EOS & VTX.
 ◆ vesktop : Vesktop gives you the performance of web Discord.
@@ -2347,6 +2368,7 @@
 ◆ vnote : Note-taking application for pleasant Markdown.
 ◆ vocabsieve : Simple sentence mining tool for language learning.
 ◆ voicevox : Offical Frontend for the free VOICEVOX TTS Engine.
+◆ volaris : Volaris-Gui is the wrapper for Volaris, a secure file encryption software.
 ◆ vpaint : Experimental vector graphics and 2D animation editor.
 ◆ vrest-ng : Zero code API test automation solution.
 ◆ vrew : Your first video editor, your easiest choice.
@@ -2424,6 +2446,7 @@
 ◆ wootomation : The official Wooting Macros software.
 ◆ wordtsar : Document mode clone for Wordstar, supports Wordstar, RTF and DOCX.
 ◆ workflowy : A notetaking tool.
+◆ wournal : Simple "digitial paper" for note taking and PDF annotation. Heavily inspired by Xournal.
 ◆ wowup : WowUp the World of Warcraft addon updater.
 ◆ wps-office : Unofficial, Office suite built from the official .deb package.
 ◆ wrapbox : An Electron wrapper for web pages.
@@ -2488,6 +2511,7 @@
 ◆ ytmdesktop : A Desktop App for YouTube Music.
 ◆ yts-streaming : Stream or play yts and torrent movies. 
 ◆ yubikey-manager : Configure your YubiKey over all USB transports.
+◆ yup : Arch Linux AUR Helper with ncurses functionality and better searching and sorting.
 ◆ yuview : YUV player with an advanced analytic toolset.
 ◆ zap : Delightful command line AppImage package manager for appimage.github.io.
 ◆ zapdesktop : Desktop application for the lightning network.

--- a/programs/x86_64/aisap
+++ b/programs/x86_64/aisap
@@ -12,13 +12,13 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*$APP.*x86_64.*mage$" | head -1)
 wget "$version" || exit 1
-# Keep this space in sync with other installation scripts
+#wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
-# Keep this space in sync with other installation scripts
+mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
 chmod a+x ./"$APP" || exit 1
@@ -33,19 +33,16 @@ set -u
 APP=aisap
 SITE="mgord9518/aisap"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*$APP.*x86_64.*mage$" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if command -v appimageupdatetool >/dev/null 2>&1; then
-	cd "/opt/$APP" || exit 1
-	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
-fi
-if [ "$version" != "$version0" ]; then
+if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
-	notify-send "A new version of $APP is available, please wait"
-	wget "$version" || exit 1
+	[ -e ../*.zsync ] || notify-send "A new version of $APP is available, please wait"
+	[ -e ../*.zsync ] && wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
-	mv --backup=t ./tmp/*mage ./"$APP"
+	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
+	[ -e ./*.zsync ] && { zsync ./"$APP".zsync || notify-send -u critical "zsync failed to update $APP"; }
 	chmod a+x ./"$APP" || exit 1
 	echo "$version" > ./version
 	rm -R -f ./*zs-old ./*.part ./tmp ./*~
@@ -62,11 +59,11 @@ chmod a+x ./AM-updater || exit 1
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
 	if [ -L ./"$APP".desktop ]; then
-		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
+		LINKPATH=$(readlink ./"$APP".desktop)
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
 	fi
 	if [ -L ./DirIcon ]; then
-		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		LINKPATH=$(readlink ./DirIcon)
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
 	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break

--- a/programs/x86_64/aretext
+++ b/programs/x86_64/aretext
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=aretext
+SITE="aretext/aretext"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/aretext/aretext/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=aretext
+SITE="aretext/aretext"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/aretext/aretext/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/binfinder
+++ b/programs/x86_64/binfinder
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=binfinder
+SITE="aquasecurity/binfinder"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/aquasecurity/binfinder/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "Linux_amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=binfinder
+SITE="aquasecurity/binfinder"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/aquasecurity/binfinder/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "Linux_amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/boxxy
+++ b/programs/x86_64/boxxy
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=boxxy
+SITE="queer/boxxy"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/queer/boxxy/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "unknown-linux-gnu.tar.xz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=boxxy
+SITE="queer/boxxy"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/queer/boxxy/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "unknown-linux-gnu.tar.xz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/brutespray
+++ b/programs/x86_64/brutespray
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=brutespray
+SITE="x90skysn3k/brutespray"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/x90skysn3k/brutespray/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=brutespray
+SITE="x90skysn3k/brutespray"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/x90skysn3k/brutespray/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/cowitness
+++ b/programs/x86_64/cowitness
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=cowitness
+SITE="stolenusername/cowitness"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/stolenusername/cowitness/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=cowitness
+SITE="stolenusername/cowitness"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/stolenusername/cowitness/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/dbin
+++ b/programs/x86_64/dbin
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=dbin
+SITE="xplshn/dbin"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/xplshn/dbin/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "amd64" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=dbin
+SITE="xplshn/dbin"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/xplshn/dbin/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "amd64" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/gickup
+++ b/programs/x86_64/gickup
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=gickup
+SITE="cooperspencer/gickup"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/cooperspencer/gickup/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=gickup
+SITE="cooperspencer/gickup"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/cooperspencer/gickup/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/git-cliff
+++ b/programs/x86_64/git-cliff
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=git-cliff
+SITE="orhun/git-cliff"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/orhun/git-cliff/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64-unknown-linux-gnu.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=git-cliff
+SITE="orhun/git-cliff"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/orhun/git-cliff/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64-unknown-linux-gnu.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/gitleaks
+++ b/programs/x86_64/gitleaks
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=gitleaks
+SITE="gitleaks/gitleaks"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/gitleaks/gitleaks/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_x64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=gitleaks
+SITE="gitleaks/gitleaks"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/gitleaks/gitleaks/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_x64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/gitql
+++ b/programs/x86_64/gitql
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=gitql
+SITE="filhodanuvem/gitql"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/filhodanuvem/gitql/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "Linux_x86_64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=gitql
+SITE="filhodanuvem/gitql"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/filhodanuvem/gitql/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "Linux_x86_64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/godmode
+++ b/programs/x86_64/godmode
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=godmode
+SITE="smol-ai/GodMode"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/smol-ai/GodMode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=godmode
+SITE="smol-ai/GodMode"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/smol-ai/GodMode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/gost-shred
+++ b/programs/x86_64/gost-shred
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=gost-shred
+SITE="pedroalbanese/gost-shred"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/pedroalbanese/gost-shred/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux-x86.zip" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=gost-shred
+SITE="pedroalbanese/gost-shred"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/pedroalbanese/gost-shred/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux-x86.zip" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/himalaya
+++ b/programs/x86_64/himalaya
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=himalaya
+SITE="pimalaya/himalaya"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/pimalaya/himalaya/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64-linux.zip" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=himalaya
+SITE="pimalaya/himalaya"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/pimalaya/himalaya/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "x86_64-linux.tgz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# ICON
+mkdir -p icons
+wget https://raw.githubusercontent.com/pimalaya/himalaya/master/logo.svg -O ./icons/"$APP" 2> /dev/null
+
+# LAUNCHER
+echo "[Desktop Entry]
+Type=Application
+Name=himalaya
+DesktopName=Himalaya
+GenericName=Mail Reader
+Comment=Command-line interface for email management
+Terminal=true
+Exec=himalaya %U
+Categories=Application;Network
+Keywords=email
+MimeType=x-scheme-handler/mailto;message/rfc822
+Actions=Compose
+
+[Desktop Action Compose]
+Name=Compose
+Exec=himalaya write %U" > /usr/local/share/applications/"$APP"-AM.desktop

--- a/programs/x86_64/iptracker
+++ b/programs/x86_64/iptracker
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=iptracker
+SITE="modernben/iptracker"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/modernben/iptracker/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=iptracker
+SITE="modernben/iptracker"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/modernben/iptracker/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/keep
+++ b/programs/x86_64/keep
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=keep
+SITE="andrepolischuk/keep"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/andrepolischuk/keep/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=keep
+SITE="andrepolischuk/keep"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/andrepolischuk/keep/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/leaflet
+++ b/programs/x86_64/leaflet
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=leaflet
+SITE="PotatoProject/Leaflet"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/PotatoProject/Leaflet/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=leaflet
+SITE="PotatoProject/Leaflet"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/PotatoProject/Leaflet/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/pho
+++ b/programs/x86_64/pho
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=pho
+SITE="zyrouge/pho"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/zyrouge/pho/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "amd64" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=pho
+SITE="zyrouge/pho"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/zyrouge/pho/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "amd64" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/rustypaste
+++ b/programs/x86_64/rustypaste
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=rustypaste
+SITE="orhun/rustypaste"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/orhun/rustypaste/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "unknown-linux-gnu.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=rustypaste
+SITE="orhun/rustypaste"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/orhun/rustypaste/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "unknown-linux-gnu.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/sphia
+++ b/programs/x86_64/sphia
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=sphia
+SITE="YukidouSatoru/sphia"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/YukidouSatoru/sphia/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=sphia
+SITE="YukidouSatoru/sphia"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/YukidouSatoru/sphia/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/stew
+++ b/programs/x86_64/stew
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=stew
+SITE="marwanhawari/stew"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/marwanhawari/stew/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux-amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=stew
+SITE="marwanhawari/stew"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/marwanhawari/stew/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux-amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/vegeta
+++ b/programs/x86_64/vegeta
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=vegeta
+SITE="tsenart/vegeta"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/tsenart/vegeta/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=vegeta
+SITE="tsenart/vegeta"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/tsenart/vegeta/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux_amd64.tar.gz" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1

--- a/programs/x86_64/volaris
+++ b/programs/x86_64/volaris
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=volaris
+SITE="volar-is/volaris-gui"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/volar-is/volaris-gui/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=volaris
+SITE="volar-is/volaris-gui"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/volar-is/volaris-gui/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/wournal
+++ b/programs/x86_64/wournal
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=wournal
+SITE="dominiksta/wournal"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/dominiksta/wournal/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=aisap
-SITE="mgord9518/aisap"
+APP=wournal
+SITE="dominiksta/wournal"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/mgord9518/aisap/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/dominiksta/wournal/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/yup
+++ b/programs/x86_64/yup
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=yup
+SITE="ericm/yup"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+#printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/ericm/yup/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "http.*download.*yup$" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+cd ..
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./$APP || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=yup
+SITE="ericm/yup"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/ericm/yup/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "http.*download.*yup$" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
+	cd ..
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1


### PR DESCRIPTION
[aisap.md](https://github.com/user-attachments/files/17356414/aisap.md)
[aretext.md](https://github.com/user-attachments/files/17356415/aretext.md)
[binfinder.md](https://github.com/user-attachments/files/17356417/binfinder.md)
[boxxy.md](https://github.com/user-attachments/files/17356418/boxxy.md)
[brutespray.md](https://github.com/user-attachments/files/17356419/brutespray.md)
[cowitness.md](https://github.com/user-attachments/files/17356421/cowitness.md)
[dbin.md](https://github.com/user-attachments/files/17356422/dbin.md)
[gickup.md](https://github.com/user-attachments/files/17356423/gickup.md)
[git-cliff.md](https://github.com/user-attachments/files/17356424/git-cliff.md)
[gitleaks.md](https://github.com/user-attachments/files/17356425/gitleaks.md)
[gitql.md](https://github.com/user-attachments/files/17356426/gitql.md)
[godmode.md](https://github.com/user-attachments/files/17356427/godmode.md)
[gost-shred.md](https://github.com/user-attachments/files/17356428/gost-shred.md)
[himalaya.md](https://github.com/user-attachments/files/17356429/himalaya.md)
[iptracker.md](https://github.com/user-attachments/files/17356430/iptracker.md)
[keep.md](https://github.com/user-attachments/files/17356431/keep.md)
[leaflet.md](https://github.com/user-attachments/files/17356432/leaflet.md)
[pho.md](https://github.com/user-attachments/files/17356433/pho.md)
[rustypaste.md](https://github.com/user-attachments/files/17356434/rustypaste.md)
[sphia.md](https://github.com/user-attachments/files/17356435/sphia.md)
[stew.md](https://github.com/user-attachments/files/17356436/stew.md)
[vegeta.md](https://github.com/user-attachments/files/17356437/vegeta.md)
[volaris.md](https://github.com/user-attachments/files/17356438/volaris.md)
[wournal.md](https://github.com/user-attachments/files/17356439/wournal.md)
[yup.md](https://github.com/user-attachments/files/17356440/yup.md)

```
❯ cat list
◆ leaflet : 
◆ wournal : Simple \"digitial paper\" for note taking and PDF annotation. Heavily inspired by Xournal.
◆ volaris : 
◆ gost-shred : GOST R 50739-95 Data Sanitization Method (2 passes)
◆ sphia : Sphia - a Proxy Handling Intuitive Application
◆ iptracker : Desktop tool to keep track of your IP address and update you when it changes
◆ aisap : Tool to make sandboxing AppImages easy
◆ godmode : AI Chat Browser: Fast, Full webapp access to ChatGPT / Claude / Bard / Bing / Llama2! I use this 20 times a day.
◆ keep : Desktop app for Google Keep packaged with Electron
◆ yup : 
◆ pho : 
◆ stew : 🥘 An independent package manager for compiled binaries.
◆ binfinder : Find binary files not installed through package manager
◆ dbin : 📦 Poor man's package manager. +2930 statically linked binaries in the repos! The easy to use, easy to get, suckless software distribution system
◆ aretext : Minimalist text editor with vim-compatible key bindings.
◆ cowitness : CoWitness is a powerful web application testing tool that enhances the accuracy and efficiency of your testing efforts. It allows you to mimic an HTTP server and a DNS server, providing complete responses and valuable insights during your testing process.
◆ boxxy : boxxy puts bad Linux applications in a box with only their files.
◆ brutespray : Bruteforcing from various scanner output - Automatically attempts default creds on found services.
◆ vegeta : HTTP load testing tool and library. It's over 9000!
◆ rustypaste : A minimal file upload/pastebin service.
◆ himalaya : CLI to manage emails
◆ gickup : "description": null,
◆ gitleaks : Protect and discover secrets using Gitleaks 🔑
◆ git-cliff : A highly customizable Changelog Generator that follows Conventional Commit specifications ⛰️ 
◆ gitql : 💊 A git query language
```