### PR TITLE
remove "light" buidls from `eden-nightly`

### DIFF
--- a/programs/x86_64/eden-nightly
+++ b/programs/x86_64/eden-nightly
@@ -30,7 +30,7 @@ elif echo "$response" | grep -q "^3"; then
 fi
 [ -z "$RELEASE" ] && exit 0
 
-version=$(curl -Ls https://api.github.com/repos/pflyly/eden-nightly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*mage$" | grep -i "$RELEASE" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pflyly/eden-nightly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*mage$" | grep -i "$RELEASE" | grep -vi light | head -1)
 if [ -z "$version" ]; then
 	printf "\n 💀 ERROR: it seems that upstream removed %b, please retry\n" "$RELEASE" && exit 1
 else
@@ -53,7 +53,7 @@ set -u
 APP=eden-nightly
 SITE="pflyly/eden-nightly"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/pflyly/eden-nightly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*mage$" | grep -i "TYPE" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pflyly/eden-nightly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*x86_64.*mage$" | grep -i "TYPE" | grep -vi light | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
the eden nightly repo makes a smaller version of the appimage that uses linuxdeploy. 

I'm not a fan of that appimage because it is built on archlinux, meaning it only works on very new distros. 

This change removes it from being downloaded, since the light build is named `common-light` selecting common in the script makes it download the light build instead of the common one. 