### PR TITLE
update ghostty-nightly, add glfw versions

### DIFF
--- a/programs/x86_64-appimages
+++ b/programs/x86_64-appimages
@@ -662,7 +662,9 @@
 ◆ gerbv : Gerber file viewer for PCB design.
 ◆ getthermal : Cross-platform Thermal Camera Viewer.
 ◆ gextractwinicons : Extract cursors, icons and images from MS Windows files.
+◆ ghostty-glfw-nightly : Unofficial, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (Tip, Nightly) (glfw version)
 ◆ ghostty-nightly : Unoffical, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (Tip, Nightly)
+◆ ghostty-glfw : Unofficial, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (glfw version)
 ◆ ghostty : Unofficial, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (Stable)
 ◆ giada : Hardcore audio music production tool and drum machine for DJs.
 ◆ gibs : Generally In-source Build System, build C++ projects without a project.

--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -821,7 +821,9 @@
 ◆ ghdl : A much more convenient way to download GitHub release binaries on the command line.
 ◆ gh-eco : gh cli extension to explore the ecosystem.
 ◆ gh : GitHub’s official command line tool.
+◆ ghostty-glfw-nightly : Unofficial, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (Tip, Nightly) (glfw version)
 ◆ ghostty-nightly : Unoffical, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (Tip, Nightly)
+◆ ghostty-glfw : Unofficial, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (glfw version)
 ◆ ghostty : Unofficial, 👻 ⚙️ AppImage for Ghostty Terminal Emulator (Stable)
 ◆ ghrel : Download and verify GitHub release.
 ◆ giada : Hardcore audio music production tool and drum machine for DJs.

--- a/programs/x86_64/ghostty-glfw
+++ b/programs/x86_64/ghostty-glfw
@@ -2,7 +2,7 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=ghostty-nightly
+APP=ghostty-glfw
 SITE="pkgforge-dev/ghostty-appimage"
 
 # CREATE DIRECTORIES AND ADD REMOVER
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*tip.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*glfw.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=ghostty-nightly
+APP=ghostty-glfw
 SITE="pkgforge-dev/ghostty-appimage"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*tip.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*glfw.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/ghostty-glfw-nightly
+++ b/programs/x86_64/ghostty-glfw-nightly
@@ -2,7 +2,7 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=ghostty-nightly
+APP=ghostty-glfw-nightly
 SITE="pkgforge-dev/ghostty-appimage"
 
 # CREATE DIRECTORIES AND ADD REMOVER
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*tip.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*tip.*glfw.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=ghostty-nightly
+APP=ghostty-glfw-nightly
 SITE="pkgforge-dev/ghostty-appimage"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*tip.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/ghostty-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*tip.*glfw.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
* fixes `nightly` picking stable releases

* adds glfw versions, **which don't use GTK4 and libadwaita** and are much much faster, better and smaller as result: 


![image](https://github.com/user-attachments/assets/504d1c81-6747-4512-a491-f197b162a09b)

