### PR TITLE
Update README.md#set-appman-configuration-file-in-a-non-interactive-way

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ or
 ```
 appman_location=/path/to/directory appman
 ```
+
+or if you want to set the default location
+```
+echo "" | appman
+```
+
 NOTE: This only works if the configuration file doesn't exist.
 
 ------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -331,24 +331,31 @@ NOTE: by modifying the contents of `~/.config/appman`, you will only change the 
 
 To change locations, remove local apps, and reinstall in the new location, see the `--relocate` or `relocate` option, [here](docs/guides-and-tutorials/relocate.md).
 
-### Set AppMan configuration file in a non interactive way
+### Set AppMan configuration file in a non-interactive way
 
-If you haven't yet set up the configuration file and want to set the application directory non-interactively, simply add the path to the "$appman_location" variable, like this:
-```
-appman_location=/path/to/directory am -i --user {PROGRAM}
+If you haven't yet set up the configuration file and want to set the application directory non-interactively, simply add the path to the `appman_location` variable using `export`, like this:
+
+```bash
+export appman_location=/path/to/directory am -i --user {PROGRAM}
 
 ```
+
 or
-```
-appman_location=/path/to/directory am --user
+
+```bash
+export appman_location=/path/to/directory am --user
 
 ```
+
 or
-```
-appman_location=/path/to/directory appman
+
+```bash
+export appman_location=/path/to/directory appman
+
 ```
 
-or if you want to set the default location
+or to set the default location
+
 ```
 echo "" | appman
 ```


### PR DESCRIPTION
# `echo "" | appman`
If the default application directory in AppMan changes in a future release (for example, switching from "$HOME/Applications" to "$HOME/AppImages"), existing scripts (e.g, `appman_location="$HOME/Applications"`) will break because they rely on an outdated hardcoded path.

To bypass the interactive prompt and install to the default path automatically, use `echo "" | appman`

# `export`
Updated the documentation examples to include `export` before `appman_location` so that environment variables are correctly passed to child processes for non-interactive execution.

Works:
```
sudo apt-get update && sudo apt-get install -y curl binutils
wget -q https://raw.githubusercontent.com/ivan-hc/AM/main/AM-INSTALLER && chmod a+x ./AM-INSTALLER && ./AM-INSTALLER --install appman && rm ./AM-INSTALLER
source $HOME/.bashrc
export appman_location="$HOME/Applications"
appman
```

Does **not** work without `export`:

```
sudo apt-get update && sudo apt-get install -y curl binutils
wget -q https://raw.githubusercontent.com/ivan-hc/AM/main/AM-INSTALLER && chmod a+x ./AM-INSTALLER && ./AM-INSTALLER --install appman && rm ./AM-INSTALLER
source $HOME/.bashrc
appman_location="$HOME/Applications"
appman
```