### PR TITLE
allow setting `$SCRIPTDIR`

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -28,7 +28,7 @@ export CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 export APPMANCONFIG="$CONFIGDIR/appman"
 APPMANCONFIG="$CONFIGDIR/appman"
 SCRIPTDIR="${SCRIPTDIR:-$(xdg-user-dir DESKTOP 2>/dev/null)}"
-[ -d "$SCRIPTDIR" ] || SCRIPTDIR="$HOME"
+[ -d "$SCRIPTDIR" ] || SCRIPTDIR="$PWD"
 export SCRIPTDIR
 
 # Colors

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -27,7 +27,8 @@ export CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 export CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 export APPMANCONFIG="$CONFIGDIR/appman"
 APPMANCONFIG="$CONFIGDIR/appman"
-SCRIPTDIR="$(xdg-user-dir DESKTOP 2>/dev/null || echo "$HOME")"
+SCRIPTDIR="${SCRIPTDIR:-$(xdg-user-dir DESKTOP 2>/dev/null)}"
+[ -d "$SCRIPTDIR" ] || SCRIPTDIR="$HOME"
 export SCRIPTDIR
 
 # Colors


### PR DESCRIPTION
This allows the user to set the location of the `$SCRIPTDIR` directory, if the variable isn't set it will default to `xdg-user-dir DESKTOP 2>/dev/nul`

~~It also has a check that makes sure that the directory actually exists, if it doesn't it defaults to `$HOME`.~~ EDIT: Changed it to `$PWD` instead. 