### PR TITLE
Enhancement of the Program List Functionality

### DIFF
--- a/programs/generate-programs-list.sh
+++ b/programs/generate-programs-list.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -eu
+
+generate_list() {
+    file="$1"
+
+    [ ! -f "$file" ] && { echo "Error: not found '$file'"; return; }
+
+    name=$(basename "$file")
+    type=$(sed -n "/^# Type:[\ ]*/{s///p;q}" "$file")
+    description=$(sed -n "/^# Description:[\ ]*/{s///p;q}" "$file")
+
+    if [ -z "$description" ]; then
+        echo "Warn: not description: '$file' " >&2
+    fi
+
+    line="◆ $name : $description"
+
+    if echo "$type" | grep -iqE "^(pkg2)?appimage$"; then
+        echo "$line" >> "$arch-appimages"
+    fi
+    echo "$line" >> "$arch-apps"
+}
+
+DIRS=$(find . -type d | grep "/" | sed 's:.*/::')
+[ $# -gt 0 ] && DIRS="$*"
+
+for arch in $DIRS; do
+    [ ! -d "$arch" ] && { echo "Error: directory not found: $arch"; continue; }
+    echo "Info: Generate program list for '$arch'"
+
+    [ -f "$arch-apps" ] && rm "$arch-apps"
+    [ -f "$arch-appimages" ] && rm "$arch-appimages"
+
+    find "$arch" -type f -print | sort | while IFS= read -r file; do
+        generate_list "$file"
+    done
+done
+

--- a/programs/run_once_add_description_to_programs_scripts.sh
+++ b/programs/run_once_add_description_to_programs_scripts.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -eu
+
+get_program_type() {
+    [ $# -ne 2 ] && { echo "need 2 args" >&2; exit 1; }
+    arch="$1"
+    program_name="$2"
+    file="$arch/$program_name"
+
+    if grep -qe 'APP=ffwa-*' "$file"; then
+        echo "webapp"
+        return
+    elif grep -qe '--pbundle_desktop' "$file"; then
+        echo "appbundle"
+        return
+    elif grep -qe '\./appimagetool \./pkg2appimage' "$file" \
+    || grep -qE 'SITE="ivan-hc/(KDE[^ ]*|Data[^ ]*pkg2)appimage' "$file"; then
+        echo "pkg2appimage"
+        return
+    #elif grep -qe '--appimage-extract' "$file" \
+    #|| grep -e 'version=' "$file" | grep -iqE '[\.\ ]{1}appimage[^a-zA-Z0-9_-]|(\*)mage|mage(\$)' \
+    #&& ! echo "$program_name" | grep -qwE '[^ ]*flatimage|rimage|gameimage'; then
+        #echo "appimage"
+        #return
+    elif grep -iq '◆ '"$program_name"' :' "$arch-appimages"; then
+        echo "appimage"
+        return
+    elif grep -qe 'AM-rollback' "$file"; then
+        echo "roolback"
+        return
+    else
+        echo "archive"
+    fi
+}
+
+DIRS=$(find . -type d | grep "/" | sed 's:.*/::')
+for arch in $DIRS; do
+    [ ! -f "$arch-apps" ] && continue
+
+    while IFS= read -r line; do
+        program_name=$(echo "$line" | awk '{print $2}')
+        description=$(echo "$line" | sed 's/◆ [^ ]* : //')
+
+        file="$arch/$program_name"
+
+        if [ ! -f "$file" ]; then
+            echo "Error: not found: '$file' " >&2
+            continue
+        fi
+
+        program_type=$(get_program_type "$arch" "$program_name")
+
+        insert_string="# Type: $program_type\n# Description: $description"
+        sed -i '2 i '"$insert_string"'' "$file"
+
+    done < "$arch-apps"
+done
+

--- a/templates/AM-SAMPLE-AppBundle
+++ b/templates/AM-SAMPLE-AppBundle
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Type: appbundle
+# Description: A oneline description for this program.
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Type: appimage
+# Description: A oneline description for this program.
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u

--- a/templates/AM-SAMPLE-Archive
+++ b/templates/AM-SAMPLE-Archive
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Type: archive
+# Description: A oneline description for this program.
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u

--- a/templates/AM-SAMPLE-Firefox-webapp
+++ b/templates/AM-SAMPLE-Firefox-webapp
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Type: webapp
+# Description: A oneline description for this program.
 
 APP=ffwa-SAMPLE
 APPNAME="GIVEMEANAME"

--- a/templates/AM-SAMPLE-pkg2appimage
+++ b/templates/AM-SAMPLE-pkg2appimage
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Type: pkg2appimage
+# Description: A oneline description for this program.
 
 set -u
 APP=SAMPLE

--- a/templates/AM-SAMPLE-pkg2appimage-custom
+++ b/templates/AM-SAMPLE-pkg2appimage-custom
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Type: pkgappimage
+# Description: A oneline description for this program.
 
 set -u
 APP=SAMPLE

--- a/templates/SAMPLE-rollback
+++ b/templates/SAMPLE-rollback
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Type: rollback
+# Description: A oneline description for this program.
 
 APP=SAMPLE
 rm -f ./rollback-args ./AM-rollback


### PR DESCRIPTION
Introducing two new comment fields for each program entry:

```
# Type: webapp | appbundle | pkg2appimage | appimage | rollback
# Description: A one-line description for this program.
```

The `Type` field stores the installation type of the script. There may be naming or categorization inconsistencies in the current pull request.

`run_once_add_description_to_programs_scripts.sh`: This script adds the new comments to all existing program scripts.

`generate-programs-list.sh`: This script iterates through all folders in the current directory, reads the comments from all programs within the subfolders, and updates the list. It can accept a specific folder to process.

The main purpose of this pull request is to improve the maintainability of the program list. The list generation method remains the same: `$arch-apps` and `$arch-appimages`.  The `appimage` list includes AppImage programs built from the `ivan-hc/(KDE[^ ]*|Data[^ ]*pkg2)appimage.*` repositories (Type: pkg2appimage). Therefore, `$arch-appimage` is a larger list than the original. These scripts can be modified to change this.

Because all existing program scripts need to be updated, the number of changes is significant. Only the scripts are uploaded.

![image](https://github.com/user-attachments/assets/5fd75e82-67e9-495c-9ce1-a2c7c64e05b4)

Note that several programs are currently missing descriptions, as indicated in the script output.