### PR TITLE
add option to install and sandbox multiple apps at once

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1070,6 +1070,19 @@ case "$1" in
 		MODULE="sandboxes.am"
 		_use_module "$@"
 		;;
+	'-ias')
+		shift
+		for arg in "${@}"; do
+			if [ "$CLI" = am ] && [ -f "$APPMANCONFIG"/appman-mode ]; then
+				echo -e "$APPMAN_MSG"
+			fi
+			MODULE="install.am"
+			_online_check
+			( _use_module -i "$arg" )
+			MODULE="sandboxes.am"
+			_use_module --sandbox "$arg"
+		done
+		;;
 	'download'|'-d'|\
 	'extra'|'-e'|\
 	'install'|'-i'|\


### PR DESCRIPTION
Wasn't as hard as I thought it would be: 

Test: 

![image](https://github.com/user-attachments/assets/b09e2c3b-d61b-44a4-8d74-8a4cd35292cf)

For some reason I have to run the install module in a subshell, otherwise it does an `exit 0` and does not continue.
