### PR TITLE
simplify check for `${SUDO,DOAS}_USER`

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -51,7 +51,7 @@ _download_am_modules() {
 	cd ..
 
 	# ENABLE NON-ROOT PERMISSIONS TO THE MAIN DIRECTORY FOR THE CURRENT USER
-	[ -n "$SUDO_USER" ] && chown -R "$SUDO_USER" /opt/am 2> /dev/null || [ -n "$DOAS_USER" ] && chown -R "$DOAS_USER" /opt/am 2> /dev/null
+	chown -R "${SUDO_USER:-$DOAS_USER}" /opt/am 2>/dev/null
 }
 
 echo '--------------------------------------------------------------------------'


### PR DESCRIPTION
Another check can also be added to not allow the INSTALL script to be ran without sudo/doas by checking if those two variables aren't set btw.