### PR TITLE
Add soar

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -2063,6 +2063,7 @@
 ◆ snippetstore : A snippet management app for developers.
 ◆ snomcontrol : An application to control snom D3xx phones from the desktop.
 ◆ snowball : Find and filter literature, fast.
+◆ soar : A fast modern package manager for static binaries, portable apps & more.
 ◆ soapy-sdr : I/Q recorder and processor using SoapySDR as backend.
 ◆ socnetv : Social Network Analysis and Visualization software.
 ◆ soft-serve : The mighty, self-hostable Git server for the command line.

--- a/programs/x86_64/soar
+++ b/programs/x86_64/soar
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=dbin
-SITE="xplshn/dbin"
+APP=soar
+SITE="QaidVoid/soar"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../r
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls  https://api.github.com/repos/xplshn/dbin/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*amd64" | head -1)
+version=$(curl -Ls  https://api.github.com/repos/QaidVoid/soar/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*linux" | head -1)
 wget "$version" || exit 1
 [ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
 [ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=dbin
-SITE="xplshn/dbin"
+APP=soar
+SITE="QaidVoid/soar"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls  https://api.github.com/repos/xplshn/dbin/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*amd64" | head -1)
+version=$(curl -Ls  https://api.github.com/repos/QaidVoid/soar/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*linux" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1


### PR DESCRIPTION
Turns out I was going to add both `soar` and `dbin` but dbin was already added kek.

[soar.md](https://github.com/user-attachments/files/17616360/soar.md)
