### PR TITLE
Add whatly (WhatsApp Web client, maintained fork of Whatsie)

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -3192,6 +3192,7 @@
 ◆ wezterm-nightly : A GPU-accelerated terminal emulator and multiplexer.
 ◆ wget : Network utility to retrieve files from the web. This is part of "am-utils" suite.
 ◆ whalebird : An Electron based Mastodon client.
+◆ whatly : Unofficial, feature-rich WhatsApp web client based on Qt WebEngine. A maintained fork of Whatsie with multi-account support, tray integration and messaging automation.
 ◆ whatsdesk : Unofficial, An unofficial client of WhatsApp.
 ◆ whatsie : Unofficial, feature rich WhatsApp web client based on Qt WebEngine.
 ◆ whatstron : Unofficial WhatsApp desktop client for Linux.

--- a/programs/x86_64/whatly
+++ b/programs/x86_64/whatly
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.6
+set -u
+APP=whatly
+SITE="shakaran/whatly"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/shakaran/whatly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+wget "$version" || exit 1
+# Keep this space in sync with other installation scripts
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=whatly
+SITE="shakaran/whatly"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/shakaran/whatly/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	for f in squashfs-root/*.desktop; do
+		FILE="$f"
+		if [ -L "$f" ]; then
+			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
+			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
+			FILE="./squashfs-root/$LINKPATH"
+		fi
+		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
+		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
+		fi
+	done
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP"-AM.desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+for f in ./*-AM.desktop; do [ "$f" != ./"$APP"-AM.desktop ] && [ -f "$f" ] && [ "$(sort ./"$APP"-AM.desktop)" = "$(sort "$f")" ] && rm -f "$f"; done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop
+mv ./*-AM.desktop /usr/local/share/applications/ && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
This adds an installation script for **whatly** (`programs/x86_64/whatly`) and its entry in `programs/x86_64-apps`.

**What it is:** whatly is a feature-rich WhatsApp Web desktop client based on Qt WebEngine — a maintained MIT fork of Whatsie (already in the catalogue), with multi-account support, tray integration, themes, spellcheck and messaging automation.

- Repo: https://github.com/shakaran/whatly
- Releases: https://github.com/shakaran/whatly/releases

**Notes on the script:**
- Built from the current `AM-SAMPLE-AppImage` (v3.6) template.
- The AppImage is published on GitHub releases as `Whatly-<version>-x86_64.AppImage`, with embedded AppImage update-information (`gh-releases-zsync|shakaran|whatly|latest|Whatly-*-x86_64.AppImage.zsync`) and a matching `.zsync`, so the `appimageupdatetool -Or` path in `AM-updater` works for delta updates.
- x86_64 only (no ARM AppImage is published upstream).
- Verified locally that the released AppImage exposes an extractable `.desktop` and `.DirIcon` (both symlinks, resolved by the template's loop).
