### PR TITLE
Fix StartupWMClass in ungoogled-chromium desktop file

### DIFF
--- a/programs/x86_64/ungoogled-chromium
+++ b/programs/x86_64/ungoogled-chromium
@@ -75,3 +75,13 @@ done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root
+
+# Fix StartupWMClass
+if ! grep -q "StartupWMClass" $HOME/.local/share/applications/ungoogled-chromium-AM.desktop; then
+  # Compatibile con FreeBSD sed
+  sed -i '/^\[Desktop Entry\]/a\
+StartupWMClass=chromium-browser
+' $HOME/.local/share/applications/ungoogled-chromium-AM.desktop
+else
+  sed -i 's|^StartupWMClass=.*|StartupWMClass=chromium-browser|' $HOME/.local/share/applications/ungoogled-chromium-AM.desktop
+fi


### PR DESCRIPTION
Hi @ivan-hc, 
as requested in #2436, I tested the script modification locally and it successfully fixes the duplicate icon issue on KDE Wayland.

This PR adds the correct `StartupWMClass=chromium-browser` patch to the end of the ungoogled-chromium script. 

Thanks for your support!