### PR TITLE
Add myhondaplus-desktop

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1848,6 +1848,7 @@
 ◆ mybelka : Accounting system written in C++ with QTCore.
 ◆ mycroft-ai : Qt5 Frontend for Mycroft Ai
 ◆ mycrypto : MyCrypto web and electron app.
+◆ myhondaplus-desktop : Unofficial, desktop GUI for Honda Connect Europe (My Honda+) to monitor and control your vehicle.
 ◆ mypaint : Simple drawing and painting program, graphics.
 ◆ mystiq : Qt5/C++ FFmpeg Media Converter.
 ◆ mytonwallet : Feature-rich web wallet and browser extension for TON Network.

--- a/programs/x86_64/myhondaplus-desktop
+++ b/programs/x86_64/myhondaplus-desktop
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.6
+set -u
+APP=myhondaplus-desktop
+SITE="enricobattocchi/myhondaplus-desktop"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/enricobattocchi/myhondaplus-desktop/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+wget "$version" || exit 1
+# Keep this space in sync with other installation scripts
+# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+cd ..
+mv ./tmp/*mage ./"$APP"
+# Keep this space in sync with other installation scripts
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=myhondaplus-desktop
+SITE="enricobattocchi/myhondaplus-desktop"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/enricobattocchi/myhondaplus-desktop/releases/latest | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	# Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract *.desktop 1>/dev/null
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do # Tries to get the actual icon/desktop if it is a symlink to another symlink
+	for f in squashfs-root/*.desktop; do
+		FILE="$f"
+		if [ -L "$f" ]; then
+			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
+			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
+			FILE="./squashfs-root/$LINKPATH"
+		fi
+		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
+		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
+		fi
+	done
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP"-AM.desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+for f in ./*-AM.desktop; do [ "$f" != ./"$APP"-AM.desktop ] && [ -f "$f" ] && [ "$(sort ./"$APP"-AM.desktop)" = "$(sort "$f")" ] && rm -f "$f"; done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop
+mv ./*-AM.desktop /usr/local/share/applications/ && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
Adds **myhondaplus-desktop**, an unofficial desktop GUI for Honda Connect Europe (My Honda+), built with PyQt6 and distributed as an x86_64 AppImage from GitHub Releases.

- Upstream: https://github.com/enricobattocchi/myhondaplus-desktop
- License: GPL-3.0-or-later
- Script generated with `am -t` from the standard AppImage template, only `APP`, `SITE` and the version line filled in.

Tested locally with `am -i` on the generated script: installs to `/opt`, links into `/usr/local/bin`, and the launcher comes out with `Exec=myhondaplus-desktop` and a real 256x256 icon. The installed AppImage checksum matches the published release asset.

The AppImage carries update information (`gh-releases-zsync|enricobattocchi|myhondaplus-desktop|latest|My-Honda-Plus-for-desktop-*-x86_64.AppImage.zsync`) and ships a companion `.zsync` file with every release, so the `appimageupdatetool` path in `AM-updater` does a delta update rather than a full re-download. Measured on a real 2.14.0 to 2.14.1 update: 695 KB fetched out of 79 MB.
