### PR TITLE
Option -f, add "🔒" to versions locked with option "lock"

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -275,6 +275,7 @@ _files() {
 		if test -f ./"$arg"/remove 2>/dev/null; then
 			APPVERSION=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/version-args | tr '	' '\n' | tail -1)
 			[ -f ./"$arg"/AM-LOCK ] && APPVERSION="$APPVERSION🔒"
+			echo "$APPVERSION" | grep -q "🔒$" && APPLOCKED=1
 			APPTYPE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-type | tr '	' '\n' | tail -1)
 			APPSYZE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-sizes | tr '	' '\n' | tail -1)
 			APPDB=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-db | tr '	' '\n' | tail -1)
@@ -305,13 +306,14 @@ _files_appimage_type_notes() {
 
 _files_total_size() {
 	printf "\n"
-	if command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files* && grep -q "[0-9]🔒" "$AMCACHEDIR"/files*; then
+	if command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files* && [ -n "$APPLOCKED" ]; then
 		printf '%s\n\n' " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
 	elif command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files*; then
 		printf '%s\n\n' " AppImages with 🔒 are sandboxed with aisap"
-	elif grep -q "[0-9]🔒" "$AMCACHEDIR"/files*; then
+	elif [ -n "$APPLOCKED" ]; then
 		printf '%s\n\n' " Versions with 🔒 are locked"
 	fi
+	APPLOCKED=""
 	INSTALLED_APPS_PLAN=$(echo "$INSTALLED_APPS_PATHS" | tr '\n' ' ')
 	TOTAL_SIZE=$(du -shc $INSTALLED_APPS_PLAN | awk 'END {print $1"iB"}' | sed 's/...$/ &/')
 	echo " TOTAL SIZE: $TOTAL_SIZE of disk space in use"

--- a/modules/database.am
+++ b/modules/database.am
@@ -305,8 +305,12 @@ _files_appimage_type_notes() {
 
 _files_total_size() {
 	printf "\n"
-	if command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files*; then
+	if command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files* && grep -q "[0-9]🔒" "$AMCACHEDIR"/files*; then
+		printf '%s\n\n' " AppImages with 🔒 are sandboxed with aisap, versions with 🔒 are locked"
+	elif command -v aisap >/dev/null 2>&1 && grep -qe "appimage🔒" "$AMCACHEDIR"/files*; then
 		printf '%s\n\n' " AppImages with 🔒 are sandboxed with aisap"
+	elif grep -q "[0-9]🔒" "$AMCACHEDIR"/files*; then
+		printf '%s\n\n' " Versions with 🔒 are locked"
 	fi
 	INSTALLED_APPS_PLAN=$(echo "$INSTALLED_APPS_PATHS" | tr '\n' ' ')
 	TOTAL_SIZE=$(du -shc $INSTALLED_APPS_PLAN | awk 'END {print $1"iB"}' | sed 's/...$/ &/')

--- a/modules/database.am
+++ b/modules/database.am
@@ -274,6 +274,7 @@ _files() {
 	for arg in $INSTALLED_APPS; do
 		if test -f ./"$arg"/remove 2>/dev/null; then
 			APPVERSION=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/version-args | tr '	' '\n' | tail -1)
+			[ -f ./"$arg"/AM-LOCK ] && APPVERSION="$APPVERSION🔒"
 			APPTYPE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-type | tr '	' '\n' | tail -1)
 			APPSYZE=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-sizes | tr '	' '\n' | tail -1)
 			APPDB=$(grep -w " ◆ $arg	|" "$AMCACHEDIR"/files-db | tr '	' '\n' | tail -1)


### PR DESCRIPTION
Applications that have version locked not to be updated will be shown with 🔒

In the example below I locked Virtualbox using the command `am lock virtualbox`

![Istantanea_2024-12-25_22-20-49](https://github.com/user-attachments/assets/c2673139-37d3-44d6-b9a5-6b0b7cf07291)

Fun fact, I just updated [my VirtualBox KVM AppImage](https://github.com/ivan-hc/VirtualBox-appimage) yesterday, version 7.1.4 is based on QT6 and is way too slow for my taste... plus Kvantum 6 hasn't been ported to Debian Testing/Unstable yet, so I downgraded with `--rollback` and used the 7.0.20 release, which works better.