### PR TITLE
Move gtk3 AppImages back from "am-extras" to "AM"

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1,3 +1,10 @@
+◆ baobab : Unofficial. A graphical directory tree analyzer.
+◆ eog : Unofficial. Eye of Gnome: An image viewing and cataloging program.
+◆ file-roller : Unofficial. Create and modify archives.
+◆ galculator : Unofficial. GTK+ based scientific calculator.
+◆ gedit : Unofficial. Easy-to-use general-purpose text editor.
+◆ gnome-system-monitor : Unofficial. View current processes and monitor system state.
+◆ simple-scan : Unofficial. Simple scanning utility.
 ◆ 0ad : FOSS historical Real Time Strategy, RTS game of ancient warfare.
 ◆ 0ad-prerelease : FOSS historical Real Time Strategy, RTS game of ancient warfare (Pre-release).
 ◆ 12to11 : Unofficial, tool for running Wayland applications on an X server.
@@ -995,7 +1002,6 @@
 ◆ fzf : A command-line fuzzy finder.
 ◆ g-v2ray : Advanced V2Ray/Xray GUI Client for Linux.
 ◆ gaiasky : Gaia Sky, a real-time 3D space simulator & astronomy visualisation.
-◆ galculator : A GTK 2 / GTK 3 based scientific calculator.
 ◆ gale : A modern mod manager for Thunderstore.
 ◆ gallery-dl : Command-line program to download image galleries and collections.
 ◆ gameconqueror : Unofficial. Memory scanner designed to isolate the adress of an arbitrary variable in an executing process (gtk GUI).
@@ -1090,7 +1096,6 @@
 ◆ gnome-boxes : Unofficial, A simple GNOME application to access virtual machines.
 ◆ gnome-calculator : Unofficial, Perform arithmetic, scientific or financial calculations.
 ◆ gnome-pomodoro : A productivity tool designed to help you manage your time effectively using the Pomodoro Technique.
-◆ gnome-system-monitor : Unofficial. View current processes and monitor system state.
 ◆ gnome-text-editor : Unofficial AppImage of the Gnome's Text Editor application.
 ◆ gnome-tweaks : Unofficial, Experimental AppImage port of advanced GNOME 3 settings GUI.
 ◆ gnu-freedink : Unofficial, a portable and enhanced version of the Dink Smallwood game engine.

--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1,10 +1,9 @@
-◆ baobab : Unofficial. A graphical directory tree analyzer.
-◆ eog : Unofficial. Eye of Gnome: An image viewing and cataloging program.
-◆ file-roller : Unofficial. Create and modify archives.
-◆ galculator : Unofficial. GTK+ based scientific calculator.
-◆ gedit : Unofficial. Easy-to-use general-purpose text editor.
-◆ gnome-system-monitor : Unofficial. View current processes and monitor system state.
-◆ simple-scan : Unofficial. Simple scanning utility.
+◆ baobab : A graphical directory tree analyzer for the GNOME desktop environment, to keep your disk usage and available space under control.
+◆ eog : Eye of Gnome is an image viewing and cataloging program.
+◆ file-roller : File Roller is an archive manager for the GNOME desktop environment. Create and modify archives.
+◆ gedit : An easy-to-use general-purpose text editor for the GNOME desktop environment.
+◆ gnome-system-monitor : System Monitor is a process viewer and system monitor with an attractive, easy-to-use interface for the GNOME desktop environment.
+◆ simple-scan : Make a digital copy of your photos and documents. Simple scanning utility for the GNOME desktop environment.
 ◆ 0ad : FOSS historical Real Time Strategy, RTS game of ancient warfare.
 ◆ 0ad-prerelease : FOSS historical Real Time Strategy, RTS game of ancient warfare (Pre-release).
 ◆ 12to11 : Unofficial, tool for running Wayland applications on an X server.
@@ -1002,6 +1001,7 @@
 ◆ fzf : A command-line fuzzy finder.
 ◆ g-v2ray : Advanced V2Ray/Xray GUI Client for Linux.
 ◆ gaiasky : Gaia Sky, a real-time 3D space simulator & astronomy visualisation.
+◆ galculator : A GTK 2 / GTK 3 based scientific calculator.
 ◆ gale : A modern mod manager for Thunderstore.
 ◆ gallery-dl : Command-line program to download image galleries and collections.
 ◆ gameconqueror : Unofficial. Memory scanner designed to isolate the adress of an arbitrary variable in an executing process (gtk GUI).

--- a/programs/x86_64/baobab
+++ b/programs/x86_64/baobab
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=gnome-system-monitor
-SITE1="pkgforge-dev/Gnome-System-Monitor-AppImage" SITE2="ivan-hc/GNOME3-appimages"
+APP=baobab
+SITE1="" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -15,7 +15,7 @@ chmod a+x ../remove || exit 1
 [ -n "$SITE1" ] && read -r -p "
  Choose which version of $APP AppImage to use:
 
- 1. Latest build
+ 1. Latest build.
 
     Source: https://github.com/$SITE1
 
@@ -52,7 +52,7 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=gnome-system-monitor
+APP=baobab
 SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(curl -Ls https://api.github.com/repos/REPLACETHIS/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)

--- a/programs/x86_64/eog
+++ b/programs/x86_64/eog
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=gnome-system-monitor
-SITE1="pkgforge-dev/Gnome-System-Monitor-AppImage" SITE2="ivan-hc/GNOME3-appimages"
+APP=eog
+SITE1="" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -15,7 +15,7 @@ chmod a+x ../remove || exit 1
 [ -n "$SITE1" ] && read -r -p "
  Choose which version of $APP AppImage to use:
 
- 1. Latest build
+ 1. Latest build.
 
     Source: https://github.com/$SITE1
 
@@ -52,7 +52,7 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=gnome-system-monitor
+APP=eog
 SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(curl -Ls https://api.github.com/repos/REPLACETHIS/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)

--- a/programs/x86_64/file-roller
+++ b/programs/x86_64/file-roller
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=gnome-system-monitor
-SITE1="pkgforge-dev/Gnome-System-Monitor-AppImage" SITE2="ivan-hc/GNOME3-appimages"
+APP=file-roller
+SITE1="" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -15,7 +15,7 @@ chmod a+x ../remove || exit 1
 [ -n "$SITE1" ] && read -r -p "
  Choose which version of $APP AppImage to use:
 
- 1. Latest build
+ 1. Latest build.
 
     Source: https://github.com/$SITE1
 
@@ -52,7 +52,7 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=gnome-system-monitor
+APP=file-roller
 SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(curl -Ls https://api.github.com/repos/REPLACETHIS/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)

--- a/programs/x86_64/galculator
+++ b/programs/x86_64/galculator
@@ -15,11 +15,11 @@ chmod a+x ../remove || exit 1
 [ -n "$SITE1" ] && read -r -p "
  Choose which version of $APP AppImage to use:
 
- 1. Latest build.
+ 1. Anylinux build, works everywhere (~17 MB).
 
     Source: https://github.com/$SITE1
 
- 2. Legacy, old GTK implementation.
+ 2. Legacy, old implementation based on Debian (~3 MB).
 
     Source: https://github.com/$SITE2
 

--- a/programs/x86_64/galculator
+++ b/programs/x86_64/galculator
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=galculator
-SITE="pkgforge-dev/Galculator-AppImage"
+SITE1="pkgforge-dev/Galculator-AppImage" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,10 +12,32 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/Galculator-AppImage/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
-wget "$version" || exit 1
-# Keep this space in sync with other installation scripts
-# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+[ -n "$SITE1" ] && read -r -p "
+ Choose which version of $APP AppImage to use:
+
+ 1. Latest build.
+
+    Source: https://github.com/$SITE1
+
+ 2. Legacy, old GTK implementation.
+
+    Source: https://github.com/$SITE2
+
+ Which version you choose (type a number and press ENTER)?" response
+RELEASE=""
+if [ -n "$SITE1" ] && echo "$response" | grep -q "^1"; then
+	RELEASE="$SITE1"
+elif [ -z "$SITE1" ] || echo "$response" | grep -q "^2"; then
+	RELEASE="$SITE2"
+fi
+[ -z "$RELEASE" ] && exit 0
+
+version=$(curl -Ls https://api.github.com/repos/"$RELEASE"/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)
+if [ -z "$version" ]; then
+	printf "\n 💀 ERROR: it seems that upstream removed %b, please retry\n" "$RELEASE" && exit 1
+else
+	wget "$version" || exit 1
+fi
 cd ..
 mv ./tmp/*mage ./"$APP"
 # Keep this space in sync with other installation scripts
@@ -31,9 +53,9 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=galculator
-SITE="pkgforge-dev/Galculator-AppImage"
+SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/Galculator-AppImage/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/REPLACETHIS/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1
@@ -55,6 +77,7 @@ else
 fi
 EOF
 chmod a+x ./AM-updater || exit 1
+sed -i "s#REPLACETHIS#$RELEASE#g" /opt/"$APP"/AM-updater
 
 # LAUNCHER & ICON
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop

--- a/programs/x86_64/gedit
+++ b/programs/x86_64/gedit
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=gedit
-SITE="ivan-hc/Gedit-appimage"
+SITE1="" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,10 +12,32 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/ivan-hc/Gedit-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
-wget "$version" || exit 1
-# Keep this space in sync with other installation scripts
-# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+[ -n "$SITE1" ] && read -r -p "
+ Choose which version of $APP AppImage to use:
+
+ 1. Latest build.
+
+    Source: https://github.com/$SITE1
+
+ 2. Legacy, old GTK implementation.
+
+    Source: https://github.com/$SITE2
+
+ Which version you choose (type a number and press ENTER)?" response
+RELEASE=""
+if [ -n "$SITE1" ] && echo "$response" | grep -q "^1"; then
+	RELEASE="$SITE1"
+elif [ -z "$SITE1" ] || echo "$response" | grep -q "^2"; then
+	RELEASE="$SITE2"
+fi
+[ -z "$RELEASE" ] && exit 0
+
+version=$(curl -Ls https://api.github.com/repos/"$RELEASE"/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)
+if [ -z "$version" ]; then
+	printf "\n 💀 ERROR: it seems that upstream removed %b, please retry\n" "$RELEASE" && exit 1
+else
+	wget "$version" || exit 1
+fi
 cd ..
 mv ./tmp/*mage ./"$APP"
 # Keep this space in sync with other installation scripts
@@ -31,9 +53,9 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=gedit
-SITE="ivan-hc/Gedit-appimage"
+SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/ivan-hc/Gedit-appimage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/REPLACETHIS/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1
@@ -55,6 +77,7 @@ else
 fi
 EOF
 chmod a+x ./AM-updater || exit 1
+sed -i "s#REPLACETHIS#$RELEASE#g" /opt/"$APP"/AM-updater
 
 # LAUNCHER & ICON
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
@@ -72,6 +95,6 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
-sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root

--- a/programs/x86_64/gedit
+++ b/programs/x86_64/gedit
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=gedit
-SITE1="" SITE2="ivan-hc/GNOME3-appimages"
+SITE1="ivan-hc/Gedit-appimage" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1

--- a/programs/x86_64/simple-scan
+++ b/programs/x86_64/simple-scan
@@ -2,8 +2,8 @@
 
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
-APP=gnome-system-monitor
-SITE1="pkgforge-dev/Gnome-System-Monitor-AppImage" SITE2="ivan-hc/GNOME3-appimages"
+APP=simple-scan
+SITE1="" SITE2="ivan-hc/GNOME3-appimages"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -15,7 +15,7 @@ chmod a+x ../remove || exit 1
 [ -n "$SITE1" ] && read -r -p "
  Choose which version of $APP AppImage to use:
 
- 1. Latest build
+ 1. Latest build.
 
     Source: https://github.com/$SITE1
 
@@ -52,7 +52,7 @@ ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
 cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
-APP=gnome-system-monitor
+APP=simple-scan
 SITE="REPLACETHIS"
 version0=$(cat "/opt/$APP/version")
 version=$(curl -Ls https://api.github.com/repos/REPLACETHIS/releases | sed 's/[()",{} ]/\n/g' | grep -io 'https.*x86_64.*mage$' | grep -i "$APP" | head -1)


### PR DESCRIPTION
Multiple choice scripts with first SITE reference or SITE1 for "latest" (if exists) and SITE2 for https://github.com/ivan-hc/GNOME3-appimages as a fallback, if the first is empty