### PR TITLE
Add opencode-desktop

### DIFF
--- a/programs/stats-appimages
+++ b/programs/stats-appimages
@@ -1593,7 +1593,6 @@
 ◆ openbor : Ultimate 2D side scrolling engine for beat em ups, shooters... #itsdesktopapp
 ◆ openclaw : Unofficial, reimplementation of Captain Claw (1997) platformer. #itsdesktopapp
 ◆ opencloud : Desktop application to synchronize files from OpenCloud with your computer. #itsdesktopapp
-◆ opencode : The open source coding agent. #itsdesktopapp
 ◆ opencode-desktop : Desktop application for opencode, the open source coding agent. #itsdesktopapp
 ◆ opencode-enhanced : Unofficial, improved AppImage of opencode, the open source coding agent. #itsdesktopapp
 ◆ opencomic : Comic and Manga reader, written with Node.js and using Electron. #itsdesktopapp

--- a/programs/stats-appimages
+++ b/programs/stats-appimages
@@ -1594,6 +1594,7 @@
 ◆ openclaw : Unofficial, reimplementation of Captain Claw (1997) platformer. #itsdesktopapp
 ◆ opencloud : Desktop application to synchronize files from OpenCloud with your computer. #itsdesktopapp
 ◆ opencode : The open source coding agent. #itsdesktopapp
+◆ opencode-desktop : Desktop application for opencode, the open source coding agent. #itsdesktopapp
 ◆ opencode-enhanced : Unofficial, improved AppImage of opencode, the open source coding agent. #itsdesktopapp
 ◆ opencomic : Comic and Manga reader, written with Node.js and using Electron. #itsdesktopapp
 ◆ opengothic : Unofficial AppImage of OpenGothic. #itsdesktopapp

--- a/programs/x86_64-appimages
+++ b/programs/x86_64-appimages
@@ -1593,7 +1593,6 @@
 ◆ openbor : Ultimate 2D side scrolling engine for beat em ups, shooters...
 ◆ openclaw : Unofficial, reimplementation of Captain Claw (1997) platformer.
 ◆ opencloud : Desktop application to synchronize files from OpenCloud with your computer.
-◆ opencode : The open source coding agent.
 ◆ opencode-desktop : Desktop application for opencode, the open source coding agent.
 ◆ opencode-enhanced : Unofficial, improved AppImage of opencode, the open source coding agent.
 ◆ opencomic : Comic and Manga reader, written with Node.js and using Electron.

--- a/programs/x86_64-appimages
+++ b/programs/x86_64-appimages
@@ -1594,6 +1594,7 @@
 ◆ openclaw : Unofficial, reimplementation of Captain Claw (1997) platformer.
 ◆ opencloud : Desktop application to synchronize files from OpenCloud with your computer.
 ◆ opencode : The open source coding agent.
+◆ opencode-desktop : Desktop application for opencode, the open source coding agent.
 ◆ opencode-enhanced : Unofficial, improved AppImage of opencode, the open source coding agent.
 ◆ opencomic : Comic and Manga reader, written with Node.js and using Electron.
 ◆ opengothic : Unofficial AppImage of OpenGothic.

--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -2016,6 +2016,7 @@
 ◆ openclaw : Unofficial, reimplementation of Captain Claw (1997) platformer.
 ◆ opencloud : Desktop application to synchronize files from OpenCloud with your computer.
 ◆ opencode : The open source coding agent.
+◆ opencode-desktop : Desktop application for opencode, the open source coding agent.
 ◆ opencode-enhanced : Unofficial, improved AppImage of opencode, the open source coding agent.
 ◆ opencomic : Comic and Manga reader, written with Node.js and using Electron.
 ◆ opengothic : Unofficial AppImage of OpenGothic.

--- a/programs/x86_64/opencode
+++ b/programs/x86_64/opencode
@@ -8,20 +8,19 @@ SITE="anomalyco/opencode"
 # CREATE DIRECTORIES AND ADD REMOVER
 [ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
 printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
-printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/anomalyco/opencode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*mage$" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/anomalyco/opencode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l\|baseline\|musl\|desktop\|darwin\|windows\|win-\|mac-" | grep -i "linux.*tar.gz" | head -1)
 wget "$version" || exit 1
-# Keep this space in sync with other installation scripts
-# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 cd ..
-mv ./tmp/*mage ./"$APP"
-# Keep this space in sync with other installation scripts
+if [ -d ./tmp/* 2>/dev/null ]; then mv ./tmp/*/* ./; else mv ./tmp/* ./"$APP" 2>/dev/null || mv ./tmp/* ./; fi
 rm -R -f ./tmp || exit 1
 echo "$version" > ./version
-chmod a+x ./"$APP" || exit 1
+chmod a+x ./$APP || exit 1
 
 # LINK TO PATH
 ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
@@ -33,45 +32,23 @@ set -u
 APP=opencode
 SITE="anomalyco/opencode"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/anomalyco/opencode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*mage$" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/anomalyco/opencode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l\|baseline\|musl\|desktop\|darwin\|windows\|win-\|mac-" | grep -i "linux.*tar.gz" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
-if command -v appimageupdatetool >/dev/null 2>&1; then
-	cd "/opt/$APP" || exit 1
-	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
-fi
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
 	notify-send "A new version of $APP is available, please wait"
 	wget "$version" || exit 1
-	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	[ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
+	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
+	[ -e ./*zip ] && unzip -qq ./*zip 1>/dev/null && rm -f ./*zip
 	cd ..
-	mv --backup=t ./tmp/*mage ./"$APP"
+	if [ -d ./tmp/* 2>/dev/null ]; then mv --backup=t ./tmp/*/* ./; else mv --backup=t ./tmp/* ./"$APP" 2>/dev/null || mv --backup=t ./tmp/* ./; fi
 	chmod a+x ./"$APP" || exit 1
 	echo "$version" > ./version
-	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	rm -R -f ./tmp ./*~
 	notify-send "$APP is updated!"
 else
 	echo "Update not needed!"
 fi
 EOF
 chmod a+x ./AM-updater || exit 1
-
-# LAUNCHER & ICON
-./"$APP" --appimage-extract *e.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
-./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
-COUNT=0
-while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
-	if [ -L ./"$APP".desktop ]; then
-		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
-		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
-	fi
-	if [ -L ./DirIcon ]; then
-		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
-		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
-	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
-	COUNT=$((COUNT + 1))
-done
-sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./"$APP".desktop
-mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
-rm -R -f ./squashfs-root

--- a/programs/x86_64/opencode-desktop
+++ b/programs/x86_64/opencode-desktop
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.5
+set -u
+APP=opencode-desktop
+SITE="anomalyco/opencode"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/anomalyco/opencode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*desktop.*mage$" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+wget "$version" || exit 1
+# Keep this space in sync with other installation scripts
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=opencode-desktop
+SITE="anomalyco/opencode"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/anomalyco/opencode/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*desktop.*mage$" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	if [ -L ./"$APP".desktop ]; then
+		LINKPATH="$(readlink ./"$APP".desktop | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./"$APP".desktop
+	fi
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./"$APP".desktop
+mv ./"$APP".desktop /usr/local/share/applications/"$APP"-AM.desktop && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
## Summary
- Add `opencode-desktop`: install script for the opencode desktop app (Electron-based AppImage from anomalyco/opencode releases), listed alongside the existing `opencode` and `opencode-enhanced` packages.
- Fix `opencode`: upstream anomalyco/opencode no longer ships a plain AppImage, so the package's generic `mage$` filter was silently matching the new `opencode-desktop-*.AppImage` asset instead of the CLI. Switched it to fetch the `linux-x64` CLI tarball (`the-way`-style tar.gz install pattern), and removed it from the appimages/stats lists since it no longer creates a desktop launcher.

## Test plan
- [x] Verified the `opencode-desktop` grep pattern resolves to `opencode-desktop-linux-x86_64.AppImage`
- [x] Verified the fixed `opencode` grep pattern resolves to `opencode-linux-x64.tar.gz`
- [x] Downloaded and extracted the `opencode` tarball locally and confirmed `opencode --version` runs correctly