### PR TITLE
Fix: Correct application name variable in install script of `programs/x86_64/dbgate-premium`

### DIFF
--- a/programs/x86_64/dbgate-premium
+++ b/programs/x86_64/dbgate-premium
@@ -2,7 +2,7 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=dbgate
+APP=dbgate-premium
 SITE="dbgate/dbgate"
 
 # CREATE DIRECTORIES AND ADD REMOVER
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/dbgate/dbgate/releases | sed 's/[()",{} ]/\n/g' | grep -oiE "https.*${APP}-premium-[0-9]+.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/dbgate/dbgate/releases | sed 's/[()",{} ]/\n/g' | grep -oiE "https.*${APP}-[0-9]+.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -30,10 +30,10 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=dbgate
+APP=dbgate-premium
 SITE="dbgate/dbgate"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/dbgate/dbgate/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*${APP}-premium-[0-9]+.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/dbgate/dbgate/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*${APP}-[0-9]+.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
`am -a dbgate-premium` should now correctly display the status of "installed" when you install the program.

![000001_2025-09-27_16-41-01](https://github.com/user-attachments/assets/64763f64-acc9-4fb9-bc15-8e1f815d37d8)
