### PR TITLE
Option "`-b`" or "`backup`", give the name you want to the snapshots

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="8.3.2"
+AMVERSION="8.4"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/modules/management.am
+++ b/modules/management.am
@@ -7,6 +7,24 @@
 ##############################################################################################
 
 # BACKUP
+
+function _backup_name() {
+	printf "\n ◆ To set date and time as a name, press ENTER (default)\n ◆ To set the version as a name, press \"1\"\n ◆ To set a custom name, write anything else\n\n"
+	read -r -p " Write your choice here, or leave blank to use \"date/time\": " response
+	case "$response" in
+		'')
+			backupname=$(date +%F-%X | sed 's/://g' | sed 's/-//g')
+			;;
+		'1')
+			_check_version
+			backupname=$(grep -w " ◆ $app_name	|" "$AMCACHEDIR"/version-args 2>/dev/null | sed 's:.*|	::')
+			;;
+		*)	
+			backupname="$(echo "$response" | sed 's/ /_/g')"
+			;;
+	esac
+}
+
 function _backup() {
 	if [ ! -f "$APPSPATH"/"$2"/remove ]; then
 		echo " \"$2\" is not a valid argument or is not installed."
@@ -16,11 +34,19 @@ function _backup() {
 			printf "\n OPERATION ABORTED!\n\n"
 		else
 			mkdir -p "$HOME/.am-snapshots/$2"
-			date="$(date +%F-%X | sed 's/://g' | sed 's/-//g')"
-			cp -r "$APPSPATH"/"$2" "$HOME/.am-snapshots/$2/$date"
-			echo " SAVED in $HOME/.am-snapshots/$2"
+			app_name="$2"
+			_backup_name
+			if test -d "$HOME/.am-snapshots/$2/$backupname"; then
+				echo " 💀 ERROR: \"$2/$backupname\" already exists, ABORTED!"
+				echo "$DIVIDING_LINE"
+				return 1
+			else
+				cp -r "$APPSPATH"/"$2" "$HOME/.am-snapshots/$2/$backupname"
+			fi
+			echo " SAVED in $HOME/.am-snapshots/$2/$backupname"
 		fi
 	fi
+	echo "$DIVIDING_LINE"
 }
 
 # RESTORE
@@ -32,7 +58,7 @@ function _overwrite() {
 	else
 		read -r -p " Do you wish to overwrite $2 with an older version? (y,N) " yn
 		if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
-			printf "\n OPERATION ABORTED!\n\n"
+			printf "\n OPERATION ABORTED! \n\n"
 		else
 			printf "\n Please, select a snapshot or press CTRL+C to abort:\n\n"
 			sleep 1


### PR DESCRIPTION
Now it is possible to give the name you want for the snapshots:
- press enter to to give date and time as aname, like always
- press "1" to use the version of the app
- write anything you want (eccept "1", its busy, see above), it will be used as a snapshot

![Istantanea_2024-10-16_15-40-29 png](https://github.com/user-attachments/assets/da6f3aec-b2cf-4186-babe-f5ebf4985cd0)

The option shows also the exact directory name.

![Istantanea_2024-10-16_15-44-55 png](https://github.com/user-attachments/assets/92d8fdf0-96d0-4447-8c39-21860654a5bf)

Now to restore backups using `-o` is more user friendly!