### PR TITLE
fix(APP-MANAGER): Use _clean_all_tmp_directories_from_appspath

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1119,7 +1119,7 @@ _update_all_apps() {
 	wait
 	rm -f "$AMDATADIR"/torsocks.conf
 	_update_determine_apps_version_changes
-	rm -Rf "$APPSPATH"/*/tmp
+	_clean_all_tmp_directories_from_appspath
 	[ -d "$APPMAN_APPSPATH" ] && rm -Rf "$APPMAN_APPSPATH"/*/tmp
 }
 


### PR DESCRIPTION
Use existing function to remove tmp directories to avoid removing tmp directories from apps that are not handled by am.

I has having errors when running `am -u`, from directories unrelated to the apps managed by AM:

`rm: cannot remove '/opt/sophos-spl/tmp': Permission denied`