### PR TITLE
remove `-d` flag from `strings`

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -250,6 +250,7 @@ _files_files() {
 		 		_files_type &
 			fi
 		done
+		wait
 	fi
 	rm -f "$AMCACHEDIR"/files-sizes "$AMCACHEDIR"/files-db
 	for arg in $INSTALLED_APPS; do

--- a/modules/database.am
+++ b/modules/database.am
@@ -241,13 +241,13 @@ _files_db() {
 _files_files() {
 	cd "$APPSPATH" || exit 1
 	INSTALLED_APPS=$(find . -name 'remove' -printf "%h\n" 2>/dev/null | du -sh -- * 2> /dev/null | sort -rh | sed 's@.*	@@')
-	if ! test -f "$AMCACHEDIR"/version-args; then
+	if [ ! -f "$AMCACHEDIR"/version-args ]; then
 		_check_version
 	fi
-	if ! test -f "$AMCACHEDIR"/files-type; then
+	if [ ! -f "$AMCACHEDIR"/files-type ]; then
 		for arg in $INSTALLED_APPS; do
-			if test -f ./"$arg"/remove 2>/dev/null; then
-		 		_files_type
+			if [ -f ./"$arg"/remove 2>/dev/null ]; then
+		 		_files_type &
 			fi
 		done
 	fi

--- a/modules/database.am
+++ b/modules/database.am
@@ -175,7 +175,7 @@ _files_if_script() {
 }
 
 _files_if_appimage() {
-	if ! echo "$string" | grep 'AppImages require FUSE to run' >/dev/null 2>&1; then
+	if file ./"$arg/$arg" | grep -qi "static"; then
 		if grep "SANDBOXDIR" "$FILE" >/dev/null 2>&1; then
 			echo " ◆ $arg	|	appimage🔒" >> "$AMCACHEDIR"/files-type
 		else
@@ -192,10 +192,9 @@ _files_if_appimage() {
 
 _files_type() {
 	APPVERSION=$(<"$AMCACHEDIR"/version-args grep -w " ◆ $arg	|" | sed 's:.*|	::')
-	string=$(strings -d ./"$arg/$arg" 2>/dev/null)
 	FILE=$(command -v "$arg" 2>/dev/null)
 	LINK=$(readlink "$FILE" 2>/dev/null)
-	if echo "$string" | grep 'github.com/AppImage/AppImageKit/wiki/FUSE' >/dev/null 2>&1; then
+	if strings ./"$arg/$arg" 2>/dev/null | grep -q -m 1 'github.com/AppImage/AppImageKit/wiki/FUSE'; then
 		_files_if_appimage
 	elif file ./"$arg"/* | grep -E 'LSB|/bin' >/dev/null 2>&1; then
 		_files_if_binary

--- a/modules/management.am
+++ b/modules/management.am
@@ -200,9 +200,9 @@ function _launcher_appimage_bin() {
 
 function _launcher(){
 	_clean_launchers 2>/dev/null 1>/dev/null
-	if ! test -f "$arg"; then
+	if [ ! -f "$arg" ]; then
 		echo "ERROR: \"$arg\" not found" | _fit
-	elif ! strings -d "$arg" 2>/dev/null | grep -F -q 'if you run it with the --appimage-extract option'; then
+	elif ! strings "$arg" 2>/dev/null | grep -q -m 1 'github.com/AppImage/AppImageKit/wiki/FUSE'; then
 		echo "ERROR: \"$arg\" is NOT an AppImage" | _fit
 	else
 		printf " ◆ File: %s\n" "$arg"
@@ -257,11 +257,10 @@ function _nolibfuse() {
 		echo " ⚠️ Error: \"$target\" is NOT installed."
 		return 1
 	fi
-	string="$(strings -d "./$2" 2>/dev/null)"
-	if ! echo "$string" | grep -q -- 'run it with the --appimage-extract'; then
+	if ! strings "$arg" 2>/dev/null | grep -q -m 1 'github.com/AppImage/AppImageKit/wiki/FUSE'; then
 		echo " ⚠️ Error: $target is NOT an AppImage."
 		return 1
-	elif ! echo "$string" | grep -q -- 'AppImages require FUSE to run'; then
+	elif file "$arg" 2>/dev/null | grep -qi "static"; then
 		echo " ◆ $target is already a new generation AppImage."
 		return 1
 	elif test -f ./*.zsync; then

--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -29,7 +29,7 @@ _check_appimage() {
 	if [ ! -e "$APPIMAGE" ]; then
 		echo " ERROR: \"$1\" is not installed"
 		return 1
-	elif ! strings -d "$APPIMAGE" | grep -- '--appimage-extract' 1>/dev/null; then
+	elif ! strings "$APPIMAGE" | grep -q -m 1 -- '--appimage-extract'; then
 		echo " ERROR: \"$1\" is NOT an AppImage"
 		return 1
 	fi


### PR DESCRIPTION
Related to #1199

Using `grep -m 1` reduced the time it takes for `am -f` to complete over what was done before with `strings -d`:

Test (2nd result being with the change): 

![image](https://github.com/user-attachments/assets/0dacaa04-77d0-41bd-b245-cb3da7f6250a)

@xplshn if you know something that could speed this up even more, this feature of am has always been slow in first try without the cached files (+4 seconds).


