### PR TITLE
update mpv install script

### DIFF
--- a/programs/x86_64/mpv
+++ b/programs/x86_64/mpv
@@ -2,7 +2,7 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 APP=mpv
-SITE1="Samueru-sama/mpv-AppImage"
+SITE1="pkgforge-dev/mpv-AppImage"
 SITE2="ivan-hc/MPV-appimage"
 
 # CREATE DIRECTORIES AND ADD REMOVER
@@ -14,16 +14,13 @@ chmod a+x ../remove || exit 1
 # CHOOSE A VERSION
 read -r -p "
  Choose which version of mpv AppImage to use:
- 
- 1. mpv AppImage build using linuxdeploy, this how most appimages are made,
-    however they only work on distros equal or newer than Ubuntu 20.04 at 
-    the time of this writting.
 
-    Source: https://github.com/Samueru-sama/mpv-AppImage
+ 1. mpv AppImage built with all dependencies, makes it able to work on
+    any linux system, even musl ones.
 
- 2. mpv Archimage, this AppImage is made on top of JuNest, which makes it
-    able to run on distributions older than what the AppImage spec requires
-    however it comes at the cost of a increased installation size, near 10x.
+    Source: https://github.com/pkgforge-dev/mpv-AppImage
+
+ 2. mpv Archimage, this AppImage is made on top of JuNest (Archlinux).
 
     Source: https://github.com/ivan-hc/MPV-appimage
 
@@ -31,7 +28,7 @@ read -r -p "
 case "$response" in
 	1) rm -f /opt/"$APP"/version
 	UPDATER=1
-	version=$(curl -Ls https://api.github.com/repos/"$SITE1"/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*continuous.*mpv.*86_64.*mage$' | head -1)
+	version=$(curl -Ls https://api.github.com/repos/"$SITE1"/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*mpv.*86_64.*mage$' | head -1)
 	wget "$version"
 	echo "$version" >> /opt/$APP/version;;
 	2) rm -f /opt/"$APP"/version
@@ -56,7 +53,7 @@ set -u
 APP=mpv
 if [ -z "$APP" ]; then exit 1; fi
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/$SITE/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*continuous.*mpv.*86_64.*mage$' | head -1)
+version=$(curl -Ls https://api.github.com/repos/$SITE/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*mpv.*86_64.*mage$' | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	notify-send "A new version of $APP is available, please wait"
@@ -73,7 +70,7 @@ else
 fi
 EOF
 if [ "$UPDATER" = "1" ]; then
-	sed -i 's#$SITE#Samueru-sama/mpv-AppImage#g' /opt/"$APP"/AM-updater
+	sed -i 's#$SITE#pkgforge-dev/mpv-AppImage#g' /opt/"$APP"/AM-updater
 elif [ "$UPDATER" = "2" ]; then
 	sed -i 's#$SITE#ivan-hc/MPV-appimage#g' /opt/"$APP"/AM-updater
 fi
@@ -99,4 +96,3 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-


### PR DESCRIPTION
Turns out the script broke for my mpv because [I changed it to have versioned releases](https://github.com/pkgforge-dev/mpv-AppImage/releases) and there is no more continuous tag as result. 

It did not break because I transfered the repo to pkg-forge, github redirects this.

Also updated the description since I no longer use linuxdeploy to make the appimage since long ago lol. 

closes https://github.com/pkgforge-dev/mpv-AppImage/issues/10