### PR TITLE
"AM" 9.4.1

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.4-2"
+AMVERSION="9.4.1"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
 AMBRANCH=$(basename "$AMREPO")
 MODULES_SOURCE="$AMREPO/modules"
-
-# Determine catalogue in use
-export AMCATALOGUEMARKDOWNS="https://portable-linux-apps.github.io/apps"
-export AMCATALOGUEICONS="https://portable-linux-apps.github.io/icons"
 
 # Determine the name of this script and its working directory
 export REALDIR="$PWD"
@@ -268,9 +264,17 @@ _betatester_message_on() {
 	fi
 }
 
+################################################################################
+#				APPS DATABASE
+################################################################################
+
 # Apps database in use
-APPSDB="$AMREPO/programs/$ARCH"
-APPSLISTDB="$AMREPO/programs/$ARCH-apps"
+[ -z "$APPSDB" ] && APPSDB="$AMREPO/programs/$ARCH"
+[ -z "$APPSLISTDB" ] && APPSLISTDB="$AMREPO/programs/$ARCH-apps"
+
+# Determine catalogue in use
+[ -z "$AMCATALOGUEMARKDOWNS" ] && export AMCATALOGUEMARKDOWNS="https://portable-linux-apps.github.io/apps"
+[ -z "$AMCATALOGUEICONS" ] && export AMCATALOGUEICONS="https://portable-linux-apps.github.io/icons"
 
 ################################################################################
 #				SECURITY
@@ -862,7 +866,7 @@ _use_sync() {
 	_betatester_message_on
 	_sync_installation_scripts
 	_sync_databases
-	if [ "$(realpath "$0")" != "/usr/bin/am" ]; then
+	if [ "$(realpath "$0")" != "/usr/bin/am" ] && [ "$AMSYNC" != 1 ]; then
 		_sync_modules
 		_sync_amcli
 	fi

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can use the command `am -a {PROGRAM}` to view the description and get the so
  - [How to set the path to local apps](#how-to-set-the-path-to-local-apps)
  - [What programs can be installed](#what-programs-can-be-installed)
    - [Supported third-party databases](#supported-third-party-databases)
+   - [How to replace AM database](#how-to-replace-am-database)
 
 [How to update all programs, for real!](#how-to-update-all-programs-for-real)
  - [How to update all installed apps](#how-to-update-all-installed-apps)
@@ -228,6 +229,22 @@ These databases have the task of supporting and enriching the list of applicatio
 Third-party databases can show basic information normally with the option `-a` or `about`, no flag is needed here. However, the name of the package will be shown with an extension equivalent to the flag used to install it. For example `{PROGRAM}` will be `{PROGRAM}.toolpack` if coming from the "Toolpacks" database.
 
 Same thing, you can use `am -i {PROGRAM}.toolpack` or `am -i --user {PROGRAM}.toolpack` to install the program without using the flag.
+
+#### How to replace AM database
+One thing I care a lot about is **continuity**, and as I have seen over the years, not all open source developers are able to maintain a project. This could happen to me in the future. I don't want it to be that way.
+
+Because of this, I have made some essential variables "customizable":
+- `APPSDB`, i.e. the "raw" directory of the architecture in use, containing the installation scripts (default value *https://raw.githubusercontent.com/ivan-hc/AM/main/programs/$ARCH*), this is mainly used in `-i`, `-d` and `-s`/`-u`
+- `APPSDBLIST`, i.e. the list of applications available for that architecture (default value *https://raw.githubusercontent.com/ivan-hc/AM/main/$ARCH-apps*), this is used every time lists are updated, for example in `-l`, `-q` and `-s`/`-u`
+- `AMCATALOGUEMARKDOWNS`, i.e. the pages in .md format from the catalog of applications available in this database (default value *https://portable-linux-apps.github.io/apps*), this is used in `-a`
+- `AMCATALOGUEICONS`, i.e. the icons in .png format available in the catalog of applications available in this database (default value *https://portable-linux-apps.github.io/icons*), this is used in `-i`, in case the installation script fails to get an icon for the application
+- `AMSYNC`, if set to "1" prevents AM from updating itself and updating modules when running `-s` or `-u`
+
+it is enough to `export` the variables above and respect the destination file format (follow the URLs in parentheses) in case you decide to open a new community-driven database that can make up for the lack of support in this repository.
+
+I did this to not tie users to this database and to allow them to use AM and all its features if I, Ivan, am unable to intervene for any reason.
+
+There are many discontinuous projects. Should this become one too, it will not be obsolete.
 
 ------------------------------------------------------------------------
 

--- a/modules/database.am
+++ b/modules/database.am
@@ -54,11 +54,11 @@ _about_description_for_third_party() {
 	if echo "$appname" | grep -q ".appbundle$"; then
 		readme_source="$appbundle_readme"
 		repo_source="$appbundle_repo"
-	else
+	elif echo "$arg" | grep -q ".toolpack$"; then
 		readme_source="$toolpack_readme"
 		repo_source="$toolpack_repo"
 	fi
-	appname_arg=$(curl -Ls "$readme_source" | grep -i "^| $appname " | tr '|' '\n' | cut -c 2- | grep .)
+	appname_arg=$(curl -Ls "$readme_source" 2>/dev/null | grep -i "^| $appname " | tr '|' '\n' | cut -c 2- | grep .)
 	about_description=$(echo "$appname_arg" | awk -F: "NR==$awk_description")
 	about_site=$(echo "$appname_arg" | awk -F: "NR==$awk_site")
 	printf "\n%b\n\nSOURCE: %b\n\nDATABASE: %b\n" "$about_description" "$about_site" "$repo_source"


### PR DESCRIPTION
Allow usage of third party databases by exporting variables

# Apps database in use
```
[ -z "$APPSDB" ] && APPSDB="$AMREPO/programs/$ARCH"
[ -z "$APPSLISTDB" ] && APPSLISTDB="$AMREPO/programs/$ARCH-apps"
```
# Determine catalogue in use
```
[ -z "$AMCATALOGUEMARKDOWNS" ] && export AMCATALOGUEMARKDOWNS="https://portable-linux-apps.github.io/apps"
[ -z "$AMCATALOGUEICONS" ] && export AMCATALOGUEICONS="https://portable-linux-apps.github.io/icons"
```

To determine alternative sources, its enough to "export" the above variables
```
export APPSDB="https://url-to-site.something"
export APPSLISTDB="https://url-to-site.something/list.txt"
```
catalogues are optional, you may not have description or URL btw
```
export AMCATALOGUEMARKDOWNS="https://url-to-site.something/markdown-files/file.md"
```
you can leave the url to icons as is, but if you have a better source, consider that what you install apps, the icon must have the same name of the argument
```
export AMCATALOGUEICONS="https://url-to-site.something/app.png"
```

Finally, if you still want to use the main CLI of AM, you can prevent updating AM and modulesfrom a different path
```
export AMSYNC=1
```
so you can keep AM and its modules as they are, without updates.