### PR TITLE
use posix `LOGNAME` and shell built in test

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -10,7 +10,6 @@ _away_all() {
 
 # DETERMINE SYSTEM ARCHITECTURE AND CURRENT USER
 arch=$(uname -m)
-currentuser=$(who | awk '{print $1}')
 
 _check_dependency() {
     program="$1"
@@ -46,7 +45,7 @@ _download_am_modules() {
 	cd /opt/am/modules || exit
 	MODULES=$(curl -Ls https://raw.githubusercontent.com/ivan-hc/AM/main/APP-MANAGER | tr '"' '\n' | grep "[a-z]\.am$")
 	for module_name in $MODULES; do
-		if ! test -f ./"$module_name"; then
+		if [ ! -f ./"$module_name" ]; then
 			echo " ◆ Downloading $module_name..."
 			wget -q "https://raw.githubusercontent.com/ivan-hc/AM/main/modules/$module_name"
 			chmod a+x ./"$module_name"
@@ -55,7 +54,7 @@ _download_am_modules() {
 	cd ..
 
 	# ENABLE NON-ROOT PERMISSIONS TO THE MAIN DIRECTORY FOR THE CURRENT USER
-	chown -R $currentuser /opt/am 2> /dev/null
+	chown -R "${LOGNAME:-$USER}" /opt/am 2>/dev/null
 }
 
 echo '--------------------------------------------------------------------------'


### PR DESCRIPTION
This way the script depends less on external binaries.

`$LOGNAME` is posix and has to be set in any posix compliant system (which includes freebsd) I also added a fallback to `$USER just in case LOGNAME gets manually unset lol`