### PR TITLE
"AM" 9.3, allow enable sandoxing when installing AppImages

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -370,6 +370,9 @@ case "$1" in
 			echo " USAGE: $AMCLI $1 --debug [ARGUMENT]"
 			echo " USAGE: $AMCLI $1 --force-latest [ARGUMENT]"
 			echo " USAGE: $AMCLI $1 --icons [ARGUMENT]"
+			if [ "$1" = "-ia" ] || [ "$1" = "install-appimage" ]; then
+				echo " USAGE: $AMCLI $1 --sandbox [ARGUMENT]"
+			fi
 			[ "$AMCLI" = "am" ] && echo " USAGE: $AMCLI $1 --user [ARGUMENT]"
 			exit 1
 			;;
@@ -422,6 +425,11 @@ case "$1" in
 				_install_normally
 			else
 				echo "💀 ERROR: \"$arg\" does NOT exist in the \"AM\" database, $(printf "please check the list, run the \"%b$AMCLIPATH_ORIGIN -l\033[0m\" command.\n\n" "${Gold}")" | fold -sw 72 | sed 's/^/ /g'
+			fi
+			if [ "$1" = "-ia" ] || [ "$1" = "install-appimage" ]; then
+				if echo "$@" | grep -q -- "--sandbox"; then
+					"$AMCLIPATH_ORIGIN" --sandbox "$arg"
+				fi
 			fi
 			echo "____________________________________________________________________________"
 		done

--- a/modules/install.am
+++ b/modules/install.am
@@ -428,7 +428,13 @@ case "$1" in
 			fi
 			if [ "$1" = "-ia" ] || [ "$1" = "install-appimage" ]; then
 				if echo "$@" | grep -q -- "--sandbox"; then
-					"$AMCLIPATH_ORIGIN" --sandbox "$arg"
+					if ! command -v aisap >/dev/null 2>&1; then
+						mv "$AMCACHEDIR"/installed "$CACHEDIR"/installed.backup.am 2>/dev/null
+						"$AMCLIPATH_ORIGIN" --sandbox "$arg"
+						mv "$CACHEDIR"/installed.backup.am "$AMCACHEDIR"/installed 2>/dev/null
+					else
+						"$AMCLIPATH_ORIGIN" --sandbox "$arg"
+					fi
 				fi
 			fi
 			echo "____________________________________________________________________________"

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -4,6 +4,8 @@
 # THIS MODULE INCLUDES ALL ACTIONS INTENDED TO ISOLATE DOTFILES OR CONTAINERIZE INSTALLED APPIMAGES
 ###################################################################################################
 
+SUDOCMD_ORIGIN="$SUDOCMD"
+
 # Get xdg variables for _configure_dirs_access
 for DIR in DESKTOP DOCUMENTS DOWNLOAD GAMES MUSIC PICTURES VIDEOS; do
 	eval XDG_DIR="$(xdg-user-dir $DIR 2>/dev/null)"
@@ -82,10 +84,13 @@ _check_aisap() {
 		fi
 		command -v aisap 1>/dev/null || return 1
 		echo " aisap installed successfully!"
-	fi	
+	fi
 	if grep "aisap-am" "$TARGET" >/dev/null 2>&1; then
 		echo " $1 is already sandboxed!"
 		return 1
+	fi
+	if [ -n "$BINDIR" ] && test -f "$BINDIR"/"$1"; then
+		SUDOCMD=""
 	fi
 }
 
@@ -248,6 +253,7 @@ _install_sandbox_script() {
 	printf '\033[0m%s\033[33m\n' " to revert the changes, in this case that is:"
 	printf '\033[33m%s\033[0m' " $1 --disable-sandbox"
 	printf '%s\033[33m%s\n\033[0m\n' " or " "$AMCLI --disable-sandbox $1"
+	SUDOCMD="$SUDOCMD_ORIGIN"
 }
 
 # Main logic

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -70,7 +70,16 @@ _check_aisap() {
 			echo " OPERATION ABORTED!"
 			return 1
 		fi
-		"$AMCLIPATH" -i aisap >/dev/null 2>&1
+		if [ "$CLI" = am ] && [ -f "$APPMANCONFIG"/appman-config ]; then
+			read -r -p " ◆ DO YOU WISH TO INSTALL AISAP LOCALLY? (Y/n) " yn
+			if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+				"$AMCLIPATH" -i aisap >/dev/null 2>&1
+			else
+				"$AMCLIPATH" -i --user aisap >/dev/null 2>&1
+			fi
+		else
+			"$AMCLIPATH" -i aisap >/dev/null 2>&1
+		fi
 		command -v aisap 1>/dev/null || return 1
 		echo " aisap installed successfully!"
 	fi	


### PR DESCRIPTION
new flag `--sandbox` for `-ia` or `install-appimage`

![Istantanea_2024-12-02_02-36-14](https://github.com/user-attachments/assets/9326a933-faf0-460a-80ad-dfafd04e96a6)

also, fix `--sandbox` option for unprivileged use cases while using AM, in the examples below, sandboxing/unsandboxing alternate unprivileged/privileged/unprivileged apps
![Istantanea_2024-12-02_02-39-21](https://github.com/user-attachments/assets/cac4b510-bdc4-427c-bf4a-ff9c9cedd323)
![Istantanea_2024-12-02_02-40-45](https://github.com/user-attachments/assets/c5b43dbb-280c-495b-9fc7-1c303efa2723)
