### PR TITLE
Speed up updating of third-party database lists

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-1"
+AMVERSION="9.8.2-2"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -583,16 +583,15 @@ _third_party_lsts_filter() {
 	grep -v -- "---\|^| appname" | grep "^| .* | .* | http.* | http.* | .* |$" 2>/dev/null | awk -F'|' '{print $2, $3}' | sed 's/^/◆/g; s/   / : /g; s/ $//g'
 }
 
+_third_party_lsts_generator() {
+	tprepo_readme="${tp_list}_readme" && curl -Ls "${!tprepo_readme}" 2>/dev/null | _third_party_lsts_filter \
+	| sed "s/$/. To install it use the --$tp_list flag or the .$tp_list extension./g" | sort > "$AMDATADIR"/"$ARCH"-"$tp_list" || touch "$AMDATADIR"/"$ARCH"-"$tp_list"
+}
+
 _sync_third_party_lists() {
 	_am_extras_sources
 	for tp_list in $third_party_lists; do
-		rm -f "$AMDATADIR"/"$ARCH"-"$tp_list"
-		tprepo_readme="${tp_list}_readme"
-		if [ -n "${!tprepo_readme}" ]; then
-			curl -Ls "${!tprepo_readme}" | _third_party_lsts_filter \
-			| sed "s/$/. To install it use the --$tp_list flag or the .$tp_list extension./g" | sort > "$AMDATADIR"/"$ARCH"-"$tp_list" \
-			|| touch "$AMDATADIR"/"$ARCH"-"$tp_list"
-		fi
+		_third_party_lsts_generator &
 	done
 }
 
@@ -1088,8 +1087,10 @@ _sync_portable_list() {
 
 _sync_databases() {
 	printf $"%b\n Check and update offline lists of additional databases...\n" "$DIVIDING_LINE"
-	_sync_appimages_list
-	_sync_portable_list
+	if [ -z "$MODULE" ]; then
+		_sync_appimages_list
+		_sync_portable_list
+	fi
 	_sync_third_party_lists 2>/dev/null
 	_completion_lists
 }


### PR DESCRIPTION
With the prospect of adding more third-party databases in the future, the `-l` and `-q` options for displaying lists need to be speeded up:
- The addition of the `--all` flag also loaded the "portable" and "appimages" lists, but from now on, these will also not be loaded unless called individually when needed, with the respective flags.
- The updating of third-party lists will be performed in parallel.

Below are the benchmarks.

-------

## Before
<img width="747" height="492" alt="Istantanea_2025-08-17_02-34-41" src="https://github.com/user-attachments/assets/4fabdca6-f255-4d1a-bd2d-e91bc5e20705" />

## After
<img width="747" height="492" alt="Istantanea_2025-08-17_02-35-35" src="https://github.com/user-attachments/assets/51bceab1-a956-49d1-8473-b57c19d3adb0" />
