### PR TITLE
fix nasty bug

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -109,13 +109,13 @@ _generate_sandbox_script() {
 	  eval $DIR="$XDG_DIR"
 	done
 	# Use default location if var is not set
-	DESKTOP="${DESKTOP:-~/Desktop}"
-	DOCUMENTS="${DOCUMENTS:-~/Documents}"
-	DOWNLOAD="${DOWNLOAD:-~/Downloads}"
-	GAMES="${GAMES:-~/Games}"
-	MUSIC="${MUSIC:-~/Music}"
-	PICTURES="${PICTURES:-~/Pictures}"
-	VIDEOS="${VIDEOS:-~/Videos}"
+	DESKTOP="${DESKTOP:-$HOME/Desktop}"
+	DOCUMENTS="${DOCUMENTS:-$HOME/Documents}"
+	DOWNLOAD="${DOWNLOAD:-$HOME/Downloads}"
+	GAMES="${GAMES:-$HOME/Games}"
+	MUSIC="${MUSIC:-$HOME/Music}"
+	PICTURES="${PICTURES:-$HOME/Pictures}"
+	VIDEOS="${VIDEOS:-$HOME/Videos}"
 	# Try find the right name of the app conf/data dir
 	APPDATA=$( ls "$DATADIR" | grep -i "$APPNAME" | head -1 )
 	APPCONF=$( ls "$CONFIGDIR" | grep -i "$APPNAME" | head -1 )


### PR DESCRIPTION
This is wrong and I mistake that didn't discover until @fiftydinar pointed it out in the discord. Because the `~` is in quotes it never expands to the value of `$HOME`.

Amazingly this problem never showed up before because aisap resolves the literal `~`.