### PR TITLE
update the ryujinx situation

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1956,7 +1956,8 @@
 ◆ rusty-rain : CLI, a cross platform matrix rain made with Rust. 
 ◆ rx-bin : A modern and extensible pixel editor implemented in Rust.
 ◆ ryowallet : Modern GUI interface for Ryo Currency.
-◆ ryujinx : Ryujinx Nintendo Switch emulator.
+◆ ryujinx : Continuation of the original Ryujinx with new features.
+◆ ryujinx-mirror : Hard-fork of Ryujinx, more similar to the original Ryujinx.
 ◆ s3drive : Convert S3, SFTP, WebDAV or Rclone back-end into your encrypted storage.
 ◆ sabaki : Modern, elegant, cross-platform Go/Baduk/Weiqi game board.
 ◆ saber : A work-in-progress cross-platform libre handwritten notes app.

--- a/programs/x86_64/ryujinx-mirror
+++ b/programs/x86_64/ryujinx-mirror
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=ryujinx
-SITE="GreemDev/Ryujinx"
+APP=ryujinx-mirror
+SITE="ryujinx-mirror/ryujinx"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/GreemDev/Ryujinx/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ryujinx-mirror/ryujinx/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=ryujinx
-SITE="GreemDev/Ryujinx"
+APP=ryujinx-mirror
+SITE="ryujinx-mirror/ryujinx"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/GreemDev/Ryujinx/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ryujinx-mirror/ryujinx/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
Well looks like Ryujinx is going to continue at https://github.com/GreemDev/Ryujinx while the mirror-repo will stay more in line with the original vision. 

[ryujinx.md](https://github.com/user-attachments/files/17878289/ryujinx.md)
[ryujinx-mirror.md](https://github.com/user-attachments/files/17878290/ryujinx-mirror.md)
