### PR TITLE
Show total number of programs available in `-l`...

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -722,7 +722,7 @@ function _sync_toolpacks_list() {
 }
 
 function _sync_databases() {
-	echo -e "$DIVIDING_LINE\n Sync databases..."
+	echo -e "$DIVIDING_LINE\n Check and update offline lists of additional databases..."
 	_sync_appimages_list
 	_sync_toolpacks_list
 	_completion_lists

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-4"
+AMVERSION="9.1-5"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -380,7 +380,7 @@ function _completion_lists() {
 	# Remove existing lists and download new ones
 	curl -Ls "$APPSLISTDB" > "$AMDATADIR/$arch-apps"
 	awk -v FS="(◆ | : )" '{print $2}' <"$AMDATADIR"/"$arch"-apps > "$AMDATADIR"/list
-	curl -Ls "$toolpack_readme" | grep -v "\.appimage " 2>/dev/null | cut -d' ' -f2- | awk '{print $1}' | uniq >> "$AMDATADIR"/list
+	curl -Ls "$toolpack_readme" | grep -v "\.appimage " 2>/dev/null | cut -d' ' -f2- | awk '{print $1}' | uniq | sed -e 's/$/.toolpack/' >> "$AMDATADIR"/list
 	# Append options to the list
 	for o in $available_options; do
 		echo "$o" >> "$AMDATADIR"/list

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-5"
+AMVERSION="9.1-6"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -163,12 +163,12 @@ function _detect_appman_apps() {
 }
 
 function _determine_args() {
-	ARGPATHS=$(find "$APPSPATH" -name 'remove' -printf " %h\n" 2>/dev/null | sort -u | sed 's/ //g')
+	ARGPATHS=$(find "$APPSPATH" -maxdepth 2 -name 'remove' -printf " %h\n" 2>/dev/null | sort -u | sed 's/ //g')
 	ARGS=$(echo "$ARGPATHS" | xargs -n 1 basename 2>/dev/null)
 	if [ "$AMCLI" = am ]; then
 		_detect_appman_apps
 		if [ -d "$APPMAN_APPSPATH" ]; then
-			APPMAN_PATHS=$(find "$APPMAN_APPSPATH" -name 'remove' -printf " %h\n" 2>/dev/null | sort -u | sed 's/ //g')
+			APPMAN_PATHS=$(find "$APPMAN_APPSPATH" -maxdepth 2 -name 'remove' -printf " %h\n" 2>/dev/null | sort -u | sed 's/ //g')
 			ARGPATHS=$(echo -e "$ARGPATHS\n$APPMAN_PATHS")
 			ARGS=$(echo "$ARGPATHS" | xargs -n 1 basename 2>/dev/null)
 		fi

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-2"
+AMVERSION="9.1-3"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -362,7 +362,7 @@ _am_newrepo_check "$@"
 
 # 3RD PARTY SOURCES -- TOOLPACK
 toolpack_repo="https://github.com/Azathothas/Toolpacks"
-export toolpack_readme="https://bin.pkgforge.dev/${ARCH}/AM.txt"
+toolpack_readme="https://bin.pkgforge.dev/${ARCH}/AM.txt"
 export toolpack_name="1" toolpack_description="2" toolpack_site="3" toolpack_dl="4" toolpack_ver="5"
 
 ################################################################################
@@ -699,6 +699,35 @@ function _sync_installation_scripts() {
 	done
 }
 
+function _sync_appimages_list() {
+	rm -f "$AMDATADIR/$ARCH-appimages"
+	APPIMAGE_NAMES=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g' | grep -v "\[")
+	for appimage in $APPIMAGE_NAMES; do
+		grep "◆ $appimage :" "$AMDATADIR/$ARCH-apps" >> "$AMDATADIR/$ARCH-appimages" &
+	done
+	wait
+}
+
+function _sync_toolpacks_list() {
+	rm -f "$AMDATADIR/$ARCH-toolpack"
+	toolpack_md=$(curl -Ls "$toolpack_readme" | grep -v "\.appimage ")
+	TOOLPACK_NAMES=$(echo "$toolpack_md" | cut -d' ' -f2- | awk '{print $1}')
+	for toolpack in $TOOLPACK_NAMES; do
+		toolpack_arg=$(echo "$toolpack_md" | grep -i "^| $toolpack " | tr '|' '\n' | cut -c 2- | grep .) \
+		&& toolpack_about_description=$(echo "$toolpack_arg" | awk -F: "NR==$toolpack_description" | sed 's/ $/./g') \
+		&& echo "◆ $toolpack : $toolpack_about_description" >> "$AMDATADIR/$ARCH-toolpack" &
+	done
+	wait
+	sort "$AMDATADIR/$ARCH-toolpack" | uniq > "$AMDATADIR/$ARCH-toolpack-new" && mv "$AMDATADIR/$ARCH-toolpack-new" "$AMDATADIR/$ARCH-toolpack" || exit 1
+}
+
+function _sync_databases() {
+	echo -e "$DIVIDING_LINE\n Sync databases..."
+	_sync_appimages_list
+	_sync_toolpacks_list
+	_completion_lists
+}
+
 function _sync_modules() {
 	echo -e "$DIVIDING_LINE\n Check for updates in modules..."
 	MODULES=$(curl -Ls "$AMREPO/APP-MANAGER" | tr '"' '\n' | grep "[a-z]\.am$")
@@ -723,7 +752,6 @@ function _sync_modules() {
 
 function _sync_amcli() {
 	echo "$DIVIDING_LINE"
-	_completion_lists
 	CURRENT_AM_VERSION="$AMVERSION"
 	echo -ne "\n ◆ SYNCHRONIZING \"$AMCLIUPPER\" VERSION \"$CURRENT_AM_VERSION\"...\r" && sleep 0.25
 	_clean_amcachedir 1>/dev/null
@@ -746,6 +774,7 @@ function _use_sync() {
 	_online_check
 	_betatester_message_on
 	_sync_installation_scripts
+	_sync_databases
 	if [ "$(realpath "$0")" != "/usr/bin/am" ]; then
 		_sync_modules
 		_sync_amcli

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-7"
+AMVERSION="9.1-8"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -710,15 +710,7 @@ function _sync_appimages_list() {
 
 function _sync_toolpacks_list() {
 	rm -f "$AMDATADIR/$ARCH-toolpack"
-	toolpack_md=$(curl -Ls "$toolpack_readme" | grep -v "\.appimage ")
-	TOOLPACK_NAMES=$(echo "$toolpack_md" | cut -d' ' -f2- | awk '{print $1}')
-	for toolpack in $TOOLPACK_NAMES; do
-		toolpack_arg=$(echo "$toolpack_md" | grep -i "^| $toolpack " | tr '|' '\n' | cut -c 2- | grep .) \
-		&& toolpack_about_description=$(echo "$toolpack_arg" | awk -F: "NR==$toolpack_description" | sed 's/ $/./g') \
-		&& echo "◆ $toolpack : $toolpack_about_description" >> "$AMDATADIR/$ARCH-toolpack" &
-	done
-	wait
-	sort "$AMDATADIR/$ARCH-toolpack" | uniq > "$AMDATADIR/$ARCH-toolpack-new" && mv "$AMDATADIR/$ARCH-toolpack-new" "$AMDATADIR/$ARCH-toolpack" || exit 1
+	curl -Ls "$toolpack_readme" | grep -v "\.appimage " | cut -d":" -f1 | cut -d"@" -f2 | sed 's/^| /◆ /g; s/ | https$/./g; s/ | / : /g' > "$AMDATADIR/$ARCH-toolpack"
 }
 
 function _sync_databases() {

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-3"
+AMVERSION="9.1-4"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1157,7 +1157,8 @@ case "$1" in
 
 					${LightBlue}$AMCLI -l
 					${LightBlue}$AMCLI -l --all
-					${LightBlue}$AMCLI -l --appimages\033[0m
+					${LightBlue}$AMCLI -l --appimages
+					${LightBlue}$AMCLI -l --toolpack {KEYWORD}\033[0m
 
 			Description: Shows the list of all the apps available, or just the AppImages. It can also be extended with additional flags, the \"--all\" flag allows you to consult the set of all supported databases (see \"--toolpack\").
 
@@ -1188,7 +1189,8 @@ case "$1" in
 					${LightBlue}$AMCLI -q {KEYWORD}
 					${LightBlue}$AMCLI -q --all {KEYWORD}
 					${LightBlue}$AMCLI -q --appimages {KEYWORD}
-					${LightBlue}$AMCLI -q --pkg {PROGRAM1} {PROGRAM2}\033[0m
+					${LightBlue}$AMCLI -q --pkg {PROGRAM1} {PROGRAM2}
+					${LightBlue}$AMCLI -q --toolpack {KEYWORD}\033[0m
 
 			Description: Search for keywords in the list of available applications, add the \"--appimages\" option to list only the AppImages or add \"--pkg\" to list multiple programs at once. It can also be extended with additional flags, the \"--all\" flag allows you to consult the set of all supported databases (see \"--toolpack\").
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-8"
+AMVERSION="9.1.1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.1-6"
+AMVERSION="9.1-7"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -380,7 +380,7 @@ function _completion_lists() {
 	# Remove existing lists and download new ones
 	curl -Ls "$APPSLISTDB" > "$AMDATADIR/$arch-apps"
 	awk -v FS="(◆ | : )" '{print $2}' <"$AMDATADIR"/"$arch"-apps > "$AMDATADIR"/list
-	curl -Ls "$toolpack_readme" | grep -v "\.appimage " 2>/dev/null | cut -d' ' -f2- | awk '{print $1}' | uniq | sed -e 's/$/.toolpack/' >> "$AMDATADIR"/list
+	[ -f "$AMDATADIR"/"$ARCH"-toolpack ] && awk '{print $2}' "$AMDATADIR"/"$ARCH"-toolpack | sed -e 's/$/.toolpack/' >> "$AMDATADIR"/list
 	# Append options to the list
 	for o in $available_options; do
 		echo "$o" >> "$AMDATADIR"/list

--- a/modules/database.am
+++ b/modules/database.am
@@ -322,6 +322,21 @@ _list() {
 	APPSNUMBER=$(("$ITEMSNUMBER" - "$LIBNUMBER"))
 	# Determine the number of available apps from the list
 	AVAILABLE_APPS_NUMBER=$(grep -v "ffwa-\|\"kdegames\"\|\"kdeutils\"\|\"node\"\|\"platform-tools\"" "$AMDATADIR/$ARCH-apps" | grep -e "$" -c)
+	if ! test -f "$AMDATADIR/$ARCH-appimages"; then
+		_online_check
+		_sync_appimages_list
+		AVAILABLE_APPIMAGES_NUMBER=$(grep -e "$" -c "$AMDATADIR/$ARCH-appimages")
+	else
+		AVAILABLE_APPIMAGES_NUMBER=$(grep -e "$" -c "$AMDATADIR/$ARCH-appimages")
+	fi
+	if ! test -f "$AMDATADIR/$ARCH-toolpack"; then
+		_online_check
+		_sync_toolpacks_list
+		AVAILABLE_TOOLPACKS_NUMBER=$(grep -e "$" -c "$AMDATADIR/$ARCH-toolpack")
+	else
+		AVAILABLE_TOOLPACKS_NUMBER=$(grep -e "$" -c "$AMDATADIR/$ARCH-toolpack")
+	fi
+	[ -n "$AVAILABLE_TOOLPACKS_NUMBER" ] && AVAILABLE_TOTAL_APPS_NUMBER=$(("$AVAILABLE_APPS_NUMBER" + "$AVAILABLE_TOOLPACKS_NUMBER"))
 	# Generate a list of the installed apps with version
 	[ ! -f "$AMCACHEDIR"/version-args ] && _check_version
 	if [ -n "$APPMAN_ITEMS" ]; then
@@ -336,43 +351,29 @@ _list() {
 	if [ "$LIBNUMBER" != 0 ]; then
 		# Check if the installed libraries are more than one
 		if [ "$LIBNUMBER" = 1 ]; then
-			MESSAGE=" YOU HAVE INSTALLED $APPSNUMBER APPLICATIONS OUT OF $AVAILABLE_APPS_NUMBER AVAILABLE, AND $LIBNUMBER LIBRARY"
+			MESSAGE=" YOU HAVE INSTALLED $APPSNUMBER PROGRAMS OUT OF $AVAILABLE_TOTAL_APPS_NUMBER AVAILABLE, AND $LIBNUMBER LIBRARY"
 		else
-			MESSAGE=" YOU HAVE INSTALLED $APPSNUMBER APPLICATIONS OUT OF $AVAILABLE_APPS_NUMBER AVAILABLE, AND $LIBNUMBER LIBRARIES"
+			MESSAGE=" YOU HAVE INSTALLED $APPSNUMBER PROGRAMS OUT OF $AVAILABLE_TOTAL_APPS_NUMBER AVAILABLE, AND $LIBNUMBER LIBRARIES"
 		fi
 	else
-		MESSAGE=" YOU HAVE INSTALLED $APPSNUMBER APPLICATIONS OUT OF $AVAILABLE_APPS_NUMBER AVAILABLE"
+		MESSAGE=" YOU HAVE INSTALLED $APPSNUMBER PROGRAMS OUT OF $AVAILABLE_TOTAL_APPS_NUMBER AVAILABLE"
 	fi
 }
 
 _list_appimages() {
-	# Determine the number of available apps
-	APPIMAGE_NAMES=$(curl -Ls https://portable-linux-apps.github.io/appimages.md | tr '/)' '\n' | grep -i ".md$" | uniq | sed 's/.md$//g' | grep -v "\[")
-	if ! test -f "$AMCACHEDIR/$ARCH-appimages"; then
+	wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_appimages_list
+	if ! test -f "$AMDATADIR/$ARCH-appimages"; then
 		_online_check
-		for appimage in $APPIMAGE_NAMES; do
-			grep "◆ $appimage :" "$AMDATADIR/$ARCH-apps" >> "$AMCACHEDIR/$ARCH-appimages" &
-		done
-		wait
+		_sync_appimages_list
 	fi
-	AVAILABLE_APPIMAGES_NUMBER=$(grep -e "$" -c "$AMCACHEDIR/$ARCH-appimages")
 }
 
 _list_toolpacks() {
-	# Determine the number of available apps
-	if ! test -f "$AMCACHEDIR/$ARCH-toolpack"; then
+	wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_toolpacks_list
+	if ! test -f "$AMDATADIR/$ARCH-toolpack"; then
 		_online_check
-		toolpack_md=$(curl -Ls "$toolpack_readme" | grep -v "\.appimage ")
-		TOOLPACK_NAMES=$(echo "$toolpack_md" | cut -d' ' -f2- | awk '{print $1}')
-		for toolpack in $TOOLPACK_NAMES; do
-			toolpack_arg=$(echo "$toolpack_md" | grep -i "^| $toolpack " | tr '|' '\n' | cut -c 2- | grep .) \
-			&& toolpack_about_description=$(echo "$toolpack_arg" | awk -F: "NR==$toolpack_description" | sed 's/ $/./g') \
-			&& echo "◆ $toolpack : $toolpack_about_description" >> "$AMCACHEDIR/$ARCH-toolpack" &
-		done
-		wait
-		sort "$AMCACHEDIR/$ARCH-toolpack" | uniq > "$AMCACHEDIR/$ARCH-toolpack-new" && mv "$AMCACHEDIR/$ARCH-toolpack-new" "$AMCACHEDIR/$ARCH-toolpack" || exit 1
+		_sync_toolpacks_list
 	fi
-	AVAILABLE_TOOLPACKS_NUMBER=$(grep -e "$" -c "$AMCACHEDIR/$ARCH-toolpack")
 }
 
 _list_msg_head() {
@@ -385,28 +386,25 @@ _list_msg_footer() {
 
 _list_toolpacks_msg() {
 	_list_msg_head
-	echo " LIST OF THE $AVAILABLE_TOOLPACKS_NUMBER TOOLPACK PROGRAMS AVAILABLE:"
+	echo " LIST OF THE $AVAILABLE_TOOLPACKS_NUMBER PROGRAMS AVAILABLE IN THE \"TOOLPACKS\" DATABASE:"
 	_list_msg_footer
 }
 
 _list_appimages_msg() {
 	_list_msg_head
-	echo " LIST OF THE $AVAILABLE_APPIMAGES_NUMBER APPIMAGES AVAILABLE IN THE 'AM' REPOSITORY:"
+	echo " LIST OF THE $AVAILABLE_APPIMAGES_NUMBER APPIMAGES AVAILABLE IN THE \"AM\" DATABASE:"
 	_list_msg_footer
 }
 
 _list_apps_msg() {
 	_list_msg_head
-	echo " LIST OF THE $AVAILABLE_APPS_NUMBER APPLICATIONS AVAILABLE IN THE 'AM' REPOSITORY:"
+	echo " LIST OF THE $AVAILABLE_APPS_NUMBER PROGRAMS AVAILABLE IN THE \"AM\" DATABASE:"
 	_list_msg_footer
 }
 
 _list_apps_all_msg() {
 	_list_msg_head
-	AVAILABLE_APPS_NUMBER=$(grep -v "ffwa-\|\"kdegames\"\|\"kdeutils\"\|\"node\"\|\"platform-tools\"" "$AMDATADIR/$ARCH-apps" | grep -e "$" -c)
-	AVAILABLE_TOOLPACKS_NUMBER=$(grep -e "$" -c "$AMCACHEDIR/$ARCH-toolpack")
-	AVAILABLE_TOTAL_PROGRAMS=$(("$AVAILABLE_APPS_NUMBER" + "$AVAILABLE_TOOLPACKS_NUMBER"))
-	echo " LIST OF THE $AVAILABLE_TOTAL_PROGRAMS PROGRAMS AVAILABLE IN ALL OUR SUPPORTED DATABASES:"
+	echo " LIST OF THE $AVAILABLE_TOTAL_APPS_NUMBER PROGRAMS AVAILABLE IN ALL SUPPORTED DATABASES:"
 	_list_msg_footer
 }
 
@@ -455,21 +453,21 @@ case "$1" in
 		_list
 		if [ "$2" = --all ]; then
 			_list_toolpacks
-			LIST=$(sort "$AMDATADIR/$ARCH-apps" "$AMCACHEDIR/$ARCH-toolpack" | uniq | _pretty_list)
+			LIST=$(sort "$AMDATADIR/$ARCH-apps" "$AMDATADIR/$ARCH-toolpack" | uniq | _pretty_list)
 			_list_apps_all_msg | less -Ir
 			echo "$DIVIDING_LINE"
 			echo " $(("$AVAILABLE_APPS_NUMBER" + "$AVAILABLE_TOOLPACKS_NUMBER")) programs in all supported databases"
 			echo "$DIVIDING_LINE"
 		elif [ "$2" = --appimages ]; then
 			_list_appimages
-			LIST=$(sort "$AMCACHEDIR/$ARCH-appimages" | _pretty_list)
+			LIST=$(sort "$AMDATADIR/$ARCH-appimages" | _pretty_list)
 			_list_appimages_msg | less -Ir
 			echo "$DIVIDING_LINE"
 			echo " $AVAILABLE_APPIMAGES_NUMBER AppImages in the \"AM\" database"
 			echo "$DIVIDING_LINE"
 		elif [ "$2" = --toolpack ]; then
 			_list_toolpacks
-			LIST=$(sort "$AMCACHEDIR/$ARCH-toolpack" | _pretty_list)
+			LIST=$(sort "$AMDATADIR/$ARCH-toolpack" | _pretty_list)
 			_list_toolpacks_msg | less -Ir
 			echo "$DIVIDING_LINE"
 			echo " $AVAILABLE_TOOLPACKS_NUMBER programs in the \"Toolpacks\" database"
@@ -501,19 +499,19 @@ case "$1" in
 			printf "\n Search results for \"%s\":\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'
 			pattern="$(echo "$entries" | sed 's/ /(?=.*/g; s/$/)/g; s/(/)(/g; s/^/(?=.*/g;')"
 			_list_appimages
-			grep -Pi "$pattern" "$AMCACHEDIR/$ARCH-appimages" | _pretty_list_compat
+			grep -Pi "$pattern" "$AMDATADIR/$ARCH-appimages" | _pretty_list_compat
 		elif [ "$2" = --toolpack ]; then
 			entries="$(echo "$@" | cut -f3- -d ' ')"
 			printf "\n Search results for \"%s\":\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'
 			pattern="$(echo "$entries" | sed 's/ /(?=.*/g; s/$/)/g; s/(/)(/g; s/^/(?=.*/g;')"
 			_list_toolpacks
-			grep -Pi "$pattern" "$AMCACHEDIR/$ARCH-toolpack" | _pretty_list_compat
+			grep -Pi "$pattern" "$AMDATADIR/$ARCH-toolpack" | _pretty_list_compat
 		elif [ "$2" = --all ]; then
 			entries="$(echo "$@" | cut -f3- -d ' ')"
 			printf "\n Search results for \"%s\":\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'
 			pattern="$(echo "$entries" | sed 's/ /(?=.*/g; s/$/)/g; s/(/)(/g; s/^/(?=.*/g;')"
 			_list_toolpacks
-			sort "$AMCACHEDIR/$ARCH-toolpack" "$AMDATADIR/$ARCH-apps" | grep -Pi "$pattern" | _pretty_list_compat
+			sort "$AMDATADIR/$ARCH-toolpack" "$AMDATADIR/$ARCH-apps" | grep -Pi "$pattern" | _pretty_list_compat
 		else
 			entries="$(echo "$@" | cut -f2- -d ' ')"
 			printf "\n Search results for \"%s\":\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'

--- a/modules/database.am
+++ b/modules/database.am
@@ -380,6 +380,10 @@ _list_msg_head() {
 	echo "" && echo "$MESSAGE" && echo "" && echo "$MESSAGE2" && echo ""
 }
 
+_list_msg_suggest_all() {
+	printf "\n To list all installable programs, use the \"%b--all\033[0m\" flag\n" "${LightBlue}"
+}
+
 _list_msg_footer() {
 	echo "$LIST" && echo ""
 }
@@ -387,18 +391,21 @@ _list_msg_footer() {
 _list_toolpacks_msg() {
 	_list_msg_head
 	echo " LIST OF THE $AVAILABLE_TOOLPACKS_NUMBER PROGRAMS AVAILABLE IN THE \"TOOLPACKS\" DATABASE:"
+	_list_msg_suggest_all
 	_list_msg_footer
 }
 
 _list_appimages_msg() {
 	_list_msg_head
 	echo " LIST OF THE $AVAILABLE_APPIMAGES_NUMBER APPIMAGES AVAILABLE IN THE \"AM\" DATABASE:"
+	_list_msg_suggest_all
 	_list_msg_footer
 }
 
 _list_apps_msg() {
 	_list_msg_head
 	echo " LIST OF THE $AVAILABLE_APPS_NUMBER PROGRAMS AVAILABLE IN THE \"AM\" DATABASE:"
+	_list_msg_suggest_all
 	_list_msg_footer
 }
 

--- a/modules/database.am
+++ b/modules/database.am
@@ -494,6 +494,7 @@ case "$1" in
 			entries="$(echo "$@" | cut -f3- -d ' ' | tr -s ' ' '|')"
 			printf "\n Search results for packages: %s\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'
 			grep -iE "$entries" "$AMDATADIR/$ARCH-apps" --color=always | _pretty_list_compat
+			[ -f "$AMDATADIR/$ARCH-toolpack" ] && grep -iE "$entries" "$AMDATADIR/$ARCH-toolpack" --color=always | _pretty_list_compat
 		elif [ "$2" = --appimages ]; then
 			entries="$(echo "$@" | cut -f3- -d ' ')"
 			printf "\n Search results for \"%s\":\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'


### PR DESCRIPTION
...and keep all the lists locally so you can consult them offline, in case of no internet connection.

![Istantanea_2024-11-13_04-33-40 png](https://github.com/user-attachments/assets/3fd55735-b8ac-4a80-8b3b-27c2516ca2f4)

@Samueru-sama @xplshn @Azathothas

The Toolpacks and AppImage lists will only be updated if called with the respective flag in `-l` or if synchronization is performed, which will be notified during the execution of `-s` or at the end of `-u`