### PR TITLE
Update kitty

### DIFF
--- a/programs/x86_64/kitty
+++ b/programs/x86_64/kitty
@@ -3,37 +3,40 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=kitty
+SUBAPP=kitten
 SITE="kovidgoyal/kitty"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
-printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -f /usr/local/bin/$SUBAPP\nrm -R -f /opt/$APP" > ../remove
 printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls  https://api.github.com/repos/kovidgoyal/kitty/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux.*amd64$" | head -1)
+version=$(curl -Ls https://api.github.com/repos/kovidgoyal/kitty/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*.txz$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 [ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
 [ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*.txz ] && tar fx ./*.txz && rm -f ./*.txz
 [ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 cd ..
 if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
-chmod a+x ./$APP || exit 1
+chmod a+x ./bin/"$APP" && chmod a+x ./bin/"$SUBAPP" || exit 1
 
 # LINK TO PATH
-ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+ln -s "/opt/$APP/bin/$APP" "/usr/local/bin/$APP" && ln -s "/opt/$APP/bin/$SUBAPP" "/usr/local/bin/$SUBAPP"
 
 # SCRIPT TO UPDATE THE PROGRAM
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=kitty
+SUBAPP=kitten
 SITE="kovidgoyal/kitty"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls  https://api.github.com/repos/kovidgoyal/kitty/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | grep -i "linux.*amd64$" | head -1)
+version=$(curl -Ls https://api.github.com/repos/kovidgoyal/kitty/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*.txz$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
@@ -41,10 +44,11 @@ if [ "$version" != "$version0" ]; then
 	wget "$version" || exit 1
 	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*.txz ] && tar fx ./*.txz && rm -f ./*.txz
 	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 	cd ..
 	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
-	chmod a+x ./"$APP" || exit 1
+	chmod a+x ./bin/"$APP" && chmod a+x ./bin/"$SUBAPP" || exit 1
 	echo "$version" > ./version
 	rm -R -f ./tmp ./*~
 	notify-send "$APP is updated!"
@@ -64,9 +68,14 @@ Version=1.0
 Type=Application
 Name=kitty
 GenericName=Terminal emulator
-Comment=Fast, feature-rich, GPU based terminal
+Comment=A fast, feature-rich, GPU-based terminal emulator
+StartupWMClass=kitty-AM
 TryExec=kitty
-StartupNotify=true
-Exec=$APP
-Icon=/opt/$APP/icons/$APP
-Categories=System;TerminalEmulator;" > /usr/local/share/applications/"$APP"-AM.desktop
+Exec=kitty --class kitty-AM
+Icon=/opt/kitty/icons/kitty
+Categories=System;TerminalEmulator;
+X-TerminalArgExec=--
+X-TerminalArgTitle=--title
+X-TerminalArgAppId=--class
+X-TerminalArgDir=--working-directory
+X-TerminalArgHold=--hold" > /usr/local/share/applications/"$APP"-AM.desktop


### PR DESCRIPTION
[kitty.md](https://github.com/user-attachments/files/21706067/kitty.md)

◆ kitty : Cross-platform, fast, feature-rich, GPU based terminal

---

Now using the kitty archive, which contains both kitty and kitten. Kitten is required for kitty to function correctly. I tested it without linking kitten to `/usr/local/bin`, but it behaved a bit buggy, so now both are linked. This is also reflected in the update and remove scripts. Tested on both user and system level.