### PR TITLE
remove `--no-sandbox` nonsense from apps

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -114,7 +114,7 @@ _check_if_script_installs_a_metapackage() {
 			return 1
 		fi
 	fi
-	
+
 }
 
 _check_if_spooky_flag_exists() {
@@ -210,6 +210,7 @@ _post_installation_processes() {
 			sed -i "s#Exec=$pure_arg#Exec=$BINDIR/$pure_arg#g" "$a" 2>/dev/null
 			sed -i "s#Exec=/usr/bin/#Exec=$BINDIR/#g" "$a" 2>/dev/null
 			sed -i "s#Exec=/opt/#Exec=$BINDIR/#g" "$a" 2>/dev/null
+			sed -i "s#--no-sandbox##g" "$a" 2>/dev/null
 		done
 	fi
 	# Export all icons for hicolor theme usage


### PR DESCRIPTION
I noticed that electron apps (freetube) are starting to ship with the `--no-sandbox` flag in the `.desktop` due to ubuntu's apparmor nonsense.

This patch removes this since [we already warn and tell users what do to for ubuntu.](https://github.com/ivan-hc/AM/blob/main/docs/troubleshooting.md#ubuntu-mess)

NOTE: This only fixes it for `appman`, not sure how this can be fixed with `am` btw 👀
