### PR TITLE
shutter-encoder: fix broken .desktop file

### DIFF
--- a/programs/x86_64/shutter-encoder
+++ b/programs/x86_64/shutter-encoder
@@ -72,6 +72,6 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
-sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+sed -i "s#Exec=.*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
 mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
 rm -R -f ./squashfs-root


### PR DESCRIPTION
The sed pattern `Exec=[^ ]*` stops at the first space, so the quoted value from the AppImage's built-in `.desktop` file is only partially replaced.


Original `.desktop` file from the AppImage:

```
[Desktop Entry]
Name=Shutter Encoder
Exec="Shutter Encoder"
Icon=shutter-encoder
Type=Application
Categories=AudioVideo;Video;
Terminal=false
```

Result with the old pattern:

`Exec=/home/user/.local/bin/shutter-encoder Encoder"`

Result with the fix:

`Exec=/home/user/.local/bin/shutter-encoder`
