### PR TITLE
Improve language detection logic

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -59,7 +59,7 @@ _check_valid_iso_codes() {
 			language_code="$lang"
 		fi
 	done
-	[ -n "$language_code" ] && iso_code="$language_code"
+	[ -n "$language_code" ] && iso_code="${language_code%%_*}"
 }
 
 _set_locale() {

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -76,7 +76,7 @@ _set_locale() {
 	fi
 }
 
-[ -f "$DATADIR/AM/locale" ] && iso_code="$(cat "$DATADIR/AM/locale" | head -1 | cut -c -2)"
+[ -f "$DATADIR/AM/locale" ] && iso_code="$(cat "$DATADIR/AM/locale" | head -1)"
 [ -n "$iso_code" ] && export LANGUAGE="$iso_code"
 if ! echo "$LANG" | grep -q "^en.\|^C" && [ "$iso_code" != "en" ]; then
 	if [ -n "$LANG" ]; then

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -59,7 +59,7 @@ _check_valid_iso_codes() {
 			language_code="$lang"
 		fi
 	done
-	[ -n "$language_code" ] && iso_code="${language_code%%_*}"
+	[ -n "$language_code" ] && language_code="${language_code%@*}"; iso_code="${language_code%%_*}"
 }
 
 _set_locale() {


### PR DESCRIPTION
All symbols after `_` or `@` are variants of one language, so I just remove all those symbols.
AM only supports translations of 1 variant per language.

As a result, detection is `sr` instead of `sr_RS`.