### PR TITLE
Update install.am

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -214,7 +214,7 @@ _post_installation_processes() {
 	# Patch .desktop to change paths if the app is installed locally
 	if [ "$AMCLI" = "appman" ]; then
 		for a in $DATADIR/applications/*-AM.desktop; do
-			sed -i "s#Exec=$arg#Exec=$BINDIR/$arg#g" "$a" 2>/dev/null
+			sed -i "s#Exec=$pure_arg#Exec=$BINDIR/$pure_arg#g" "$a" 2>/dev/null
 			sed -i "s#Exec=/usr/bin/#Exec=$BINDIR/#g" "$a" 2>/dev/null
 			sed -i "s#Exec=/opt/#Exec=$BINDIR/#g" "$a" 2>/dev/null
 		done


### PR DESCRIPTION
- fix launchers for installation scripts with the name that ends with "-appimage", in AppMan