### PR TITLE
change grep pattern to also recognize uruntime appimages

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -161,7 +161,7 @@ _files_type() {
 	string=$(strings -d ./"$arg/$arg" 2>/dev/null)
 	FILE=$(command -v "$arg" 2>/dev/null)
 	LINK=$(readlink "$FILE" 2>/dev/null)
-	if echo "$string" | grep -- '--appimage-extract option' >/dev/null 2>&1; then
+	if echo "$string" | grep 'github.com/AppImage/AppImageKit/wiki/FUSE' >/dev/null 2>&1; then
 		_files_if_appimage
 	elif file ./"$arg"/* | grep -E 'LSB|/bin' >/dev/null 2>&1; then
 		_files_if_binary


### PR DESCRIPTION
Otherwise uruntime appimages get recognize as static binaries.

Tested and doesn't seem to break anything, but always double check: 

![image](https://github.com/user-attachments/assets/71834010-7c3a-4eda-b369-ca9ff1450c9c)
