### PR TITLE
"AM" 9.9 - clone configurations and relocate AppMan apps

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-7"
+AMVERSION="9.8.2-8"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1086,7 +1086,12 @@ _use_clone() {
 
 		case "$2" in
 		'install'|'-i')
-			_clone_install "$@"
+			read -r -p $" Do you want to install the set of programs listed above (y,N)?" yn
+			if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+				echo "$DIVIDING_LINE"
+			else
+				_clone_install "$@"
+			fi
 			;;
 		esac
 	fi

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-5"
+AMVERSION="9.8.2-6"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1025,11 +1025,29 @@ _use_clean() {
 #				CLONE
 ################################################################################################################################################################
 
+_clone_create_clone_file() {
+	_determine_args
+	rm -f "$SCRIPTDIR"/am-clone.source
+	for arg in $ARGS; do
+		argpath=$(echo "$ARGPATHS" | grep "/$arg$")
+		[ -d "$argpath"/.am-installer ] && scriptname=$(ls "$argpath/.am-installer/" | head -1)
+		[ -z "$scriptname" ] && scriptname="$arg"
+		if [ "$arg" != am ]; then
+			echo "$argpath" | sed "s/\/$arg$/\/$scriptname/g" >> "$SCRIPTDIR"/am-clone.source
+		fi
+		scriptname=""
+	done
+	[ -f "$SCRIPTDIR"/am-clone.source ] && CLONE_FILE="$SCRIPTDIR/am-clone.source"
+}
+
 _clone_show_items_msg() {
 	echo "$DIVIDING_LINE"
 	if [ -f "$CLONE_FILE" ]; then
-		printf "File: %b\n\nContent:\n" "$CLONE_FILE"
-		sort "$CLONE_FILE" | _fit
+		printf "File: %b\n" "$CLONE_FILE"
+		system_apps=$(sort "$CLONE_FILE" | grep "^/opt" 2>/dev/null | sed -- 's:.*/::; s/^/ - /g')
+		local_apps=$(sort "$CLONE_FILE" | grep -v "^/opt" 2>/dev/null | sed -- 's:.*/::; s/^/ - /g')
+		[ -n "$system_apps" ] && printf "\nContent (system-wide installation):\n\n%b\n" "$system_apps" | _fit
+		[ -n "$local_apps" ] && printf "\nContent (local/rootless installation):\n\n%b\n" "$local_apps" | _fit
 	else
 		echo " ERROR: am-clone.source file not found"
 	fi
@@ -1057,21 +1075,10 @@ _clone_install() {
 
 _use_clone() {
 	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$SCRIPTDIR" -type f -name am-clone.source 2>/dev/null | head -1)
-	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$HOME" -type f -name am-clone.source 2>/dev/null | head -1)
-	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find / -type f -name am-clone.source 2>/dev/null | head -1)
+	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$HOME" -type f -name am-clone.source 2>/dev/null | grep -v "share/Trash" | head -1)
+	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find / -type f -name am-clone.source 2>/dev/null | grep -v "share/Trash" | head -1)
 	if [ -z "$CLONE_FILE" ]; then
-		_determine_args
-		rm -f "$SCRIPTDIR"/am-clone.source
-		for arg in $ARGS; do
-			argpath=$(echo "$ARGPATHS" | grep "/$arg$")
-			[ -d "$argpath"/.am-installer ] && scriptname=$(ls "$argpath/.am-installer/" | head -1)
-			[ -z "$scriptname" ] && scriptname="$arg"
-			if [ "$arg" != am ]; then
-				echo "$argpath" | sed "s/\/$arg$/\/$scriptname/g" >> "$SCRIPTDIR"/am-clone.source
-			fi
-			scriptname=""
-		done
-		[ -f "$SCRIPTDIR"/am-clone.source ] && CLONE_FILE="$SCRIPTDIR/am-clone.source"
+		_clone_create_clone_file
 	fi
 	if echo "$1" | grep -q -- "clone"; then
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-4"
+AMVERSION="9.8.2-5"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1036,6 +1036,25 @@ _clone_show_items_msg() {
 	echo "$DIVIDING_LINE"
 }
 
+_clone_install() {
+	if [ -f "$CLONE_FILE" ]; then
+		AMCLIPATH_ORIGIN="$AMCLIPATH"
+		ARGS=$(sort -u "$CLONE_FILE" | sed 's:.*/::' | xargs)
+		for arg in $ARGS; do
+			argpath=$(sort -u "$CLONE_FILE" | grep "/$arg$")
+			if [ "$AMCLI" = "am" ] && ! echo "$argpath" | grep -q "^/opt"; then
+				"$AMCLIPATH_ORIGIN" -i --user "$arg"
+			else
+				"$AMCLIPATH_ORIGIN" -i "$arg"
+			fi
+		done
+	else
+		echo "$DIVIDING_LINE"
+		echo " ERROR: am-clone.source file not found"
+		echo "$DIVIDING_LINE"
+	fi
+}
+
 _use_clone() {
 	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$SCRIPTDIR" -type f -name am-clone.source 2>/dev/null | head -1)
 	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$HOME" -type f -name am-clone.source 2>/dev/null | head -1)
@@ -1055,7 +1074,14 @@ _use_clone() {
 		[ -f "$SCRIPTDIR"/am-clone.source ] && CLONE_FILE="$SCRIPTDIR/am-clone.source"
 	fi
 	if echo "$1" | grep -q -- "clone"; then
+
 		_clone_show_items_msg
+
+		case "$2" in
+		'install'|'-i')
+			_clone_install "$@"
+			;;
+		esac
 	fi
 }
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-8"
+AMVERSION="9.8.2-9"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -1128,8 +1128,26 @@ _use_relocate() {
 		echo " ERROR: appman-config file not found"
 		echo "$DIVIDING_LINE"
 	else
-		rm -f "$SCRIPTDIR"/am-clone.source
-		_clone_create_clone_file
+		read -r -p $" Do you want to install the set of programs listed above (y,N)?" yn
+		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
+			AMCLIPATH_ORIGIN="$AMCLIPATH"
+			rm -f "$SCRIPTDIR"/am-clone.source
+			_clone_create_clone_file
+			sort -u "$SCRIPTDIR"/am-clone.source | grep -v "^/opt" > "$SCRIPTDIR"/am-clone.source.appman
+			_determine_args
+			APPMAN_APPS_OLD=$(echo "$ARGPATHS" | grep -v "^/opt/")
+			if [ -n "$APPMAN_APPS_OLD" ]; then
+				for arg in $APPMAN_APPS_OLD; do
+					appname=$(echo "$arg" | sed 's:.*/::')
+					"$AMCLIPATH_ORIGIN" -R "$appname"
+				done
+			fi
+			rm -f "$APPMANCONFIG"/appman-config
+			_appman
+			APPMAN_APPS_NEW=$(sort -u "$SCRIPTDIR"/am-clone.source.appman | sed 's:.*/::' | xargs)
+			"$AMCLIPATH_ORIGIN" -i --user "$APPMAN_APPS_NEW"
+		fi
+		
 	fi
 }
 

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-6"
+AMVERSION="9.8.2-7"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -632,10 +632,10 @@ fi
 
 # COMPLETION LIST
 available_options="about add apikey backup clean clone config disable downgrade download enable extra files hide home icons info \
-	install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite purge query reinstall remove sandbox \
+	install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite purge query reinstall relocate remove sandbox \
 	select sync template test translate unhide unlock update --all --appimages --apps --byname --clone --config --convert --debug \
 	--devmode-disable --devmode-enable --disable-notifications --enable-notifications --force-latest --home --icons \
-	-ias --launcher --less --pkg --portable --rollback --disable-sandbox --sandbox --system --translate --user $third_party_flags"
+	-ias --launcher --less --pkg --portable --rollback --disable-sandbox --relocate --sandbox --system --translate --user $third_party_flags"
 
 _completion_lists() {
 	# Remove existing lists and download new ones
@@ -1110,6 +1110,21 @@ _use_hide_unhide() {
 			[ -n "$APPMAN_APPSPATH" ] && [ -f "$APPMAN_APPSPATH/$arg/remove.old" ] && mv "$APPMAN_APPSPATH/$arg/remove.old" "$APPMAN_APPSPATH/$arg/remove" && echo $"✔ $APPMAN_APPSPATH/$arg can be managed again"
 		done
 		_clean_amcachedir
+	fi
+}
+
+################################################################################################################################################################
+#				RELOCATE
+################################################################################################################################################################
+
+_use_relocate() {
+	if [ ! -f "$APPMANCONFIG"/appman-config ]; then
+		echo "$DIVIDING_LINE"
+		echo " ERROR: appman-config file not found"
+		echo "$DIVIDING_LINE"
+	else
+		rm -f "$SCRIPTDIR"/am-clone.source
+		_clone_create_clone_file
 	fi
 }
 
@@ -1600,6 +1615,9 @@ case "$1" in
 		;;
 	'newrepo'|'neodb')
 		_use_newrepo "$@"
+		;;
+	'relocate'|'--relocate')
+		_use_relocate "$@"
 		;;
 	'sync'|'-s')
 		_use_sync

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-AMVERSION="9.8.2-3"
+AMVERSION="9.8.2-4"
 
 # Determine main repository and branch
 AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
@@ -631,9 +631,9 @@ fi
 ################################################################################################################################################################
 
 # COMPLETION LIST
-available_options="about add apikey backup clean config disable downgrade download enable extra files hide home icons info \
+available_options="about add apikey backup clean clone config disable downgrade download enable extra files hide home icons info \
 	install install-appimage launcher list lock neodb newrepo nolibfuse off on overwrite purge query reinstall remove sandbox \
-	select sync template test translate unhide unlock update --all --appimages --apps --byname --config --convert --debug \
+	select sync template test translate unhide unlock update --all --appimages --apps --byname --clone --config --convert --debug \
 	--devmode-disable --devmode-enable --disable-notifications --enable-notifications --force-latest --home --icons \
 	-ias --launcher --less --pkg --portable --rollback --disable-sandbox --sandbox --system --translate --user $third_party_flags"
 
@@ -1019,6 +1019,44 @@ _use_clean() {
 	_clean_all_tmp_directories_from_appspath
 	_clean_launchers 2>/dev/null
 	_clean_old_modules
+}
+
+################################################################################################################################################################
+#				CLONE
+################################################################################################################################################################
+
+_clone_show_items_msg() {
+	echo "$DIVIDING_LINE"
+	if [ -f "$CLONE_FILE" ]; then
+		printf "File: %b\n\nContent:\n" "$CLONE_FILE"
+		sort "$CLONE_FILE" | _fit
+	else
+		echo " ERROR: am-clone.source file not found"
+	fi
+	echo "$DIVIDING_LINE"
+}
+
+_use_clone() {
+	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$SCRIPTDIR" -type f -name am-clone.source 2>/dev/null | head -1)
+	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find "$HOME" -type f -name am-clone.source 2>/dev/null | head -1)
+	[ -z "$CLONE_FILE" ] && CLONE_FILE=$(find / -type f -name am-clone.source 2>/dev/null | head -1)
+	if [ -z "$CLONE_FILE" ]; then
+		_determine_args
+		rm -f "$SCRIPTDIR"/am-clone.source
+		for arg in $ARGS; do
+			argpath=$(echo "$ARGPATHS" | grep "/$arg$")
+			[ -d "$argpath"/.am-installer ] && scriptname=$(ls "$argpath/.am-installer/" | head -1)
+			[ -z "$scriptname" ] && scriptname="$arg"
+			if [ "$arg" != am ]; then
+				echo "$argpath" | sed "s/\/$arg$/\/$scriptname/g" >> "$SCRIPTDIR"/am-clone.source
+			fi
+			scriptname=""
+		done
+		[ -f "$SCRIPTDIR"/am-clone.source ] && CLONE_FILE="$SCRIPTDIR/am-clone.source"
+	fi
+	if echo "$1" | grep -q -- "clone"; then
+		_clone_show_items_msg
+	fi
 }
 
 ################################################################################################################################################################
@@ -1491,6 +1529,9 @@ case "$1" in
 		;;
 	'clean'|'-c')
 		_use_clean
+		;;
+	'clone'|'--clone')
+		_use_clone "$@"
 		;;
 	'devmode-disable'|'devmode-enable'|'--devmode-disable'|'--devmode-enable')
 		if [ "$CLI_PATH" = "/usr/bin/am" ]; then


### PR DESCRIPTION
fix https://github.com/ivan-hc/AM/issues/1817

Two new options added.

## Option `clone` or `--clone`
Clone your configuration and share it to other systems. Usage:
```
am clone
```
or
```
appman clone
```
this command without arguments only looks for a file named `am-clone.source`, on the Desktop first as prior path, then in the $HOME and then everywhere in the system, also on mounted devices.

Add the flag `-i` or `install` to also install the listed apps
```
am clone -i
```
or
```
appman clone -i
```

--------------------------------------

## Option `relocate` or `--relocate`
This option is for AppMan or for AM in AppMan mode and all AppMan apps (that can be managed also via AM).

As I explain on the README, AM installs everything always in /opt, by following the Linux Standard Base. That path will not be changed.

On the contrary, AppMan installs everything wherever you want, but you were unable to change the path once you have installed it and the apps.

Now you can
```
am relocate
```
or
```
appman relocate
```

https://github.com/user-attachments/assets/4d1aee94-bcd4-4ac3-9ce5-35fde080cb03