### PR TITLE
Fix `am` & `appman` detection in Fedora Atomic

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -198,7 +198,8 @@ _am() {
 }
 
 # DETERMINE WHEN TO USE "AM" OR "APPMAN"
-if [ "$(realpath "$0")" = "/opt/am/APP-MANAGER" ]; then
+# /opt is a symlink to /var/opt in Fedora Atomic, so we cover that here
+if [ "$(realpath "$0")" = "/opt/am/APP-MANAGER" ] || [ "$(realpath "$0")" = "/var/opt/am/APP-MANAGER" ]; then
 	_am
 	mkdir -p "$MODULES_PATH" || exit 1
 elif [ "$(realpath "$0")" = "/usr/bin/am" ]; then


### PR DESCRIPTION
realpath is `/var/opt` here, so that fixes this issue.