### PR TITLE
nvim: add aarch64 install scripts

### DIFF
--- a/programs/aarch64-apps
+++ b/programs/aarch64-apps
@@ -282,6 +282,8 @@
 ◆ nproc : Print the number of processing units available. This is part of "am-utils" suite.
 ◆ nugget-doom-enhanced : Unofficial, a Doom source port forked from Woof! with additional features.
 ◆ numfmt : From/to human-readable strings. This is part of "am-utils" suite.
+◆ nvim : NeoVim, Vim fork focused on extensibility and usability.
+◆ nvim-nightly : NeoVim, Vim fork, the most recent development build.
 ◆ nxengine-evo-enhanced : Unofficial, a somewhat upgraded/refactored version of NXEngine.
 ◆ objcopy : Translate object files. This is part of "am-utils" suite.
 ◆ objdump : From object files. This is part of "am-utils" suite.

--- a/programs/aarch64/nvim
+++ b/programs/aarch64/nvim
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=nvim
+SITE="neovim/neovim"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/neovim/neovim/releases | sed 's/[()",{} ]/\n/g' | grep -o 'https.*releases.*nvim.*mage$' | grep -v "nightly\|x86_64\|i686\|i386" | head -1)
+wget "$version" || exit 1
+# Keep this space in sync with other installation scripts
+echo "$version" > /opt/$APP/version
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=nvim
+SITE="neovim/neovim"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/neovim/neovim/releases | sed 's/[()",{} ]/\n/g' | grep -o 'https.*releases.*nvim.*mage$' | grep -v "nightly\|x86_64\|i686\|i386" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH=$(readlink ./"$APP".desktop)
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH=$(readlink ./DirIcon)
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root

--- a/programs/aarch64/nvim-nightly
+++ b/programs/aarch64/nvim-nightly
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=nvim-nightly
+SITE="neovim/neovim"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/neovim/neovim/releases | sed 's/[()",{} ]/\n/g' | grep -o 'https.*releases.*nvim.*mage$' | grep -v "x86_64\|i686\|i386" | grep -i nightly | head -1)
+wget "$version" || exit 1
+# Keep this space in sync with other installation scripts
+echo "$version" > /opt/$APP/version
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=nvim-nightly
+SITE="neovim/neovim"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/neovim/neovim/releases | sed 's/[()",{} ]/\n/g' | grep -o 'https.*releases.*nvim.*mage$' | grep -v "x86_64\|i686\|i386" | grep -i nightly | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH=$(readlink ./"$APP".desktop)
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH=$(readlink ./DirIcon)
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
Add aarch64 variants of the nvim and nvim-nightly install scripts, mirroring the existing x86_64 ones (neovim/neovim publishes an arm64 AppImage per release). Added the two entries to aarch64-apps as well.