### PR TITLE
fix: grep

### DIFF
--- a/modules/database.am
+++ b/modules/database.am
@@ -62,7 +62,7 @@ _about_description_for_third_party() {
 
 _about_description() {
 	if curl -o /dev/null -sIf "$markdown_url"; then
-		markdown_page=$(curl -Ls "$markdown_url" | grep -v -- "^#\|^.*| \[Applications\|^.*| \-\|^.*\!\[")
+		markdown_page=$(curl -Ls "$markdown_url" | grep -v -- "^#\|^.*| \[Applications\|^.*| -\|^.*!\[")
 		echo "$markdown_page"
 	elif grep -q "^◆ $package_name " "$AMDATADIR"/"$ARCH"-*; then
 		appname="$package_name"


### PR DESCRIPTION
GNU bash, version 5.2.32(1)-release (x86_64-unknown-linux-gnu)
### Output from `am -a fzf` command
before fix
```
-----------------------------------------------------------------------------
 PACKAGE: fzf
 STATUS: not installed
grep: warning: stray \ before -
grep: warning: stray \ before !
 
 A command-line fuzzy finder.
 
 SITE: https://github.com/junegunn/fzf
-----------------------------------------------------------------------------
```
after fix
```
-----------------------------------------------------------------------------
 PACKAGE: fzf
 STATUS: not installed
 
 A command-line fuzzy finder.
 
 SITE: https://github.com/junegunn/fzf
-----------------------------------------------------------------------------
```

