### PR TITLE
fix broken install of sas when appman is used

### DIFF
--- a/modules/sandboxes.am
+++ b/modules/sandboxes.am
@@ -64,6 +64,8 @@ _check_aisap() {
 				n*|N*) "$AMCLIPATH_ORIGIN" -i sas >/dev/null 2>&1;;
 				''|*)  "$AMCLIPATH_ORIGIN" -i --user sas >/dev/null 2>&1;;
 			esac
+		else
+			"$AMCLIPATH_ORIGIN" -i sas >/dev/null 2>&1
 		fi
 		command -v sas 1>/dev/null || return 1
 		echo $" sas installed successfully!"


### PR DESCRIPTION
turns out this worked on my end because I had `appman` symlinked as `am`. 

I just happened to discover this wasn't doing anything when real `appman` is used 👀