### PR TITLE
make sure we have `file`

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -280,7 +280,7 @@ APPSLISTDB="$AMREPO/programs/$arch-apps"
 _am_dependences_check() {
 	# Check for essential commands required by the application
 	missing_deps=()
-	AMDEPENDENCES="cat chmod chown curl grep sed wget"
+	AMDEPENDENCES="cat chmod chown curl grep sed wget file"
 	for name in $AMDEPENDENCES; do
 		if ! command -v "$name" &>/dev/null; then
 			missing_deps+=("$name")

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -280,7 +280,7 @@ APPSLISTDB="$AMREPO/programs/$arch-apps"
 _am_dependences_check() {
 	# Check for essential commands required by the application
 	missing_deps=()
-	AMDEPENDENCES="cat chmod chown curl grep sed wget file"
+	AMDEPENDENCES="cat chmod chown curl file grep sed wget"
 	for name in $AMDEPENDENCES; do
 		if ! command -v "$name" &>/dev/null; then
 			missing_deps+=("$name")


### PR DESCRIPTION
This actually doesn't come installed by default on chimera wtf: 

![image](https://github.com/user-attachments/assets/fe459163-95de-4c95-b661-88b25d5f7999)



