### PR TITLE
chore: Don't auto-generate shell completion when `am` is in `/usr/bin/`

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -528,21 +528,23 @@ _completion_lists() {
 }
 
 # BASH, FISH AND ZSH COMPLETION
-completion_file="$DATADIR/bash-completion/completions/$AMCLI"
-mkdir -p "$DATADIR/bash-completion/completions" || exit 1
-if ! grep -o " $AMCLI$" "$completion_file" >/dev/null 2>&1; then
-	echo "complete -W \"\$(cat $AMDATADIR/list 2>/dev/null)\" $AMCLI" >> "$completion_file"
-	if [ -f "${ZDOTDIR:-$HOME}"/.zshrc ] && echo "$SHELL" | grep -q "zsh"; then
-		cat <<-HEREDOC >> "${ZDOTDIR:-$HOME}"/.zshrc
-		autoload bashcompinit
-		bashcompinit
-		source "$completion_file"
-		HEREDOC
-	fi
-	echo "Shell completion has been enabled!"
-fi
-if [ -d "$DATADIR"/fish/completions ] || [ -d /etc/fish/completions ] || [ -d /usr/share/fish/completions ]; then
-	command -v fish 1>/dev/null && [ ! -f "$CONFIGDIR"/fish/completions/am.fish ] && mkdir -p "$CONFIGDIR"/fish/completions && echo "complete -c am -f -a \"(cat $DATADIR/AM/list 2>/dev/null)\"" > "$CONFIGDIR"/fish/completions/am.fish
+if [ "$(realpath "$0")" != "/usr/bin/am" ]; then
+    completion_file="$DATADIR/bash-completion/completions/$AMCLI"
+    mkdir -p "$DATADIR/bash-completion/completions" || exit 1
+    if ! grep -o " $AMCLI$" "$completion_file" >/dev/null 2>&1; then
+	    echo "complete -W \"\$(cat $AMDATADIR/list 2>/dev/null)\" $AMCLI" >> "$completion_file"
+	    if [ -f "${ZDOTDIR:-$HOME}"/.zshrc ] && echo "$SHELL" | grep -q "zsh"; then
+		    cat <<-HEREDOC >> "${ZDOTDIR:-$HOME}"/.zshrc
+		    autoload bashcompinit
+		    bashcompinit
+		    source "$completion_file"
+		    HEREDOC
+	    fi
+	    echo "Shell completion has been enabled!"
+    fi
+    if [ -d "$DATADIR"/fish/completions ] || [ -d /etc/fish/completions ] || [ -d /usr/share/fish/completions ]; then
+	    command -v fish 1>/dev/null && [ ! -f "$CONFIGDIR"/fish/completions/am.fish ] && mkdir -p "$CONFIGDIR"/fish/completions && echo "complete -c am -f -a \"(cat $DATADIR/AM/list 2>/dev/null)\"" > "$CONFIGDIR"/fish/completions/am.fish
+    fi
 fi
 
 # VERSION OF THE INSTALLED APPS


### PR DESCRIPTION
Shell completions should be supplied by the packager/distro in this scenario.