### PR TITLE
fix: Make `APPSPATH` point to the realpath, instead of the hardcoded …

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -191,7 +191,7 @@ _am() {
 		echo 'ERROR: No sudo or doas found'
 		exit 1
 	fi
-	APPSPATH="/opt"
+	APPSPATH="$(realpath /opt)"
 	AMPATH="$APPSPATH/$AMCLI"
 	_create_cache_dir
 	MODULES_PATH="$AMPATH/modules"


### PR DESCRIPTION
…`/opt` (#1553)

Another fix for Fedora Atomic, so system AppImages are shown when doing `am -f` & `am update`