### PR TITLE
Remove --trust-server-names flag dependency in some scripts

### DIFF
--- a/programs/aarch64/firefox
+++ b/programs/aarch64/firefox
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64-aarch64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/aarch64/firefox-beta
+++ b/programs/aarch64/firefox-beta
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64-aarch64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/aarch64/firefox-devedition
+++ b/programs/aarch64/firefox-devedition
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64-aarch64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/aarch64/firefox-esr
+++ b/programs/aarch64/firefox-esr
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64-aarch64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/aarch64/firefox-nightly
+++ b/programs/aarch64/firefox-nightly
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64-aarch64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/x86_64/firefox
+++ b/programs/x86_64/firefox
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/x86_64/firefox-beta
+++ b/programs/x86_64/firefox-beta
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/x86_64/firefox-devedition
+++ b/programs/x86_64/firefox-devedition
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/x86_64/firefox-esr
+++ b/programs/x86_64/firefox-esr
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/x86_64/firefox-nightly
+++ b/programs/x86_64/firefox-nightly
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/firefox/* ./

--- a/programs/x86_64/thunderbird
+++ b/programs/x86_64/thunderbird
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/thunderbird/* ./

--- a/programs/x86_64/thunderbird-beta
+++ b/programs/x86_64/thunderbird-beta
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/thunderbird/* ./

--- a/programs/x86_64/thunderbird-nightly
+++ b/programs/x86_64/thunderbird-nightly
@@ -29,9 +29,17 @@ RELEASE=""
 
 if echo "$response" | grep -q "^1"; then
 	RELEASE="PORTABLE"
-	LANGUAGE=$(curl -Ls https://raw.githubusercontent.com/linuxmint/mdm/master/config/locale.alias | grep -i "$LANG" | grep -o '^\S*')
-	CODE=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | cut -d ':' -f2 | grep -i "$LANGUAGE" | cut -d '=' -f2)
-	wget "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" --trust-server-names || exit 1
+	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
+	CODES=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
+	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
+		CODE="$LANGUAGE"
+	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
+		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
+	else
+		CODE=""
+	fi
+	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+	wget "$download" || exit 1
 	[ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 	cd ..
 	mv ./tmp/thunderbird/* ./

--- a/programs/x86_64/zotero
+++ b/programs/x86_64/zotero
@@ -16,7 +16,8 @@ chmod a+x /opt/"$APP"/remove
 mkdir -p tmp
 cd ./tmp
 
-wget "https://www.zotero.org/download/client/dl?channel=release&platform=linux-x86_64" --trust-server-names
+download=$(curl -I "https://www.zotero.org/download/client/dl?channel=release&platform=linux-x86_64" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
+wget "$download" || exit 1
 
 [ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
 cd ..


### PR DESCRIPTION
fix https://github.com/ivan-hc/AM/issues/2500

Firefox builds will use this approach to download the official release:

	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
	CODES=$(curl -Ls https://releases.mozilla.org/pub/firefox/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
		CODE="$LANGUAGE"
	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
	else
		CODE=""
	fi
	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
	wget "$download"

Same thing will happen for Thunderbird builds

	LANGUAGE=$(echo "${LANG%%.*}" | sed -- 's/_/-/g')
	CODES=$(curl -Ls https://releases.mozilla.org/pub/thunderbird/releases/latest/README.txt | tr ' ' '\n' | grep "^lang=")
	if echo "$CODES" | grep -q "^lang=$LANGUAGE"; then
		CODE="$LANGUAGE"
	elif echo "$CODES" | grep -q "^lang=$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"; then
		CODE="$(echo "$LANGUAGE" | tr '-' '\n' | head -1)"
	else
		CODE=""
	fi
	download=$(curl -I "https://download.mozilla.org/?product=$APP-latest&os=linux64&lang=$CODE" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
	wget "$download"

The above approach only uses one online reference, and `curl -I` to detect the correct file name, so that also distributions like Fedora can download it using `curl -LJO`

A change has been added also for Zotero
```
download=$(curl -I "https://www.zotero.org/download/client/dl?channel=release&platform=linux-x86_64" 2>/dev/null | grep -Eoi "http.*xz" | head -1)
wget "$download"
```