### PR TITLE
Use shell built-ins for `basename` & `dirname`

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -16,6 +16,53 @@ ARCH="$(uname -m)"
 [ "$ARCH" = "amd64" ] && ARCH=x86_64
 export ARCH
 
+# Substitute host dependencies for native shell built-ins
+basename() {
+    [ -n "$1" ] || return 1
+    if [ "$1" = "--" ] && [ -z "$2" ]; then
+        return 1
+    fi
+    if [ "$1" = "--" ]; then
+        dir=${2%"${2##*[!/ ]}"}
+        dir=${dir##*/}
+        dir=${dir%"${3:-}"} 
+        printf '%s\n' "${dir:-/}"
+    else
+        dir=${1%"${1##*[!/ ]}"}
+        dir=${dir##*/}
+        dir=${dir%"${2:-}"} 
+        printf '%s\n' "${dir:-/}"
+    fi
+}
+export -f basename
+
+dirname() {
+    [ -n "$1" ] || return 1
+    if [ "$1" = "--" ] && [ -z "$2" ]; then
+      return 1
+    fi
+    if [ "$1" = "--" ]; then
+      dir="$2"
+      dir=${dir%%"${dir##*[!/ ]}"}
+      if [ "${dir##*/*}" ]; then
+        dir=.
+      fi
+      dir=${dir%/*}
+      dir=${dir%%"${dir##*[!/ ]}"}
+      printf '%s\n' "${dir:-/}"
+    else
+      dir="$1"
+      dir=${dir%%"${dir##*[!/ ]}"}
+      if [ "${dir##*/*}" ]; then
+        dir=.
+      fi
+      dir=${dir%/*}
+      dir=${dir%%"${dir##*[!/ ]}"}
+      printf '%s\n' "${dir:-/}"
+    fi
+}
+export -f dirname
+
 # Fixes issue with less on bsd
 case "$(uname)" in
 	*BSD*|*DragonFly*|*DynFi*|*FreeNAS*|*OPNsense*|\


### PR DESCRIPTION
Partially solves: https://github.com/ivan-hc/AM/issues/1696