### PR TITLE
Add check and warning for restricted access to user namespaces

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -211,7 +211,17 @@ function _am_dependences_check() {
 	fi
 }
 
+function _check_ubuntu_mess() {
+	if ! unshare --user -p /bin/true >/dev/null 2>&1; then
+		echo "$DIVIDING_LINE"
+		echo " ⚠️ WARNING: Access to user namespaces is restricted!"
+		echo " Some apps may not run, please enable access to user namespaces"
+		echo "$DIVIDING_LINE"
+	fi
+}
+
 _am_dependences_check
+_check_ubuntu_mess
 
 # Function to check online connections (uses github.com by default, as the database and CLI itself are stored/hosted there)
 function _online_check() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/28a40add-5cd7-44de-afcb-9aaa63425f0d)

Ignore the `~/.local/bin` error, this was just a quick test for the function.