### PR TITLE
fix: Make `StartupWMClass` patches `BSD` compatible

### DIFF
--- a/programs/x86_64/chromium
+++ b/programs/x86_64/chromium
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=chromium-browser' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=chromium-browser" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=chromium-browser
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=chromium-browser|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/chromium-beta
+++ b/programs/x86_64/chromium-beta
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=chromium-browser' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=chromium-browser" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=chromium-browser
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=chromium-browser|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/chromium-edge
+++ b/programs/x86_64/chromium-edge
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=chromium-browser' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=chromium-browser" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=chromium-browser
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=chromium-browser|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/chromium-rc
+++ b/programs/x86_64/chromium-rc
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=chromium-browser' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=chromium-browser" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=chromium-browser
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=chromium-browser|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/google-chrome
+++ b/programs/x86_64/google-chrome
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=google-chrome' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=google-chrome" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=google-chrome
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=google-chrome|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/google-chrome-beta
+++ b/programs/x86_64/google-chrome-beta
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=google-chrome-beta' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=google-chrome-beta" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=google-chrome-beta
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=google-chrome-beta|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/google-chrome-dev
+++ b/programs/x86_64/google-chrome-dev
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=google-chrome-unstable' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=google-chrome-unstable" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=google-chrome-unstable
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=google-chrome-unstable|' /usr/local/share/applications/"$APP"-AM.desktop
+fi

--- a/programs/x86_64/tzared
+++ b/programs/x86_64/tzared
@@ -75,4 +75,12 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
-if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then sed -i '/^Exec/a StartupWMClass=tzared' /usr/local/share/applications/"$APP"-AM.desktop; else sed -i "/^StartupWMClass=/c\StartupWMClass=tzared" /usr/local/share/applications/"$APP"-AM.desktop; fi
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" /usr/local/share/applications/"$APP"-AM.desktop; then
+# It's done like this, so it's compatible with FreeBSD's sed
+sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=tzared
+' /usr/local/share/applications/"$APP"-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=tzared|' /usr/local/share/applications/"$APP"-AM.desktop
+fi


### PR DESCRIPTION
Works in both BSD's & GNU's `sed`