### PR TITLE
improve func ` _check_appimage`

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -23,10 +23,10 @@ VIDEOS="$(echo "${VIDEOS:-~/Videos}" | sed "s|$HOME|~|g")"
 
 _check_appimage() {
 	_determine_args
-	TARGET="$(command -v "$1")"
-	APPIMAGEDIR=$(echo "$ARGPATHS" | grep "/$1$")
-	APPIMAGE="$APPIMAGEDIR/$1"
-	if [ ! -d "$APPIMAGEDIR" ]; then
+	TARGET="$(command -v "$1" 2>/dev/null)"
+	APPIMAGE="$(readlink "$TARGET" 2>/dev/null)"
+	APPIMAGEDIR="$(dirname "$APPIMAGE" 2>/dev/null)"
+	if [ ! -e "$APPIMAGE" ]; then
 		echo " ERROR: \"$1\" is not installed"
 		return 1
 	elif ! strings -d "$APPIMAGE" | grep -- '--appimage-extract' 1>/dev/null; then


### PR DESCRIPTION
This way I'm not finding the apps directory by checking `ARGSPATH` for something that matches the name of the binary in PATH.

Shouldn't give issues with appman mode, but let me know.