### PR TITLE
Add Overte aarch64 recipe.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Ping Overte maintainer any time Overte's recipe gets changed.
+/programs/x86_64/overte @JulianGro
+/programs/aarch64/overte @JulianGro

--- a/programs/aarch64-appimages
+++ b/programs/aarch64-appimages
@@ -189,6 +189,7 @@
 ◆ opentyrian2000 : Unofficial, an open-source port of the DOS shoot-em-up Tyrian.
 ◆ optiimage : Unofficial, optimize your images with OptiImage, a useful image compressor that supports PNG, JPEG, WebP and SVG file types.
 ◆ oversteer : Unofficial, Steering Wheel Manager for Linux.
+◆ Overte : Overte open source virtual worlds and social-VR platform.
 ◆ pcexhumed : Unofficial, port of the PC version of Exhumed based on EDuke32.
 ◆ pcsx-redux-enhanced : Unofficial, modern fork of the pcsxr PlayStation 1 emulator focused on reverse engineering and homebrew development.
 ◆ pdf-arranger : Unofficial, a small python-gtk application, which helps the user to merge or split PDF documents and rotate, crop and rearrange their pages.

--- a/programs/aarch64/overte
+++ b/programs/aarch64/overte
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/overte-org/overte/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/overte-org/overte/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "aarch64\|arm64" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -31,9 +31,9 @@ cat >> ./AM-updater << 'EOF'
 #!/bin/sh
 set -u
 APP=overte
-SITE="overte-org/overte"
+SITE="https://overte.org"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/overte-org/overte/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/overte-org/overte/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -i "aarch64\|arm64" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64-appimages
+++ b/programs/x86_64-appimages
@@ -1609,7 +1609,7 @@
 ◆ overbind : A utility that allows binding keyboard buttons to virtual Xbox360 controller joystick outputs.
 ◆ overlayed : A modern, open-source, and free voice chat overlay for Discord.
 ◆ oversteer : Unofficial, Steering Wheel Manager for Linux.
-◆ overte : Overte open source virtual worlds platform.
+◆ Overte : Overte open source virtual worlds and social-VR platform.
 ◆ ovideo : Video Editor.
 ◆ ow-mod-man : The mod manager for the Outer Wilds Mod Loader.
 ◆ owallet : A comprehensive Ontology desktop wallet.


### PR DESCRIPTION
Add aarch64 recipe and update name and description. Also create a CODEOWNERS file to ping an upstream maintainer any time a Pull Request is opened against the recipe.

I also took the liberty of uploading AppImages to our GitHub release page, so AM doesn't pull a version from mid 2024 anymore ;)