### PR TITLE
Add option "-fi" to only show installed apps

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1251,7 +1251,7 @@ case "$1" in
 
 			Description: Install AppImages from github.com, outside the database. This allows you to install, update and manage them all like the others. Where \"user/project\" can be the whole URL to the github repository, give a name to the program so that it can be used from the command line. Optionally, add an \"univoque\" keyword if multiple AppImages are listed.
 
-			${Gold}files, -f\033, -fi[0m
+			${Gold}files, -f, -fi\033[0m
 
 					${LightBlue}$AMCLI -f
 					${LightBlue}$AMCLI -f --byname

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.4.1-1"
+AMVERSION="9.4.1-2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1105,7 +1105,7 @@ case "$1" in
 		exit 0
 		;;
 	'about'|'-a'|\
-	'files'|'-f'|\
+	'files'|'-f'|'-fi'|\
 	'list'|'-l'|\
 	'query'|'-q')
 		MODULE="database.am"
@@ -1251,13 +1251,13 @@ case "$1" in
 
 			Description: Install AppImages from github.com, outside the database. This allows you to install, update and manage them all like the others. Where \"user/project\" can be the whole URL to the github repository, give a name to the program so that it can be used from the command line. Optionally, add an \"univoque\" keyword if multiple AppImages are listed.
 
-			${Gold}files, -f\033[0m
+			${Gold}files, -f\033, -fi[0m
 
 					${LightBlue}$AMCLI -f
 					${LightBlue}$AMCLI -f --byname
 					${LightBlue}$AMCLI -f --less\033[0m
 
-			Description: Shows the list of all installed programs, with sizes. By default apps are sorted by size, use \"--byname\" to sort by name. With the option \"--less\" it shows only the number of installed apps.
+			Description: Shows the list of all installed programs, with sizes. By default apps are sorted by size, use \"--byname\" to sort by name. With the option \"--less\" it shows only the number of installed apps. Option \"-fi\" only shows installed apps, not the AppImages integrated with the \"--launcher\" option.
 
 			${Gold}help, -h\033[0m
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Install AppImages from github.com, outside the database. This allows you to inst
 NOTE: Since this is an "install" option, you can add the "`--user`" flag (before "`user/project`") to install apps locally. See "`--user`" at the bottom to learn more.
 
 ------------------------------------------------------------------------
-### `files`, `-f`
+### `files`, `-f`, `-fi`
 
 		am -f
 		am -f --byname
@@ -384,7 +384,7 @@ NOTE: Since this is an "install" option, you can add the "`--user`" flag (before
 
 **Description**:
 
-Shows the list of all installed programs, with sizes. By default apps are sorted by size, use "`--byname`" to sort by name. With the option "`--less`" it shows only the number of installed apps.
+Shows the list of all installed programs, with sizes. By default apps are sorted by size, use "`--byname`" to sort by name. With the option "`--less`" it shows only the number of installed apps. Option "`-fi`" only shows installed apps, not the AppImages integrated with the "`--launcher`" option.
 
 ------------------------------------------------------------------------
 ### `help`, `-h`

--- a/modules/database.am
+++ b/modules/database.am
@@ -557,19 +557,19 @@ case "$1" in
 		done
 		;;
 
-	'-f'|'files')
+	'-f'|'files'|'-fi')
 		if [ "$2" = "--less" ]; then
 			_files_number && echo "$FILES_NUMBER"
 			[ "$AMCLI" = am ] && [ -f "$APPMANCONFIG"/appman-config ] && _appman && echo "$DIVIDING_LINE" && _files_number && echo "$FILES_NUMBER"
 		elif [ "$2" = "--byname" ]; then
 			_files_sort_by_name
 			_files_appman_mode_view && _files_sort_by_name
-			[ -d "$DATADIR"/applications/AppImages ] && echo "$DIVIDING_LINE" && _files_launcher
+			[ "$1" != "-fi" ] && [ -d "$DATADIR"/applications/AppImages ] && echo "$DIVIDING_LINE" && _files_launcher
 			_betatester_message_on
 		else
 			_files_sort_by_size
 			_files_appman_mode_view && _files_sort_by_size
-			[ -d "$DATADIR"/applications/AppImages ] && echo "$DIVIDING_LINE" && _files_launcher
+			[ "$1" != "-fi" ] && [ -d "$DATADIR"/applications/AppImages ] && echo "$DIVIDING_LINE" && _files_launcher
 			_betatester_message_on
 		fi
 		;;


### PR DESCRIPTION
Add option "`-fi`" to only show installed apps, without the AppImages integrated with the "`--launcher`" option

![Istantanea_2024-12-27_06-36-05](https://github.com/user-attachments/assets/eade62de-4437-4c9f-8b5e-4f9d9a13b309)
