### PR TITLE
fix broken non-root check

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -195,7 +195,7 @@ _post_installation_processes() {
 	LASTDIRPATH="${APPSPATH}/${LASTDIR}"
 	# Put permission check in remove script and change ownership of directory
 	if [ "$AMCLI" = am ]; then
-		$SUDOCMD sed -i "1 a [ \"\$(id -u)\" -ne 0 ] && echo "Permission denied" && exit 1" \
+		$SUDOCMD sed -i '1 a [ "$(id -u)" -ne 0 ] && echo "Permission denied" && exit 1' \
 			"${LASTDIRPATH}"/remove 2>/dev/null
 		$SUDOCMD chown -R "$USER" "${LASTDIRPATH}" 2>/dev/null
 	fi


### PR DESCRIPTION
right now this is what is being added to the remover instead due to the usage of double quotes: 

![image](https://github.com/user-attachments/assets/2109c73f-3f95-4315-ab1f-848712aacefc)

This change using single quotes fixes it. 

![image](https://github.com/user-attachments/assets/c43f248e-0308-4358-bb4f-ab0c79f18b6b)
