### PR TITLE
Bugfix: Resolved _appimage_extract: not found for st+ install script.

### DIFF
--- a/programs/x86_64/st+
+++ b/programs/x86_64/st+
@@ -56,11 +56,10 @@ fi
 EOF
 chmod a+x ./AM-updater || exit 1
 
-# Terminfo
+# LAUNCHER & ICON
 if command -v tic > /dev/null 2>&1; then
 	./"$APP" --appimage-extract st.info 1>/dev/null && tic -qsx ./squashfs-root/st.info > /dev/null 2>&1
 fi
-# LAUNCHER & ICON
 ./"$APP" --appimage-extract *.desktop 1>/dev/null && mv ./squashfs-root/*.desktop ./"$APP".desktop
 ./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
 COUNT=0


### PR DESCRIPTION
Install scripts gives this error during install:
```./st+: 61: _appimage_extract: not found```

Solution: Terminfo for st+ install uses --appimage-extract, so it must be moved to after the "# LAUNCHER & ICON" section. This is because install.am replaces all --appimage-extract commands with _appimage_extract, but the _appimage_extract function itself is only inserted at the "# LAUNCHER & ICON" point.