### PR TITLE
Add --portable flag in "-q" or "query" and "-l" or "list"

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.6.1-3"
+AMVERSION="9.6.1-4"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -500,7 +500,7 @@ available_options="about add apikey backup clean config disable downgrade downlo
 	install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite purge query reinstall remove sandbox \
 	select sync template test unhide unlock update --all --appimages --apps --byname --config --convert --debug \
 	--devmode-disable --devmode-enable --disable-notifications --enable-notifications --force-latest --home --icons \
-	-ias --launcher --less --pkg --rollback --disable-sandbox --sandbox --system --user $third_party_flags"
+	-ias --launcher --less --pkg --portable --rollback --disable-sandbox --sandbox --system --user $third_party_flags"
 
 _completion_lists() {
 	# Remove existing lists and download new ones
@@ -512,7 +512,7 @@ _completion_lists() {
 		echo "$o" >> "$AMDATADIR"/list
 	done
 	# Detecl valid lists
-	valid_lists="apps$\|appimages$"
+	valid_lists="apps$\|appimages$\|portable$"
 	for tp_list in $third_party_lists; do
 		valid_lists="$valid_lists\|$tp_list$"
 	done
@@ -935,9 +935,15 @@ _sync_appimages_list() {
 	curl -Ls "$APPIMAGES_LIST" > "$AMDATADIR/$ARCH-appimages"
 }
 
+_sync_portable_list() {
+	PORTABLE_LIST="${PORTABLE_LIST:-$AMREPO/programs/$ARCH-portable}"
+	curl -Ls "$PORTABLE_LIST" > "$AMDATADIR/$ARCH-portable"
+}
+
 _sync_databases() {
 	printf "%b\n Check and update offline lists of additional databases...\n" "$DIVIDING_LINE"
 	_sync_appimages_list
+	_sync_portable_list
 	_sync_third_party_lists 2>/dev/null
 	_completion_lists
 }
@@ -1463,9 +1469,10 @@ case "$1" in
 
 			${Gold}list, -l\033[0m
 
-					${LightBlue}$AMCLI -l
-					${LightBlue}$AMCLI -l --all
+					${LightBlue}$AMCLI -l\033[0m
+					${LightBlue}$AMCLI -l --all\033[0m
 					${LightBlue}$AMCLI -l --appimages\033[0m
+					${LightBlue}$AMCLI -l --portable\033[0m
 
 			Description: Shows the list of all the apps available, or just the AppImages. It can also be extended with additional flags, the \"--all\" flag allows you to consult the set of all supported databases (see third-party flags, at the bottom of this message).
 
@@ -1493,12 +1500,13 @@ case "$1" in
 
 			${Gold}query, -q\033[0m
 
-					${LightBlue}$AMCLI -q {KEYWORD}
-					${LightBlue}$AMCLI -q --all {KEYWORD}
-					${LightBlue}$AMCLI -q --appimages {KEYWORD}
+					${LightBlue}$AMCLI -q {KEYWORD}\033[0m
+					${LightBlue}$AMCLI -q --all {KEYWORD}\033[0m
+					${LightBlue}$AMCLI -q --appimages {KEYWORD}\033[0m
+					${LightBlue}$AMCLI -q --portable {KEYWORD}\033[0m
 					${LightBlue}$AMCLI -q --pkg {PROGRAM1} {PROGRAM2}\033[0m
 
-			Description: Search for keywords in the list of available applications, add the \"--appimages\" option to list only the AppImages or add \"--pkg\" to list multiple programs at once. The \"--all\" flag allows you to consult the set of all supported databases.
+			Description: Search for keywords in the list of available applications, add the \"--appimages\" option to list only the AppImages, \"--portable\" option to list only the portable apps or add \"--pkg\" to list multiple programs at once. The \"--all\" flag allows you to consult the set of all supported databases.
 
 			${Gold}reinstall\033[0m
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1469,9 +1469,9 @@ case "$1" in
 
 			${Gold}list, -l\033[0m
 
-					${LightBlue}$AMCLI -l\033[0m
-					${LightBlue}$AMCLI -l --all\033[0m
-					${LightBlue}$AMCLI -l --appimages\033[0m
+					${LightBlue}$AMCLI -l
+					${LightBlue}$AMCLI -l --all
+					${LightBlue}$AMCLI -l --appimages
 					${LightBlue}$AMCLI -l --portable\033[0m
 
 			Description: Shows the list of all the apps available, or just the AppImages. It can also be extended with additional flags, the \"--all\" flag allows you to consult the set of all supported databases (see third-party flags, at the bottom of this message).
@@ -1500,10 +1500,10 @@ case "$1" in
 
 			${Gold}query, -q\033[0m
 
-					${LightBlue}$AMCLI -q {KEYWORD}\033[0m
-					${LightBlue}$AMCLI -q --all {KEYWORD}\033[0m
-					${LightBlue}$AMCLI -q --appimages {KEYWORD}\033[0m
-					${LightBlue}$AMCLI -q --portable {KEYWORD}\033[0m
+					${LightBlue}$AMCLI -q {KEYWORD}
+					${LightBlue}$AMCLI -q --all {KEYWORD}
+					${LightBlue}$AMCLI -q --appimages {KEYWORD}
+					${LightBlue}$AMCLI -q --portable {KEYWORD}
 					${LightBlue}$AMCLI -q --pkg {PROGRAM1} {PROGRAM2}\033[0m
 
 			Description: Search for keywords in the list of available applications, add the \"--appimages\" option to list only the AppImages, \"--portable\" option to list only the portable apps or add \"--pkg\" to list multiple programs at once. The \"--all\" flag allows you to consult the set of all supported databases.

--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Prevent an application being updated, if it has an"AM-updater" script.
 		am -l
 		am -l --all
 		am -l --appimages
+  		am -l --portable
 
 **Description**:
 
@@ -541,11 +542,12 @@ Overwrite apps with snapshots saved previously (see "`-b`").
 		am -q {KEYWORD}
 		am -q --all {KEYWORD}
 		am -q --appimages {KEYWORD}
+		am -q --portable {KEYWORD}
 		am -q --pkg {PROGRAM1} {PROGRAM2}
 
 **Description**:
 
-Search for keywords in the list of available applications, add the "`--appimages`" option to list only the AppImages or add "`--pkg`" to list multiple programs at once. The "`--all`" flag allows you to consult the set of all supported databases.
+Search for keywords in the list of available applications, add the "`--appimages`" option to list only the AppImages, "`--portable`" option to list only the portable apps or add "`--pkg`" to list multiple programs at once. The "`--all`" flag allows you to consult the set of all supported databases.
 
 ------------------------------------------------------------------------
 ### `reinstall`

--- a/docs/guides-and-tutorials/list-and-query.md
+++ b/docs/guides-and-tutorials/list-and-query.md
@@ -11,21 +11,28 @@ By default, only apps available on this repository are shown
 am -l
 ```
 
-https://github.com/user-attachments/assets/8862ffc4-0c4f-434d-8a5c-9c6da283cd7c
+https://github.com/user-attachments/assets/32946a04-450c-4c94-8de6-a9cdcea5e5a1
 
 To see only the AppImages from this list, use the `--appimages` flag
 ```
 am -l --appimages
 ```
 
-https://github.com/user-attachments/assets/06de5e75-a7e4-49c1-8a1a-a5ce7265502d
+https://github.com/user-attachments/assets/1f4cbc4b-a051-4571-90ac-bb2f4ca5a596
+
+To see only portable standalone programs (not AppImages) instead, use the `--portable` flag
+```
+am -l --portable
+```
+
+https://github.com/user-attachments/assets/e707728a-efe7-4dc6-bc8e-e10af469fed9
 
 To see all the programs available in all the supported databases, use the `--all` flag instead
 ```
 am -l --all
 ```
 
-https://github.com/user-attachments/assets/e629d1c3-97d7-4147-ac77-05ab19c8675c
+https://github.com/user-attachments/assets/876f365c-b62f-47b8-90de-13bed7cc147d
 
 As you may have guessed, the lists are very long. However, you can use the `-q` or `query` option to search them, using the same flags. See below.
 
@@ -40,10 +47,13 @@ https://github.com/user-attachments/assets/1b2f3f3b-fe22-416f-94d8-d5e0465b3f6d
 am -q {KEYWORD}
 am -q --all {KEYWORD}
 am -q --appimages {KEYWORD}
+am -q --portable {KEYWORD}
 am -q --pkg {PROGRAM1} {PROGRAM2}
 ```
 
 If followed by `--appimages`, the search results will be only for the available AppImages from the "AM" database.
+
+If followed by `--portable` instead, the search results will be only for portable standalone programs (not AppImages) from the "AM" database.
 
 If followed by `--pkg`, all keywords will be listed also if not on the same line. This is good if you are looking for multiple packages among the ones available in the "AM" database.
 

--- a/modules/database.am
+++ b/modules/database.am
@@ -459,11 +459,18 @@ _list() {
 	else
 		AVAILABLE_APPIMAGES_NUMBER=$(grep -e "^◆.*$" -c "$AMDATADIR/$ARCH-appimages")
 	fi
+	if ! test -f "$AMDATADIR/$ARCH-portable"; then
+		_online_check
+		_sync_portable_list
+		AVAILABLE_PORTABLE_NUMBER=$(grep -e "^◆.*$" -c "$AMDATADIR/$ARCH-portable")
+	else
+		AVAILABLE_PORTABLE_NUMBER=$(grep -e "^◆.*$" -c "$AMDATADIR/$ARCH-portable")
+	fi
 	# Determine the number of third-party apps
 	for t in $third_party_lists; do
 		[ ! -f "$AMDATADIR/$ARCH-$t" ] && _online_check && _sync_third_party_lists && _completion_lists
 	done
-	tp_lists=$(find "$AMDATADIR" -type f -name "$ARCH-*" | grep -v "appimages\|apps")
+	tp_lists=$(find "$AMDATADIR" -type f -name "$ARCH-*" | grep -v "appimages\|portable\|apps")
 	for t in $tp_lists; do
 		[ -z "$TP_LISTS" ] && TP_LISTS=$(sort -u "$t") || TP_LISTS="$TP_LISTS\n$(sort -u "$t")"
 	done
@@ -583,6 +590,14 @@ case "$1" in
 			_list_msg "$@" | less -Ir
 			printf "%b\n %b\n%b\n" "$DIVIDING_LINE" "$SUBJECT" "$DIVIDING_LINE"
 			;;
+		'--portable')
+			wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_portable_list
+			_list
+			SUBJECT="$AVAILABLE_PORTABLE_NUMBER portable programs available in the \"AM\" database"
+			LIST=$(sort -u "$AMDATADIR"/"$ARCH"-portable | grep "^◆ .*$" 2>/dev/null | _pretty_list)
+			_list_msg "$@" | less -Ir
+			printf "%b\n %b\n%b\n" "$DIVIDING_LINE" "$SUBJECT" "$DIVIDING_LINE"
+			;;
 		*)	
 			if echo "$third_party_flags" | tr ' ' '\n' | grep -q -- "$2$"; then
 				wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_third_party_lists 2>/dev/null
@@ -606,6 +621,7 @@ case "$1" in
 			echo " USAGE: $AMCLI $1 [ARGUMENT]"
 			echo "        $AMCLI $1 --all [ARGUMENT]"
 			echo "        $AMCLI $1 --appimages [ARGUMENT]"
+			echo "        $AMCLI $1 --portable [ARGUMENT]"
 			echo "        $AMCLI $1 --pkg [ARGUMENT]"
 			echo ""; exit 1
 		fi
@@ -628,6 +644,11 @@ case "$1" in
 			wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_appimages_list
 			_query_lists "$*"
 			sort -u "$AMDATADIR/$ARCH-appimages" 2>/dev/null | grep "^◆ .*$" 2>/dev/null | _find_no_order "$@" | _pretty_list_compat
+		elif [ "$1" = --portable ]; then
+			shift
+			wget -q --tries=10 --timeout=20 --spider https://github.com && _sync_portable_list
+			_query_lists "$*"
+			sort -u "$AMDATADIR/$ARCH-portable" 2>/dev/null | grep "^◆ .*$" 2>/dev/null | _find_no_order "$@" | _pretty_list_compat
 		else
 			_query_lists "$*"
 			LISTS=$(find "$AMDATADIR" -type f -name "$ARCH-app*" 2>/dev/null | grep -v appimage | xargs)


### PR DESCRIPTION
...show lists dedicated to portable apps (no AppImages) present in the "AM" database