### PR TITLE
Improve sed patch to work without gsed

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -52,11 +52,8 @@ if [ -n "${SUDO_USER:-$DOAS_USER}" ]; then
 	exit 1
 fi
 
-# check what sed we have
-if ! sed --version 2>/dev/null | grep -qi gnu && ! command -v gsed 1>/dev/null; then
-  echo "$DIVIDING_LINE"
-  echo " 💀 WARNING: You don't have GNU sed, things will likely break"
-  echo "$DIVIDING_LINE"
+if ! sed --version 2>/dev/null | grep -qi "gnu"; then
+	NO_SED_I=true
 fi
 
 _create_cache_dir() {
@@ -84,11 +81,27 @@ less() {
 
 # Force usage of a GNU implementation of "sed"
 sed() {
-    if command -v gsed >/dev/null 2>&1; then
-        command gsed "$@"
-    else
-        command sed "$@"
-    fi
+	if [ "$NO_SED_I" = true ] && [ "$1" = '-i' ]; then
+		if command -v gsed >/dev/null 2>&1; then
+			command gsed "$@"
+		else
+			shift
+			tmpsedYYY="$(command sed "$@" 2>/dev/null)"
+			while [ "$#" -gt 1 ]; do shift; done
+			if [ -n "$tmpsedYYY" ] && [ -f "$1" ]; then
+				echo "$tmpsedYYY" > "$1"
+				unset tmpsedYYY
+			else
+				>&2 echo " 💀 ERROR: Your version of sed does not support '-i' flag"
+				>&2 echo " without extension, we tried to workaround and failed"
+				>&2 echo " Please install gsed"
+				unset tmpsedYYY
+				return 1
+			fi
+		fi
+	else
+		command sed "$@"
+	fi
 }
 
 ################################################################################

--- a/modules/install.am
+++ b/modules/install.am
@@ -163,7 +163,13 @@ _apply_patches() {
 	sed -i "s#DirIcon ./icons/\"\$APP\" 1#DirIcon ./icons/\"\$APP\" 2#g" ./"$arg"
 	echo ""
 	# Use GNU implementation of "sed"
-	command -v gsed >/dev/null 2>&1 && sed -i -- "s/^sed -i/gsed -i/g; s/	sed -i/	gsed -i/g" ./"$arg"
+	if [ "$NO_SED_I" = true ]; then
+		if command -v gsed >/dev/null 2>&1; then
+			sed -i "s/sed -i/gsed -i/g" ./"$arg"
+		else
+			sed -i "s/sed -i/sed -i'' -e/g" ./"$arg"
+		fi
+	fi
 }
 
 _torsocks_error_message() {


### PR DESCRIPTION
Now am is able to install apps when there is only bsd sed without gnu sed, **tested without and with gsed** on chimera linux (bsd userland): 

![image](https://github.com/user-attachments/assets/93e1ca20-a182-4e8e-a36a-ae8539170d6a)

(Note the `broken sed detected` message is for testing, I put it where the variable about sed gets set)

---------------------------------------------

Explanation: 

* We check the version of `sed`, if it is not gnu sed the variable `NO_SED_I=true` gets set. 

* The sed function will check for `if [ "$NO_SED_I" = true ] && [ "$1" = '-i' ]; then`, if both a true it tries to see if we have gsed, if true it uses gsed by default. 

 * **If there is no gsed** it then applies a workaround that drops the `-i` flag (shift) and puts the sed command in a variable `$tmpsedYYY` and finally that variable replaces the file we just edited `echo "$tmpsedYYY" > "$1"` all while doing a some sanity checks. 

* If for some reason something goes wrong an error message explaining that situation and asking the error to install gsed is given. 



