### PR TITLE
Reduce the message about Fedora's mess with GNU Wget2

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.7.1-3"
+AMVERSION="9.7.1-4"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -314,11 +314,8 @@ _am_dependences_check() {
 
 _check_fedora_mess() {
 	if wget --version | head -1 | grep -qi ' 2.\|wget2 '; then
-		printf "\n%b WARNING: your distro maintainer ships \"wget2\" as \"wget\" \033[0m\n" "${RED}"
-		printf "\nGNU Wget was released in 1996. GNU Wget2 is a rewrite, released in 2021 with the name \"wget2\", to work alongside \"wget\".\n\nBeing a rewrite, the flags and behavior differ in several ways, and this was seen when the Fedora team decided in 2024 to replace Wget entirely with a symbolic link to Wget2, even though they are two different programs with different names, to the point of raising concerns of the creator himself.\n" | _fit
-		printf "\nRealizing the mess they had made, the RHEL team decided to introduce the new packages \"wget1\" and \"wget1-wget\", in 2025, to have the real GNU Wget back.\n\nhttps://bugzilla.redhat.com/show_bug.cgi?id=2358792\n\nOn the contrary, Fedora continued with this madness, to avoid admitting the mistake.\n" | _fit
-		printf "\nIn \"$AMCLIUPPER\", GNU Wget provides nicer and generally functional output, while GNU Wget2 has a bug where it automatically suppresses the output, making application installation and upgrade progress difficult to see.\n" | _fit
-		printf "\n%bPlease fix this crap if you want a more pleasant user experience! \033[0m\n\n" "${RED}" | _fit
+		printf "\n%bWARNING: your distro maintainer ships \"wget2\" as \"wget\" \033[0m\n\n" "${RED}" | _fit
+		[ -f /etc/redhat-release ] && printf "See https://bugzilla.redhat.com/show_bug.cgi?id=2358792\n\n" | _fit
 	fi
 }
 


### PR DESCRIPTION
Quick patch for https://github.com/ivan-hc/AM/pull/1569

The message was too big and invasive, so I decided to reduce it to two lines

![Istantanea_2025-05-24_21-16-21](https://github.com/user-attachments/assets/31062347-944e-4b42-9c22-09aab3bd23aa)

-------------------------------------

the message is to indicate this mess :point_down: 

![Istantanea_2025-05-24_21-25-14](https://github.com/user-attachments/assets/3bdfde6e-2970-408d-abf0-aecf0fbf2de2)

-------------------------------------

The URL in use is the following

https://bugzilla.redhat.com/show_bug.cgi?id=2358792

...and will only appear if the distro is based on Fedora.

I preferred to add the URL to give more context and better instructions than I could.

This is the function responsible of this
```
_check_fedora_mess() {
	if wget --version | head -1 | grep -qi ' 2.\|wget2 '; then
		printf "\n%bWARNING: your distro maintainer ships \"wget2\" as \"wget\" \033[0m\n\n" "${RED}" | _fit
		[ -f /etc/redhat-release ] && printf "See https://bugzilla.redhat.com/show_bug.cgi?id=2358792\n\n" | _fit
	fi
}
```

Other distros will have a different message in the future, if they decide to do the same stupid thing the Fedora team did on 2024... but I'm confident enough to believe that no one will follow their bad example. Or at least I hope.

PS: I have nothing against Fedora, it's a fantastic distro.

For more context on the situation, I refer you to my last post, on Reddit

https://www.reddit.com/r/Fedora/comments/1kuag0y/gnu_wget_has_been_reintroduced_alongside_wget2/