### PR TITLE
Add/replace photogimp, use pkgforge-dev release

### DIFF
--- a/programs/aarch64-apps
+++ b/programs/aarch64-apps
@@ -325,6 +325,7 @@
 ◆ perfect-dark : Unofficial, work in progress port of n64decomp/perfect_dark to modern platforms.
 ◆ phantom-satellite : Unofficial, a fork of Pale Moon that aims to support older/niche platforms, without sacrificing support for more common/modern platforms.
 ◆ phoenix-x-server : Unofficial, a new X server, written from scratch in Zig (not a fork). Designed to be a modern alternative to the Xorg server.
+◆ photogimp : Unofficial AppImage of GIMP that also includes PhotoGIMP. A patched version of GIMP for Adobe Photoshop users.
 ◆ piglit : Unofficial, a collection of automated tests for OpenGL, Vulkan, and OpenCL implementations.
 ◆ pika-backup : Doing backups the easy way. Plugin your USB drive and let the Pika do the rest for you.
 ◆ pinky : Lightweight finger. This is part of "am-utils" suite.

--- a/programs/aarch64/photogimp
+++ b/programs/aarch64/photogimp
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/GIMP-and-PhotoGIMP-AppImage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*mage$" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/GIMP-and-PhotoGIMP-AppImage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*mage$" |  grep -i "aarch64\|arm64" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -33,7 +33,7 @@ set -u
 APP=photogimp
 SITE="pkgforge-dev/GIMP-and-PhotoGIMP-AppImage"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/GIMP-and-PhotoGIMP-AppImage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*mage$" | grep -vi "i386\|i686\|armhf\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/pkgforge-dev/GIMP-and-PhotoGIMP-AppImage/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*download.*mage$" |  grep -i "aarch64\|arm64" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/obsolete-apps
+++ b/programs/obsolete-apps
@@ -647,7 +647,6 @@ pget 2023
 phinch 2023
 pho 2024
 photoflow 2020
-photogimp 2020
 photoname 2024
 photopealoader 2022
 phreshplayer 2019

--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -2182,7 +2182,7 @@
 ◆ photocrea : Unofficial Photopea wrapper, image editor that includes all the familiar features like layers, filters, magic wand selection, etc.
 ◆ photoflare : A simple but featureful image editor.
 ◆ photoflow : Edit images from digital cameras.
-◆ photogimp : A patched version of GIMP for Adobe Photoshop users.
+◆ photogimp : Unofficial AppImage of GIMP that also includes PhotoGIMP. A patched version of GIMP for Adobe Photoshop users.
 ◆ photon : Cross-platform file-transfer application built using flutter. It uses http to transfer files between devices.
 ◆ photoname : Rename photo image files based on EXIF shoot date.
 ◆ photopealoader : Photopea desktop app that loads local files and plugins.


### PR DESCRIPTION
@Samueru-sama since your GIMP AppImage need to be renamed to photogimp to run in that mode, I added some additional steps to patch the .desktop file and extract the correct icon.

```
	#if [ -L ./DirIcon ]; then
	#	LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
	#	./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
	#fi
	[ ! -L ./"$APP"-AM.desktop ] && [ ! -L ./DirIcon ] && break
	COUNT=$((COUNT + 1))
done
./"$APP" --appimage-extract PhotoGIMP/.local/share/icons/hicolor/512x512/apps/*.png 1>/dev/null && mv ./squashfs-root/PhotoGIMP/.local/share/icons/hicolor/512x512/apps/*.png ./DirIcon
for f in ./*-AM.desktop; do [ "$f" != ./"$APP"-AM.desktop ] && [ -f "$f" ] && [ "$(sort ./"$APP"-AM.desktop)" = "$(sort "$f")" ] && rm -f "$f"; done
sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g; s/^Name\(\[[^]]*\]\)\?=.*/Name\1=PhotoGIMP/" ./*-AM.desktop
```

Let me know if this is ok for you or can be done better.