### PR TITLE
KiCad source switch

### DIFF
--- a/programs/x86_64/kicad
+++ b/programs/x86_64/kicad
@@ -3,7 +3,7 @@
 # AM INSTALL SCRIPT VERSION 3.5
 set -u
 APP=kicad
-SITE="https://sourceforge.net/p/kicad-appimage"
+SITE="KiCad/kicad-source-mirror"
 
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
@@ -12,8 +12,8 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://sourceforge.net/p/kicad-appimage/activity/feed?limit=100000 | tr '">< ' '\n' | grep -i "^https://sourceforge.net/projects/.*download" | grep -i "appimage" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
-wget "$version" || exit 1
+version=$(curl -Ls https://api.github.com/repos/KiCad/kicad-source-mirror/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+wget -c "$version" -O - | tar x || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 cd ..
@@ -31,9 +31,9 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=kicad
-SITE="https://sourceforge.net/p/kicad-appimage"
+SITE="KiCad/kicad-source-mirror"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://sourceforge.net/p/kicad-appimage/activity/feed?limit=100000 | tr '">< ' '\n' | grep -i "^https://sourceforge.net/projects/.*download" | grep -i "appimage" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/KiCad/kicad-source-mirror/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1
@@ -42,7 +42,7 @@ fi
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	notify-send "A new version of $APP is available, please wait"
-	wget "$version" || exit 1
+	wget -c "$version" -O - | tar x || exit 1
 	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
 	cd ..
 	mv --backup=t ./tmp/* ./"$APP"

--- a/programs/x86_64/kicad
+++ b/programs/x86_64/kicad
@@ -12,13 +12,13 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/KiCad/kicad-source-mirror/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
-wget -c "$version" -O - | tar x || exit 1
-# Keep this space in sync with other installation scripts
-# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+version=$(curl -Ls https://api.github.com/repos/KiCad/kicad-source-mirror/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+wget "$version" || exit 1
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar* ] && tar fx ./*tar* && rm -f ./*tar*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 cd ..
-mv ./tmp/* ./"$APP"
-# Keep this space in sync with other installation scripts
+if [ -d ./tmp/* ]; then mv --backup=t ./tmp/*/* ./"$APP"; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./"$APP"; fi
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
 chmod a+x ./"$APP" || exit 1
@@ -33,7 +33,7 @@ set -u
 APP=kicad
 SITE="KiCad/kicad-source-mirror"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/KiCad/kicad-source-mirror/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/KiCad/kicad-source-mirror/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1
@@ -42,10 +42,12 @@ fi
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	notify-send "A new version of $APP is available, please wait"
-	wget -c "$version" -O - | tar x || exit 1
-	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	wget "$version" || exit 1
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar* ] && tar fx ./*tar* && rm -f ./*tar*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 	cd ..
-	mv --backup=t ./tmp/* ./"$APP"
+	if [ -d ./tmp/* ]; then mv --backup=t ./tmp/*/* ./"$APP"; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./"$APP"; fi
 	chmod a+x ./"$APP" || exit 1
 	echo "$version" > ./version
 	rm -R -f ./*zs-old ./*.part ./tmp ./*~


### PR DESCRIPTION
Switching source from sourceforce to github where most recent appimages are published (packed as tar).

Unfortunately the sourceforge repo wasn't updated for some time  (V9.0.3 which is the most recent one available was released in July 2025, 9.0.4 released a month afterwards fixed some critical bugs).

The new kicad repo is managed by kidac self, so I hope there's some sustainability. 

remark:
I had trouble with the "original" un-tar version, so I added a piped tar x 
