### PR TITLE
improve check for sudo

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -41,7 +41,10 @@ LightBlue='\033[1;34m'
 DIVIDING_LINE="-----------------------------------------------------------------------------"
 
 # Prevent the use of "sudo" ("AM")
-[ -n "$SUDO_COMMAND" ] && echo -e "\n Please do not use \"sudo\" to execute \"$CLI\", try again.\n" && exit 1
+if [ -n "${SUDO_USER:-$DOAS_USER}" ]; then
+	printf "\n Please do not use \"sudo\" to execute \"$CLI\", try again.\n\n"
+	exit 1
+fi
 
 function _create_cache_dir() {
 	AMCACHEDIR="$CACHEDIR/$AMCLI"


### PR DESCRIPTION
Turns out I'm able to use am with doas because the check only works for sudo.

Now it works:

![image](https://github.com/user-attachments/assets/8a11a6cd-ca36-4a8a-a074-a2493773c6e1)
