### PR TITLE
"AM" 9.8.2 - a new step in favor of third-party databases

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -602,7 +602,8 @@ third_party_flags_byname=$(echo "$third_party_flags" | tr ' ' '\n' | sort | xarg
 for flag in $third_party_flags_byname; do
 tpflag_name=$(echo "$flag" | tr '-' '\n ' | grep .)
 tprepo_name="${tpflag_name}_repo"
-third_party_flags_message=$(echo -e $"$third_party_flags_message\n
+tprepo_info="${tpflag_name}_info"
+third_party_flags_message=$(printf $"$third_party_flags_message\n
 ${Gold}--$tpflag_name\033[0m
 
 	${LightBlue}$AMCLI -i --$tpflag_name {PROGRAM}\033[0m
@@ -610,7 +611,8 @@ ${Gold}--$tpflag_name\033[0m
 	${LightBlue}$AMCLI -l --$tpflag_name\033[0m
 
 Description: This is a flag to use in \"-i\" and \"-l\" to install/list software from ${!tprepo_name}. You can also use it in \"-q\" as a keyword. For installations you can use .$tpflag_name as the package extension instead of using the flag.
-")
+"
+printf "\nInfo: %b\n\n" "${!tprepo_info}")
 done
 fi
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.1-5"
+AMVERSION="9.8.2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"


### PR DESCRIPTION
This commit seems small, but it's driven by all the previous ones, particularly the crazy and stubborn use of "am-extras."

You'll find out more in the release notes, at https://github.com/ivan-hc/AM/releases/tag/9.8.2