### PR TITLE
replace `grep -P` for posix alternative

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -505,8 +505,14 @@ _query_lists() {
 }
 
 _find_no_order() {
-	grep -i "$1" | grep -i "$2" | grep -i "$3" | grep -i "$4" | grep -i "$5" \
-		| grep -i "$6" | grep -i "$6" | grep -i "$7" | grep -i "$8" | grep -i "$9"
+	while read -r line; do
+		match=1
+		for term in "$@"; do
+			[ -n "$term" ] || continue
+			echo "$line" | grep -qi "$term" || { match=0; break; }
+		done
+		[ "$match" -eq 1 ] && echo "$line"
+	done
 }
 
 ################################################################################

--- a/modules/database.am
+++ b/modules/database.am
@@ -596,26 +596,26 @@ case "$1" in
 			echo "        $AMCLI $1 --toolpack [ARGUMENT]"; exit 1
 		fi
 		wget -q --tries=10 --timeout=20 --spider https://github.com && _completion_lists
-		if [ "$2" = --pkg ]; then
-			shift 2
+		shift
+		if [ "$1" = --pkg ]; then
+			shift
 			regex="$(echo "$@" | tr -s ' ' '|')"
 			printf "\n Search results for packages: %s\n\n" "$regex" | tr '[:lower:]' '[:upper:]'
 			sort "$AMDATADIR"/"$ARCH"-* | uniq \
 				| grep -iE "$regex" --color=always | _pretty_list_compat
-		elif [ "$2" = --all ]; then
-			shift 2
+		elif [ "$1" = --all ]; then
+			shift
 			_query_lists "$*"
 			_list_third_party && sort "$AMDATADIR"/"$ARCH"-* | uniq | _find_no_order "$@" | _pretty_list_compat
-		elif [ "$2" = --appimages ]; then
-			shift 2
+		elif [ "$1" = --appimages ]; then
+			shift
 			_query_lists "$*"
 			_list_appimages && sort "$AMDATADIR/$ARCH-appimages" | uniq | _find_no_order "$@" | _pretty_list_compat
-		elif [ "$2" = --toolpack ]; then
-			shift 2
+		elif [ "$1" = --toolpack ]; then
+			shift
 			_query_lists "$*"
 			_list_third_party && sort "$AMDATADIR/$ARCH-toolpack" | _find_no_order "$@" | _pretty_list_compat
 		else
-			shift
 			_query_lists "$*"
 			sort "$AMDATADIR"/"$ARCH"-app* | uniq | _find_no_order "$@" | _pretty_list_compat
 		fi

--- a/modules/database.am
+++ b/modules/database.am
@@ -326,7 +326,7 @@ _files_sort_by_size() {
 }
 
 _files_appman_mode_view() {
-	[ "$AMCLI" = am ] && [ -f "$APPMANCONFIG"/appman-config ] && _appman && APPMAN_ON=1 && _files_number && [ "$FILES_NUMBER" != 0 ] && echo "$DIVIDING_LINE" 
+	[ "$AMCLI" = am ] && [ -f "$APPMANCONFIG"/appman-config ] && _appman && APPMAN_ON=1 && _files_number && [ "$FILES_NUMBER" != 0 ] && echo "$DIVIDING_LINE"
 }
 
 _files_launcher_message() {
@@ -501,8 +501,12 @@ _list_apps_all_msg() {
 }
 
 _query_lists() {
-	printf "\n Search results for \"%s\":\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'
-	pattern="$(echo "$entries" | sed 's/ /(?=.*/g; s/$/)/g; s/(/)(/g; s/^/(?=.*/g;')"
+	printf "\n Search results for \"%s\":\n\n"  "$@" | tr '[:lower:]' '[:upper:]'
+}
+
+_find_no_order() {
+	grep -i "$1" | grep -i "$2" | grep -i "$3" | grep -i "$4" | grep -i "$5" \
+		| grep -i "$6" | grep -i "$6" | grep -i "$7" | grep -i "$8" | grep -i "$9"
 }
 
 ################################################################################
@@ -587,19 +591,27 @@ case "$1" in
 		fi
 		wget -q --tries=10 --timeout=20 --spider https://github.com && _completion_lists
 		if [ "$2" = --pkg ]; then
-			entries="$(echo "$@" | cut -f3- -d ' ' | tr -s ' ' '|')"
-			printf "\n Search results for packages: %s\n\n"  "$entries" | tr '[:lower:]' '[:upper:]'
-			sort "$AMDATADIR"/"$ARCH"-* | uniq | grep -iE "$entries" --color=always | _pretty_list_compat
-		elif [ "$2" = --appimages ] || [ "$2" = --toolpack ] || [ "$2" = --all ]; then
-			entries="$(echo "$@" | cut -f3- -d ' ')"
-			_query_lists
-			[ "$2" = --all ] && _list_third_party && sort "$AMDATADIR"/"$ARCH"-* | uniq | grep -Pi "$pattern" | _pretty_list_compat
-			[ "$2" = --appimages ] && _list_appimages && grep -Pi "$pattern" "$AMDATADIR/$ARCH-appimages" | _pretty_list_compat
-			[ "$2" = --toolpack ] && _list_third_party && sort "$AMDATADIR/$ARCH-toolpack" | grep -Pi "$pattern" | _pretty_list_compat
+			shift 2
+			regex="$(echo "$@" | tr -s ' ' '|')"
+			printf "\n Search results for packages: %s\n\n" "$regex" | tr '[:lower:]' '[:upper:]'
+			sort "$AMDATADIR"/"$ARCH"-* | uniq \
+				| grep -iE "$regex" --color=always | _pretty_list_compat
+		elif [ "$2" = --all ]; then
+			shift 2
+			_query_lists "$*"
+			_list_third_party && sort "$AMDATADIR"/"$ARCH"-* | uniq | _find_no_order "$@" | _pretty_list_compat
+		elif [ "$2" = --appimages ]; then
+			shift 2
+			_query_lists "$*"
+			_list_appimages && sort "$AMDATADIR/$ARCH-appimages" | uniq | _find_no_order "$@" | _pretty_list_compat
+		elif [ "$2" = --toolpack ]; then
+			shift 2
+			_query_lists "$*"
+			_list_third_party && sort "$AMDATADIR/$ARCH-toolpack" | _find_no_order "$@" | _pretty_list_compat
 		else
-			entries="$(echo "$@" | cut -f2- -d ' ')"
-			_query_lists
-			sort "$AMDATADIR"/"$ARCH"-app* | uniq | grep -Pi "$pattern" | _pretty_list_compat
+			shift
+			_query_lists "$*"
+			sort "$AMDATADIR"/"$ARCH"-app* | uniq | _find_no_order "$@" | _pretty_list_compat
 		fi
 		printf '\n'
 		;;

--- a/modules/database.am
+++ b/modules/database.am
@@ -509,7 +509,7 @@ _find_no_order() {
 		match=1
 		for term in "$@"; do
 			[ -n "$term" ] || continue
-			echo "$line" | grep -qi "$term" || { match=0; break; }
+			echo "$line" | grep -qi -- "$term" || { match=0; break; }
 		done
 		[ "$match" -eq 1 ] && echo "$line"
 	done


### PR DESCRIPTION
test carefully. 

Haven't found issues: 

![image](https://github.com/user-attachments/assets/4917b4d9-d54b-4857-b940-165a9047d609)

![image](https://github.com/user-attachments/assets/4c13e3f9-dc6c-4660-938b-5414dec9255f)

@xplshn @leo-arch If you have a better idea for the `_find_no_order` func let me know.