### PR TITLE
Added support for -y

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -16,6 +16,25 @@ ARCH="$(uname -m)"
 [ "$ARCH" = "amd64" ] && ARCH=x86_64
 export ARCH
 
+# Substitute read function (with auto-yes)
+_read() {
+	local prompt="$1"
+	local var_name="$2"
+	local results=""
+	if [[ "$default_yes" == true ]]; then
+		# If variable name is 'yn', default to 'y'
+		if [[ "$var_name" == "yn" ]]; then
+			results="y"
+		# If variable name is 'choice', default to '1'
+		elif [[ "$var_name" == "choice" ]]; then
+			results="1"
+		fi
+	else
+		read -r -ep "$prompt" results
+	fi
+	eval "$var_name='$results'"
+}
+
 # Substitute host dependencies for native shell built-ins
 basename() {
 	[ -n "$1" ] || return 1
@@ -220,7 +239,7 @@ _use_translate() {
 	echo "$DIVIDING_LINE"
 	if [ -z "$2" ]; then
 		printf $"Add a suitable locale code, for example \"it\" for Italian, or use the system language - \"auto\"\n\n" | _fit | grep .
-		read -r -ep $" Leave blank to use \"$CLI\" in English: " amlocale
+		_read $" Leave blank to use \"$CLI\" in English: " amlocale
 		if [ -z "$amlocale" ] || [ "$amlocale" = "en" ]; then
 			iso_code="en"
 			mkdir -p "$DATADIR/AM" && echo "en" > "$DATADIR/AM/locale"
@@ -347,7 +366,7 @@ _appman_check() {
 			echo "$DIVIDING_LINE"
 			echo "$APPMAN_SETUP_MSG" | _fit
 			echo "$DIVIDING_LINE"
-			read -r -ep $" Write the path or just press enter to use default:$(printf "\n\n ")" location
+			_read $" Write the path or just press enter to use default:$(printf "\n\n ")" location
 		else
 			location="$appman_location"
 		fi
@@ -509,9 +528,9 @@ _determine_argpath() {
 			i=$((i + 1))
 		done)" | _fit
 		printf "\n"
-		read -r -p $" Type a number and press ENTER: " response
-		response=$(echo "$argpath_items" | awk '{print $'"$response"'}')
-		argpath="$response"
+		_read " Type a number and press ENTER: " choice
+		choice=$(echo "$argpath_items" | awk '{print $'"$choice"'}')
+		argpath="$choice"
 		[ ! -d "$argpath" ] && printf "\n 💀 ERROR, invalid selection! \n\n" && argpath=""
 	else
 		argpath=$(echo "$ARGPATHS" | grep "/$arg$")
@@ -656,7 +675,7 @@ if [ "$ARCH" = aarch64 ] || [ "$ARCH" = x86_64 ]; then
 				printf "\n"
 			else
 				printf "%b\n%b:\n %b\n%b\n\033[0m\n%b\n\n" "$DIVIDING_LINE" "$missing_cmd_msg_header" "${Green}" "$fallback_binaries_needed" "$missing_cmd_msg_footer" | _fit
-				read -r -p $" Do you wish to continue? (N/y): " yn
+				_read $" Do you wish to continue? (N/y): " yn
 				if echo "$yn" | grep -qi "^y"; then
 					printf "\n"
 					_online_check
@@ -1053,8 +1072,8 @@ if [ "$CLI_PATH" != "/usr/bin/am" ]; then
 		if [ -f "${ZDOTDIR:-$HOME}"/.zshrc ] && echo "$SHELL" | grep -q "zsh"; then
 			if ! grep -q "$completion_file" "${ZDOTDIR:-$HOME}"/.zshrc && [ ! -f "$AMDATADIR"/zsh-completion-off ]; then
 				printf $"Zsh completion requires editing the main configuration file, but it may cause problems.\nSee https://github.com/ivan-hc/AM/issues/1843\n" | _fit
-				read -r -p $"Want to proceed anyway? (y,N)" response
-				if echo "$response" | grep -qi "^y"; then
+				_read $"Want to proceed anyway? (y,N)" yn
+				if echo "$yn" | grep -qi "^y"; then
 					cat <<-HEREDOC >> "${ZDOTDIR:-$HOME}"/.zshrc
 					autoload bashcompinit
 					bashcompinit
@@ -1370,7 +1389,7 @@ _use_appman() {
 	_online_check
 	[ "$CLI" = appman ] && echo $" This function only works for AM" && exit 0
 	printf "%b\n" "$APPMAN_MSG_THINK" | _fit
-	read -r -p $" Do you wish to enter \"AppMan Mode\" (y,N)?" yn
+	_read $" Do you wish to enter \"AppMan Mode\" (y,N)?" yn
 	if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 		echo "$DIVIDING_LINE"
 	else
@@ -1386,7 +1405,7 @@ if [ "$AMCLI" = am ]; then
 		_appman
 		AMCLIPATH="$CLI_PATH"
 	elif [ ! -w "$AMPATH" ]; then
-		read -r -p $" \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
+		_read $" \"AM\" is read-only, want to use it in \"AppMan Mode\" (Y,n)? " yn
 		if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 			exit 0
 		else
@@ -1584,7 +1603,7 @@ _use_clone() {
 		_clone_show_items_msg "$@"
 
 		if echo "$@" | grep -oq -- "install\|-i"; then
-			read -r -p $" Do you want to install the set of programs listed above (y,N)?" yn
+			_read $" Do you want to install the set of programs listed above (y,N)?" yn
 			if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 				echo "$DIVIDING_LINE"
 			else
@@ -1606,7 +1625,7 @@ _use_relocate() {
 	else
 		APPMAN_APPSPATH=$(sort "$APPMANCONFIG/appman-config")
 		printf $"The local path currently in use for programs is as follows:\n\n%b\n\n" "$APPMAN_APPSPATH" | _fit
-		read -r -p $" Do you want to remove and re-install everything to a new location (y,N)?" yn
+		_read $" Do you want to remove and re-install everything to a new location (y,N)?" yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			AMCLIPATH_ORIGIN="$AMCLIPATH"
 			rm -f "$SCRIPTDIR"/am-clone.source
@@ -2190,6 +2209,13 @@ _use_module() {
 	fi
 }
 
+# Parse for global switches and remove them
+if [[ "$1" == -y ]]; then
+	default_yes=true
+    shift
+fi
+
+# Parse main command
 case "$1" in
 	'')
 		echo "$DIVIDING_LINE"

--- a/modules/install.am
+++ b/modules/install.am
@@ -92,7 +92,7 @@ _check_if_spooky_flag_exists() {
 	if grep -i spooky ./"$arg" >/dev/null 2>&1; then
 		printf $" ${RED}WARNING: \"$arg\" does not have a transparent build process! \033[0m\n"
 		printf $"\n We can't be sure as to what is inside the application\n We highly recommend that you sandbox this application\n\n"
-		read -r -p $" Do you wish to continue? (N/y): " yn
+		_read $" Do you wish to continue? (N/y): " yn
 		if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			printf $"\n INSTALLATION ABORTED! \n"
 			return 1
@@ -109,7 +109,7 @@ _check_kind_of_installation_script() {
 	elif grep -q "/usr/local/lib" ./"$arg"; then
 		[ "$arg" = libfuse2 ] && [ -f /usr/local/lib/libfuse.so.2 ] && echo $" 💀 ERROR: \"$arg\" already exists in /usr/local/lib" && return 1
 		printf $"\n ⚠️ This script will install a system library in /usr/local/lib\n\n"
-		read -r -p $" Do you wish to continue? (N/y): " yn
+		_read $" Do you wish to continue? (N/y): " yn
 		if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			printf $"\n INSTALLATION ABORTED! \n"
 			return 1
@@ -540,9 +540,9 @@ _install_3rd_party_app() {
 			fi
 		elif [ -n "$DID_YOU_MEAN" ]; then
 			if [ -n "$DID_YOU_MEAN_FLAG" ]; then
-				read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
+				_read $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
 			else
-				read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+				_read $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
 			fi
 			echo ""
 			if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
@@ -686,7 +686,7 @@ _did_you_mean() {
 
 _select_did_you_mean_candidate() {
 	local choice
-	read -r -p $" Type a number and press ENTER: " choice
+	_read $" Select a number (0 to cancel): " choice
 	echo ""
 	case "$choice" in
 		''|*[!0-9]*) return 1 ;;
@@ -701,7 +701,7 @@ _select_did_you_mean_candidate() {
 _not_an_appimage_message() {
 	if [ -n "$install_appimage" ] && ! grep -q "^◆ $arg : " "$AMDATADIR/$ARCH-appimages"; then
 		printf $" ✖ ERROR: \"%b\" is NOT an AppImage\n" "$arg" && printf "\n"
-		read -r -p $" Do you wish to continue? (N/y): " yn
+		_read $" Do you wish to continue? (N/y): " yn
 		if ! echo "$yn" | grep -qi "^y"; then
 			printf $"\n INSTALLATION ABORTED! \n"
 			echo "____________________________________________________________________________"
@@ -765,12 +765,12 @@ _sandbox_check_aisap() {
 	elif ! command -v aisap 1>/dev/null && ! command -v sas 1>/dev/null; then
 		printf $'\n%s\n' $" ERROR: You need aisap or sas for this script to work"
 		printf $'\n%s\n\n' $" NOTE: Only sas can sandbox DWARFS AppImages"
-		read -r -p $" ◆ DO YOU WISH TO INSTALL SAS? Install size <5 MiB? (Y/n) " yn
+		_read $" ◆ DO YOU WISH TO INSTALL SAS? Install size <5 MiB? (Y/n) " yn
 		case "$yn" in
 			n*|N*) echo $" OPERATION ABORTED!"; return 1;;
 		esac
 		if [ "$CLI" = am ] && [ -f "$APPMANCONFIG"/appman-config ]; then
-			read -r -p $" ◆ DO YOU WISH TO INSTALL SAS LOCALLY? (Y/n) " yn
+			_read $" ◆ DO YOU WISH TO INSTALL SAS LOCALLY? (Y/n) " yn
 			case "$yn" in
 				n*|N*) "$AMCLIPATH_ORIGIN" -i sas >/dev/null 2>&1;;
 				''|*)  "$AMCLIPATH_ORIGIN" -i --user sas >/dev/null 2>&1;;
@@ -902,21 +902,21 @@ _sandbox_generate_sandbox_script() {
 
 _sandbox_configure_dirs_access() {
 	printf '\033[33m\n'
-	read -r -p $" Do you want configure access to directories? (Y/n): " yn
+	_read $" Do you want configure access to directories? (Y/n): " yn
 	if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 		return 0
 	fi
 	printf '\033[36m'
 	for DIR in DESKTOP DOCUMENTS DOWNLOAD GAMES MUSIC PICTURES VIDEOS; do
 		eval XDG_DIR=\$$DIR
-		read -r -p $" Allow $1 access to \"$XDG_DIR\"? (y/N) " yn
+		_read $" Allow $1 access to \"$XDG_DIR\"? (y/N) " yn
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			tmpscript=$(echo "$tmpscript" | sed "s#--rm-file \"\$$DIR\"#--add-file \"\$$DIR\":rw#g" )
 		fi
 	done
 	sleep 0.5
 	printf '\033[31m'
-	read -r -p $" Allow $1 access to a specific directory? (y/N) " yn
+	_read $" Allow $1 access to a specific directory? (y/N) " yn
 	if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 		echo $"  WARNING: Giving access to all of $HOME or / and similar is not safe"
 		echo $"  Also aisap might not let $1 start when such paths are given"
@@ -1224,7 +1224,7 @@ case "$1" in
 		if [ "$2" = "--all" ]; then
 			# Reinstall all applications
 			echo "$DIVIDING_LINE"
-			read -r -p $" Do you wish reinstall everything? (N/y): " yn
+			_read $" Do you wish reinstall everything? (N/y): " yn
 			if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 				printf $"%b\n ABORTED! \n%b\n" "$DIVIDING_LINE" "$DIVIDING_LINE"
 			else
@@ -1312,7 +1312,7 @@ case "$1" in
 									# Compare the installed launcher and the extracted one
 									if [ "$(sort "$LAUNCHERS_PATH"/"$launcher_name")" != "$(sort "$SCRIPTDIR"/AMLAUNCHER_DIR/"$launcher_name")" ]; then
 										printf -- $"- Found differences in %b, it probably needs to be updated.\n" "$launcher_name" | _fit
-										read -r -p $" Do you wish to continue? (N/y): " yn
+										_read $" Do you wish to continue? (N/y): " yn
 										if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 											if echo "$argpath" | grep -q "^/opt\|^/var/opt"; then
 												$SUDOCMD mv "$SCRIPTDIR"/AMLAUNCHER_DIR/"$launcher_name" "$LAUNCHERS_PATH"/"$launcher_name"

--- a/modules/management.am
+++ b/modules/management.am
@@ -12,7 +12,7 @@
 
 _backup_name() {
 	printf $"\n ◆ To set date and time as a name, press ENTER (default)\n ◆ To set the version as a name, press \"1\"\n ◆ To set a custom name, write anything else\n\n"
-	read -r -p $" Write your choice here, or leave blank to use \"date/time\": " response
+	_read $" Write your choice here, or leave blank to use \"date/time\": " response
 	case "$response" in
 		'')
 			backupname=$(date +%F-%X | sed 's/://g' | sed 's/-//g')
@@ -31,7 +31,7 @@ _backup() {
 		if [ ! -f "$argpath"/remove ]; then
 		echo $" \"$2\" is not a valid argument or is not installed."
 	else
-		read -r -p $" Do you wish to backup the current version of $2? (y/N) " yn
+		_read $" Do you wish to backup the current version of $2? (y/N) " yn
 		if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			printf $"\n OPERATION ABORTED!\n\n"
 		else
@@ -89,7 +89,7 @@ _overwrite() {
 	elif [ ! -f "$argpath"/remove ]; then
 		echo $" \"$2\" is not a valid argument or is not installed."
 	else
-		read -r -p $" Do you wish to overwrite $2 with an older version? (y,N) " yn
+		_read $" Do you wish to overwrite $2 with an older version? (y,N) " yn
 		if ! echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			printf $"\n OPERATION ABORTED! \n\n"
 		else
@@ -204,7 +204,7 @@ _downgrade() {
 
 	# Try to avoid multiple snapshots of the same version
 	echo "$DIVIDING_LINE"
-	read -r -p $" Do you want to exclude snapshot versions? (Y,n)" yn
+	_read $" Do you want to exclude snapshot versions? (Y,n)" yn
 	if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 		_downgrade_no_snapshots
 	fi
@@ -261,10 +261,10 @@ _use_unhide() {
 			printf " Detected multiple paths, please choose one:\n\n"
 			echo "1. $APPSPATH/$arg		2. $APPMAN_APPSPATH/$arg" | _fit
 			printf "\n"
-			read -r -p $" Type a number and press ENTER: " response
-			if [ "$response" = 1 ]; then
+			_read " Type a number and press ENTER: " choice
+			if [ "$choice" = 1 ]; then
 				argpath="$APPSPATH/$arg"
-			elif [ "$response" = 2 ]; then
+			elif [ "$choice" = 2 ]; then
 				argpath="$APPMAN_APPSPATH/$arg"
 			fi
 		elif [ -f "$APPSPATH/$arg/remove.old" ]; then
@@ -379,7 +379,7 @@ _launcher_appimage_bin() {
 		echo $"WARNING: \"$BINDIR\" is not in PATH, apps may not run from command line." | _fit
 		echo "$DIVIDING_LINE"
 	fi
-	read -r -p $" Write a custom command to launch the app, or leave blank: " response
+	_read $" Write a custom command to launch the app, or leave blank: " response
 	if [ -z "$response" ]; then
 		appimage_cmd=$(echo "$appimage" | tr '[:upper:]' '[:lower:]')
 		if ! echo "$appimage" | grep -q -i ".appimage"; then
@@ -392,7 +392,7 @@ _launcher_appimage_bin() {
 	elif command -v "$response" 1>/dev/null; then
 		if test -f "$BINDIR"/"$response"; then
 			echo $"WARNING, \"$BINDIR/$response\" already exists!" | _fit
-			read -r -p $" Do you Want to override it? (y,N) " yn
+			_read $" Do you Want to override it? (y,N) " yn
 			if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 				ln -sf "$arg" "$BINDIR"/"$response"
 			else
@@ -438,7 +438,7 @@ _lock() {
 		echo $" \"$AMCLIUPPER\" cannot manage updates for $2, \"AM-updater\" file not found!"
 		return 1
 	fi
-	read -r -p $" Do you wish to keep $2 at its current version? (y/N) " yn
+	_read $" Do you wish to keep $2 at its current version? (y/N) " yn
 	if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 		mv "$argpath"/AM-updater "$argpath"/AM-LOCK 1>/dev/null
 		echo $" $2 has been locked at current version!"
@@ -453,7 +453,7 @@ _unlock() {
 		echo $" \"$2\" cannot be unlocked, \"AM-LOCK\" file not found!"
 		return 1
 	fi
-	read -r -p $" Do you wish to unlock updates for $2? (Y/n) " yn
+	_read $" Do you wish to unlock updates for $2? (Y/n) " yn
 	if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 		echo $" $2 is still locked at current version!"
 		return 1
@@ -528,7 +528,7 @@ _nolibfuse() {
 	fi
 	echo $" Contact the upstream developers to make them officially upgrade!"
 	rm -f ./AM-VERIFIED
-	read -r -p $" Do you wish to remove the old libfuse2 AppImage? (Y/n) " yn
+	_read $" Do you wish to remove the old libfuse2 AppImage? (Y/n) " yn
 	if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 		return 1
 	else
@@ -542,7 +542,7 @@ _nolibfuse() {
 
 _remove() {
 	[ ! -f "$argpath"/remove ] && echo -e $" \"${RED}$arg\033[0m\" is not a valid \"APPNAME\", see \"$AMCLI -f\" for more." && return 1
-	read -r -p $" ◆ Do you wish to remove \"$arg\"? (Y/n) " yn
+	_read $" ◆ Do you wish to remove \"$arg\"? (Y/n) " yn
 	if echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
 		echo -e $" \"${LightBlue}$arg\033[0m\" has not been removed!"
 	else
@@ -641,10 +641,10 @@ case "$1" in
 		_determine_args
 		if [ "$2" = "--all" ]; then
 			entries="$ARGS"
-			read -r -p $" ◆ Do you wish to allow custom icon theming for ALL the apps? (y,N) " yn
+			_read $" ◆ Do you wish to allow custom icon theming for ALL the apps? (y,N) " yn
 		else
 			entries="$(echo "$@" | cut -f2- -d ' ')"
-			read -r -p $" ◆ Do you wish to allow custom icon theming for the selected apps? (y,N) " yn
+			_read $" ◆ Do you wish to allow custom icon theming for the selected apps? (y,N) " yn
 		fi
 		if echo "$yn" | grep -i '^y' >/dev/null 2>&1; then
 			for arg in $entries; do


### PR DESCRIPTION
This is a PR for AM with support for -y. Just add '-y' as the first command, it will auto-choose "Y" for Y/N questions, or an empty string for the others.

Echo will no longer be needed for using am/appman inside scripts, it will behave more closely like existing distro package managers (eg. `apt -y ...`).

Methodology:
1. Updated parsing to check for -y and then use "shift" to remove it.
2. Added a `_read` function to wrap the actual `read` function:
   - Provides a default "Y" if the read variable name is $yn.
   - Provides a default "1" if the read variable name is $choice.
   - Provides a default "" (empty string) if variable name is anything else.
3. Only changed APP-MANAGER, modules/management.am, and modules/install.am.

Example usage:
- To uninstall apps: `am -y -r app`
- Switch to appman: `am -y --user`
- Lock/unlock app: `am -y lock app`
- Translate: `am -y --translate`
- It also works during first run: `am -y` or `appman -y`