### PR TITLE
change check for existing binary only in `/usr/local/bin`

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -425,7 +425,7 @@ case "$1" in
 			# Various cases that may occur during installation
 			if test -f "$APPSPATH"/"$pure_arg"/remove; then
 				echo " ◆ \"$pure_arg\" is already installed!" | tr '[:lower:]' '[:upper:]'
-			elif command -v "$pure_arg" >/dev/null 2>&1; then
+			elif [ -n "$(PATH=/usr/local/bin command -v "$pure_arg" 2>/dev/null)" ]; then
 				echo " 💀 ERROR: \"$pure_arg\" command already exists!"
 			elif echo "$arg" | grep -q "/"; then
 				if test -f "$arg" 2> /dev/null; then


### PR DESCRIPTION
An issue with the current method is that by directly checking `command -v "$pure_arg"` am won't be able to install an application if the same binary name already exists in a place other than `/usr/local/bin`.

In other words this prevents the user from installing binaries of different versions than what their distro provides,

This PR changes the check to run in in a subshell with `PATH=/usr/local/bin command -v "$pure_arg" 2>/dev/null`, that way it won't allow to install the app only if there is a file with the same name in `/usr/local/bin`.