### PR TITLE
Cheat-breaker [Minecraft client]

### DIFF
--- a/programs/aarch64-apps
+++ b/programs/aarch64-apps
@@ -4,6 +4,7 @@
 ◆ arch-deployer : Script to convert Arch Linux packages to AppDir/AppImage.
 ◆ btop : A command line utility to monitor system resources, like Htop.
 ◆ crossmobile : Create native iOS/Android/Windows apps in Java. 
+◆ cheat-breaker : The free FPS boosting modpack for Minecraft 1.7 & 1.8
 ◆ figma-linux : First interface design tool based in the browser (graphics). 
 ◆ freac : fre:ac, free audio converter and CD ripper for various encoders.
 ◆ legcord : Legcord is a custom client designed to enhance your Discord experience while keeping everything lightweight.

--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -323,6 +323,7 @@
 ◆ chatterino2-nightly : Second installment of the Twitch chat client.
 ◆ chatterino2 : Second installment of the Twitch chat client.
 ◆ cheat : Create and view interactive cheatsheets on the command-line.
+◆ cheat-breaker : The free FPS boosting modpack for Minecraft 1.7 & 1.8
 ◆ chemcanvas : A very intuitive 2D chemical drawing tool.
 ◆ cherry-studio : Cherry Studio is a desktop client that supports for multiple LLM providers.
 ◆ cherrytree : A hierarchical note taking application.


### PR DESCRIPTION
Couldnt get it to grab the link with am -t (skill issue cuz the appimage isn't on github) 
Pls add both amd64 & arm64 build (also they seem to have a static link for the .AppImages)

Download:https://cheatbreaker.net/download