### PR TITLE
update `prusa-slicer` to working fork

### DIFF
--- a/programs/x86_64/prusa-slicer
+++ b/programs/x86_64/prusa-slicer
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=prusa-slicer
-SITE="prusa3d/PrusaSlicer"
+SITE="probonopd/PrusaSlicer"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,13 +12,13 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/prusa3d/PrusaSlicer/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/probonopd/PrusaSlicer/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
-#wget "$version.zsync" 2> /dev/null # Comment out this line if you want to use zsync
+# Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..
 mv ./tmp/*mage ./"$APP"
-mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null
+# Keep this space in sync with other installation scripts
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
 chmod a+x ./"$APP" || exit 1
@@ -31,18 +31,21 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=prusa-slicer
-SITE="prusa3d/PrusaSlicer"
+SITE="probonopd/PrusaSlicer"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/prusa3d/PrusaSlicer/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/probonopd/PrusaSlicer/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if [ "$version" != "$version0" ] || [ -e /opt/"$APP"/*.zsync ]; then
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
-	[ -e ../*.zsync ] || notify-send "A new version of $APP is available, please wait"
-	[ -e ../*.zsync ] && wget "$version.zsync" 2>/dev/null || { wget "$version" || exit 1; }
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
-	mv ./tmp/*.zsync ./"$APP".zsync 2>/dev/null || mv --backup=t ./tmp/*mage ./"$APP"
-	[ -e ./*.zsync ] && { zsync ./"$APP".zsync || notify-send -u critical "zsync failed to update $APP"; }
+	mv --backup=t ./tmp/*mage ./"$APP"
 	chmod a+x ./"$APP" || exit 1
 	echo "$version" > ./version
 	rm -R -f ./*zs-old ./*.part ./tmp ./*~


### PR DESCRIPTION
Context: 

Upstream added a [webkit2gtk dependency](https://github.com/prusa3d/PrusaSlicer/issues/12968) that broke the AppImage because the library is terribly written, then blamed AppImage for it and made nonsense statements such as that it is impossible to bundle glibc. https://github.com/prusa3d/PrusaSlicer/issues/13653

This PR updates the package to probonos fork because so far they have just ignored all complains from users, despite numerous issues about this, such as: 

https://github.com/prusa3d/PrusaSlicer/issues/14020

https://github.com/prusa3d/PrusaSlicer/issues/14057

https://github.com/prusa3d/PrusaSlicer/issues/13982

https://github.com/prusa3d/PrusaSlicer/issues/13720

https://github.com/prusa3d/PrusaSlicer/issues/13862#issuecomment-2564572027


