### PR TITLE
Fix duplicate symlinked AppImage launchers

### DIFF
--- a/regress/test-appimage-symlink-launchers.sh
+++ b/regress/test-appimage-symlink-launchers.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env sh
+
+set -u
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+cd "$tmpdir" || exit 1
+APP=tura
+mkdir -p squashfs-root/share/applications applications icons || exit 1
+
+cat > squashfs-root/share/applications/tura.desktop <<'EOF'
+[Desktop Entry]
+Name=Tura
+Exec=tura
+Icon=tura
+EOF
+
+ln -s ./share/applications/tura.desktop squashfs-root/tura.desktop || exit 1
+ln -s missing-icon.png DirIcon || exit 1
+
+cat > "$APP" <<'EOF'
+#!/usr/bin/env sh
+if [ "${1:-}" = "--appimage-extract" ] && [ "${2:-}" = "missing-icon.png" ]; then
+	mkdir -p squashfs-root
+	: > squashfs-root/missing-icon.png
+	exit 0
+fi
+
+mkdir -p squashfs-root/share/applications
+cat > squashfs-root/share/applications/tura.desktop <<'EOD'
+[Desktop Entry]
+Name=Tura
+Exec=tura
+Icon=tura
+EOD
+exit 0
+EOF
+chmod +x "$APP" || exit 1
+: > remove
+
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do
+	DESKTOP_SYMLINKS=0
+	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
+		FILE="$f"
+		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
+			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
+			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
+			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
+		fi
+		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
+		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
+		fi
+	done
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+
+desktop_count=$(find . -maxdepth 1 -name '*-AM.desktop' | wc -l | sed 's/ //g')
+
+if [ "$desktop_count" != "1" ] || [ ! -f ./"$APP"-AM.desktop ]; then
+	printf 'Expected exactly one desktop launcher, found %s\n' "$desktop_count" >&2
+	find . -maxdepth 1 -name '*-AM.desktop' -print >&2
+	exit 1
+fi
+
+printf 'PASS: symlinked desktop launcher is not duplicated\n'

--- a/templates/AM-SAMPLE-AppImage
+++ b/templates/AM-SAMPLE-AppImage
@@ -61,12 +61,16 @@ chmod a+x ./AM-updater || exit 1
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	DESKTOP_SYMLINKS=0
 	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
 		FILE="$f"
 		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
 			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
 		fi
 		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -76,7 +80,7 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-AppImage-download_kde_org
+++ b/templates/AM-SAMPLE-AppImage-download_kde_org
@@ -61,12 +61,16 @@ chmod a+x ./AM-updater || exit 1
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	DESKTOP_SYMLINKS=0
 	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
 		FILE="$f"
 		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
 			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
 		fi
 		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -76,7 +80,7 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-AppImage-in-archive
+++ b/templates/AM-SAMPLE-AppImage-in-archive
@@ -63,12 +63,16 @@ chmod a+x ./AM-updater || exit 1
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	DESKTOP_SYMLINKS=0
 	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
 		FILE="$f"
 		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
 			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
 		fi
 		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -78,7 +82,7 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-AppImage-muliple-choices
+++ b/templates/AM-SAMPLE-AppImage-muliple-choices
@@ -88,12 +88,16 @@ sed -i "s#REPLACETHIS#$RELEASE#g" /opt/"$APP"/AM-updater
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	DESKTOP_SYMLINKS=0
 	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
 		FILE="$f"
 		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
 			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
 		fi
 		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -103,7 +107,7 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-AppImage-muliple-choices-Archive+AppImage
+++ b/templates/AM-SAMPLE-AppImage-muliple-choices-Archive+AppImage
@@ -88,12 +88,16 @@ if [ "$RELEASE" = APPIMAGE ]; then
 	./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 	COUNT=0
 	while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+		DESKTOP_SYMLINKS=0
 		for f in squashfs-root/*.desktop; do
+			[ -e "$f" ] || continue
 			FILE="$f"
 			if [ -L "$f" ]; then
+				DESKTOP_SYMLINKS=1
 				LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 				./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 				FILE="./squashfs-root/$LINKPATH"
+				rm -f "$f"
 			fi
 			if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 			else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -103,7 +107,7 @@ if [ "$RELEASE" = APPIMAGE ]; then
 			LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 		fi
-		[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+		[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 		COUNT=$((COUNT + 1))
 	done
 	sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-AppImage-muliple-choices-if-SITE1-exists
+++ b/templates/AM-SAMPLE-AppImage-muliple-choices-if-SITE1-exists
@@ -86,12 +86,16 @@ sed -i "s#REPLACETHIS#$RELEASE#g" /opt/"$APP"/AM-updater
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	DESKTOP_SYMLINKS=0
 	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
 		FILE="$f"
 		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
 			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
 		fi
 		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -101,7 +105,7 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-portable2appimage
+++ b/templates/AM-SAMPLE-portable2appimage
@@ -63,12 +63,16 @@ chmod a+x ./AM-updater || exit 1
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0
 while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	DESKTOP_SYMLINKS=0
 	for f in squashfs-root/*.desktop; do
+		[ -e "$f" ] || continue
 		FILE="$f"
 		if [ -L "$f" ]; then
+			DESKTOP_SYMLINKS=1
 			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 			FILE="./squashfs-root/$LINKPATH"
+			rm -f "$f"
 		fi
 		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -78,7 +82,7 @@ while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a 
 		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 	fi
-	[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+	[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 	COUNT=$((COUNT + 1))
 done
 sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop

--- a/templates/AM-SAMPLE-soarpkg
+++ b/templates/AM-SAMPLE-soarpkg
@@ -88,12 +88,16 @@ else
 	./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 	COUNT=0
 	while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+		DESKTOP_SYMLINKS=0
 		for f in squashfs-root/*.desktop; do
+			[ -e "$f" ] || continue
 			FILE="$f"
 			if [ -L "$f" ]; then
+				DESKTOP_SYMLINKS=1
 				LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
 				./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
 				FILE="./squashfs-root/$LINKPATH"
+				rm -f "$f"
 			fi
 			if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
 			else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
@@ -103,7 +107,7 @@ else
 			LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
 			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
 		fi
-		[ ! -L ./"$APP".desktop ] && [ ! -L ./DirIcon ] && break
+		[ "$DESKTOP_SYMLINKS" -eq 0 ] && [ ! -L ./DirIcon ] && break
 		COUNT=$((COUNT + 1))
 	done
 	sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop


### PR DESCRIPTION
## Summary
Fix duplicate AppImage launchers when a root `.desktop` file is a symlink and another symlink keeps the launcher/icon resolution loop running.

## Root cause
The AppImage template loop followed a symlinked root `.desktop` file but left the original symlink in `squashfs-root`. If another symlink, such as `DirIcon`, kept the outer loop active, the same desktop target could be extracted and moved repeatedly as `$APP-$COUNT-AM.desktop`.

## Changes
- Remove each followed root `.desktop` symlink after resolving it.
- Track whether desktop symlinks remain and use that as part of the loop exit condition.
- Skip unmatched `squashfs-root/*.desktop` globs.
- Apply the same launcher handling to the AppImage template variants.
- Add a focused regression script for the symlinked desktop case.

## Testing
- `sh -n templates/AM-SAMPLE-AppImage templates/AM-SAMPLE-AppImage-in-archive templates/AM-SAMPLE-AppImage-muliple-choices templates/AM-SAMPLE-AppImage-muliple-choices-Archive+AppImage templates/AM-SAMPLE-AppImage-download_kde_org templates/AM-SAMPLE-soarpkg templates/AM-SAMPLE-AppImage-muliple-choices-if-SITE1-exists templates/AM-SAMPLE-portable2appimage regress/test-appimage-symlink-launchers.sh`
- `regress/test-appimage-symlink-launchers.sh`

Full regression container tests were not run locally because the project documentation recommends an isolated Podman/Docker environment for those tests.

Fixes #2487
