### PR TITLE
Substring-match "did you mean" suggestions

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -532,7 +532,13 @@ _install_3rd_party_app() {
 			echo "$FLAGS" | grep -q -- "$tp_list" && active_tp="$tp_list" && break
 		done
 		_did_you_mean "$arg" "$active_tp"
-		if [ -n "$DID_YOU_MEAN" ]; then
+		if [ "${#DID_YOU_MEAN_CANDIDATES[@]}" -gt 0 ]; then
+			if _select_did_you_mean_candidate; then
+				arg="$DID_YOU_MEAN"
+				FLAGS="$FLAGS --$DID_YOU_MEAN_FLAG"
+				_install_3rd_party_app
+			fi
+		elif [ -n "$DID_YOU_MEAN" ]; then
 			if [ -n "$DID_YOU_MEAN_FLAG" ]; then
 				read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
 			else
@@ -597,8 +603,11 @@ _levenshtein() {
 _did_you_mean() {
 	local input="$1" only_flag="$2"
 	local names match="" match_flag="" input_len=${#input} first_char="${input:0:1}" best_dist=3 diff dist
+	local -a sub_names=() sub_flags=()
 	DID_YOU_MEAN=""
 	DID_YOU_MEAN_FLAG=""
+	DID_YOU_MEAN_CANDIDATES=()
+	DID_YOU_MEAN_CANDIDATE_FLAGS=()
 
 	_did_you_mean_search() {
 		local list="$1"
@@ -608,6 +617,15 @@ _did_you_mean() {
 		while IFS= read -r name; do
 			[ -z "$name" ] && continue
 			[ "$name" = "$input" ] && [ -n "$2" ] && best_dist=0 && match=$name && match_flag="$2" && return
+			if [ "$input_len" -ge 4 ]; then
+				case "$name" in
+					*"$input"*)
+						sub_names+=("$name")
+						sub_flags+=("$2")
+						continue
+						;;
+				esac
+			fi
 			diff=$(( ${#name} - input_len ))
 			[ $diff -lt 0 ] && diff=$(( -diff ))
 			[ $diff -gt 2 ] && continue
@@ -630,7 +648,31 @@ _did_you_mean() {
 		done
 	fi
 
-	if [ -n "$match" ]; then
+	if [ "$best_dist" -ne 0 ] && [ "${#sub_names[@]}" -gt 0 ] && [ "${#sub_names[@]}" -le 15 ]; then
+		if [ "${#sub_names[@]}" -eq 1 ]; then
+			match="${sub_names[0]}"
+			match_flag="${sub_flags[0]}"
+			best_dist=1
+		else
+			DID_YOU_MEAN_CANDIDATES=("${sub_names[@]}")
+			DID_YOU_MEAN_CANDIDATE_FLAGS=("${sub_flags[@]}")
+		fi
+	fi
+
+	if [ "${#DID_YOU_MEAN_CANDIDATES[@]}" -gt 0 ]; then
+		printf $"\n Multiple matches found:\n\n"
+		local i=1 flag
+		for match in "${DID_YOU_MEAN_CANDIDATES[@]}"; do
+			flag="${DID_YOU_MEAN_CANDIDATE_FLAGS[$((i-1))]}"
+			if [ -n "$flag" ]; then
+				printf "  %2d) %b%s\033[0m (--%s)\n" "$i" "${LightBlue}" "$match" "$flag"
+			else
+				printf "  %2d) %b%s\033[0m\n" "$i" "${LightBlue}" "$match"
+			fi
+			i=$((i+1))
+		done
+		printf $"   0) None of these\n"
+	elif [ -n "$match" ]; then
 		if [ "$best_dist" -eq 0 ] && [ -n "$match_flag" ]; then
 			printf $"\n \"%b%b\033[0m\" is not in the main database, but found in --%b%b\033[0m.\n" "${LightBlue}" "$match" "${LightBlue}" "$match_flag"
 		else
@@ -639,6 +681,20 @@ _did_you_mean() {
 		DID_YOU_MEAN="$match"
 		DID_YOU_MEAN_FLAG="$match_flag"
 	fi
+}
+
+_select_did_you_mean_candidate() {
+	local choice
+	read -r -p $" Select a number (0 to cancel): " choice
+	echo ""
+	case "$choice" in
+		''|*[!0-9]*) return 1 ;;
+	esac
+	[ "$choice" -eq 0 ] && return 1
+	[ "$choice" -lt 1 ] || [ "$choice" -gt "${#DID_YOU_MEAN_CANDIDATES[@]}" ] && return 1
+	DID_YOU_MEAN="${DID_YOU_MEAN_CANDIDATES[$((choice-1))]}"
+	DID_YOU_MEAN_FLAG="${DID_YOU_MEAN_CANDIDATE_FLAGS[$((choice-1))]}"
+	return 0
 }
 
 _not_an_appimage_message() {
@@ -1048,7 +1104,20 @@ case "$1" in
 			else
 				echo $"💀 ERROR: \"$arg\" does NOT exist in the \"AM\" database, $(printf "please check the list, run the \"%b$AMCLIPATH_ORIGIN -l\033[0m\" command.\n\n" "${Gold}")" | fold -sw 72 | sed 's/^/ /g'
 				_did_you_mean "$arg"
-				if [ -n "$DID_YOU_MEAN" ]; then
+				if [ "${#DID_YOU_MEAN_CANDIDATES[@]}" -gt 0 ]; then
+					if _select_did_you_mean_candidate; then
+						arg="$DID_YOU_MEAN"
+						_not_an_appimage_message || continue
+						if [ -n "$DID_YOU_MEAN_FLAG" ]; then
+							FLAGS="$FLAGS --$DID_YOU_MEAN_FLAG"
+							_prepare_arg
+							_install_3rd_party_app
+						else
+							_prepare_arg
+							_check_and_install
+						fi
+					fi
+				elif [ -n "$DID_YOU_MEAN" ]; then
 					if [ -n "$DID_YOU_MEAN_FLAG" ]; then
 						read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
 					else

--- a/regress/test-am-fuzzy-suggest.sh
+++ b/regress/test-am-fuzzy-suggest.sh
@@ -14,6 +14,7 @@ FAIL=0
 _module="/opt/am/modules/install.am"
 eval "$(awk '/^_levenshtein\(\)/,/^}$/' "$_module")"
 eval "$(awk '/^_did_you_mean\(\)/,/^}$/' "$_module")"
+eval "$(awk '/^_select_did_you_mean_candidate\(\)/,/^}$/' "$_module")"
 
 # Variables required by _did_you_mean
 AMDATADIR="${AMDATADIR:-$HOME/.local/share/AM}"
@@ -321,6 +322,133 @@ EOF
 }
 
 ################################################################################
+# _did_you_mean substring-match tests (names far outside the length-diff /
+# same-first-char heuristics that gate the Levenshtein pass)
+################################################################################
+
+_test_did_you_mean_substring() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' RETURN
+
+	cat > "$tmpdir/${ARCH}-apps" <<'EOF'
+◆ heroic-games-launcher : Native GOG, Epic and Amazon Games client
+◆ hermit : Lightweight Chromium-based site-specific browser
+EOF
+
+	local saved_amdatadir="$AMDATADIR"
+	local saved_tp="$third_party_lists"
+	AMDATADIR="$tmpdir"
+	third_party_lists=""
+
+	printf "\n=== _did_you_mean substring-match tests ===\n"
+	local out
+
+	# Single substring match: "heroic" vs "heroic-games-launcher" is way
+	# outside the len-diff/first-char/edit-distance heuristics, so this only
+	# works via the substring pass.
+	out=$(_did_you_mean "heroic")
+	_assert_contains "heroic → suggests heroic-games-launcher" "$out" "heroic-games-launcher"
+	_assert_contains "heroic → output contains 'Did you mean'" "$out" "Did you mean"
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	_did_you_mean "heroic" > /dev/null
+	_assert_eq "heroic → DID_YOU_MEAN=heroic-games-launcher" "$DID_YOU_MEAN" "heroic-games-launcher"
+	_assert_eq "heroic → no candidate list (single match)" "${#DID_YOU_MEAN_CANDIDATES[@]}" "0"
+
+	# Second substring match added → candidate list instead of a single guess
+	cat >> "$tmpdir/${ARCH}-apps" <<'EOF'
+◆ heroic-games-launcher-cli : CLI variant
+EOF
+	out=$(_did_you_mean "heroic")
+	_assert_contains "heroic (2 matches) → lists heroic-games-launcher" "$out" "heroic-games-launcher"
+	_assert_contains "heroic (2 matches) → lists heroic-games-launcher-cli" "$out" "heroic-games-launcher-cli"
+	_assert_contains "heroic (2 matches) → 'Multiple matches' header" "$out" "Multiple matches"
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	_did_you_mean "heroic" > /dev/null
+	_assert_empty "heroic (2 matches) → DID_YOU_MEAN stays empty" "$DID_YOU_MEAN"
+	_assert_eq "heroic (2 matches) → 2 candidates" "${#DID_YOU_MEAN_CANDIDATES[@]}" "2"
+	_assert_eq "heroic (2 matches) → candidate[0]=heroic-games-launcher" "${DID_YOU_MEAN_CANDIDATES[0]}" "heroic-games-launcher"
+	_assert_eq "heroic (2 matches) → candidate[1]=heroic-games-launcher-cli" "${DID_YOU_MEAN_CANDIDATES[1]}" "heroic-games-launcher-cli"
+
+	# Short input (< 4 chars) must skip the substring pass entirely, or a
+	# single letter would substring-match almost the whole database.
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	out=$(_did_you_mean "her")
+	if echo "$out" | grep -q "Multiple matches"; then
+		_ko "her (3 chars) → substring pass skipped, no flood" "(flooded)" "(skipped)"
+	else
+		_ok "her (3 chars) → substring pass skipped, no flood"
+	fi
+	_did_you_mean "her" > /dev/null
+	_assert_eq "her (3 chars) → no candidate list" "${#DID_YOU_MEAN_CANDIDATES[@]}" "0"
+
+	# Too many substring matches (> 15) is not a useful suggestion — bail to
+	# no suggestion instead of dumping a huge list.
+	rm -f "$tmpdir/${ARCH}-apps"
+	{
+		echo "◆ heroic-games-launcher : Native GOG, Epic and Amazon Games client"
+		for i in $(seq 1 16); do
+			echo "◆ zzflood$i-heroic-app : filler entry $i"
+		done
+	} > "$tmpdir/${ARCH}-apps"
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	out=$(_did_you_mean "heroic")
+	_assert_empty "heroic (>15 substring matches) → no suggestion output" "$out"
+	_did_you_mean "heroic" > /dev/null
+	_assert_empty "heroic (>15 substring matches) → DID_YOU_MEAN empty" "$DID_YOU_MEAN"
+	_assert_eq "heroic (>15 substring matches) → no candidate list" "${#DID_YOU_MEAN_CANDIDATES[@]}" "0"
+
+	AMDATADIR="$saved_amdatadir"
+	third_party_lists="$saved_tp"
+}
+
+################################################################################
+# _select_did_you_mean_candidate unit tests
+################################################################################
+
+_test_select_did_you_mean_candidate() {
+	printf "\n=== _select_did_you_mean_candidate tests ===\n"
+
+	DID_YOU_MEAN_CANDIDATES=("foo-one" "foo-two" "foo-three")
+	DID_YOU_MEAN_CANDIDATE_FLAGS=("" "busybox" "")
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	if _select_did_you_mean_candidate <<< "2"; then
+		_ok "select 2 → returns success"
+	else
+		_ko "select 2 → returns success" "failure" "success"
+	fi
+	_assert_eq "select 2 → DID_YOU_MEAN=foo-two"      "$DID_YOU_MEAN" "foo-two"
+	_assert_eq "select 2 → DID_YOU_MEAN_FLAG=busybox" "$DID_YOU_MEAN_FLAG" "busybox"
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	if _select_did_you_mean_candidate <<< "0"; then
+		_ko "select 0 → cancels" "success" "failure"
+	else
+		_ok "select 0 → cancels"
+	fi
+	_assert_empty "select 0 → DID_YOU_MEAN stays empty" "$DID_YOU_MEAN"
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	if _select_did_you_mean_candidate <<< "99"; then
+		_ko "select out-of-range → rejected" "success" "failure"
+	else
+		_ok "select out-of-range → rejected"
+	fi
+	_assert_empty "select out-of-range → DID_YOU_MEAN stays empty" "$DID_YOU_MEAN"
+
+	DID_YOU_MEAN="" DID_YOU_MEAN_FLAG=""
+	if _select_did_you_mean_candidate <<< "abc"; then
+		_ko "select non-numeric → rejected" "success" "failure"
+	else
+		_ok "select non-numeric → rejected"
+	fi
+	_assert_empty "select non-numeric → DID_YOU_MEAN stays empty" "$DID_YOU_MEAN"
+}
+
+################################################################################
 # Main
 ################################################################################
 
@@ -329,6 +457,8 @@ _log "Running fuzzy-suggest tests: $0"
 _test_levenshtein
 _test_did_you_mean
 _test_did_you_mean_tp
+_test_did_you_mean_substring
+_test_select_did_you_mean_candidate
 
 printf "\n=== Results: \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m ===\n\n" "$PASS" "$FAIL"
 printf "Results: %d passed, %d failed\n" "$PASS" "$FAIL" >> "$test_results"


### PR DESCRIPTION
## Motivation

I wanted to install [Heroic Games Launcher](https://heroicgameslauncher.com) but wasn't sure how it's named in the database.

Tried:

    ❯ appman install heroic
     Did you mean "hermit"?
     Install "hermit" with --soarpkg flag? (Y/n)

    ❯ appman install heroic-launcher
     💀 ERROR: "heroic-launcher" does NOT exist in the "AM" database...

Neither worked, and I was about to open a PR to add the app, assuming it wasn't in the database at all. Eventually found it's already there under `heroic-games-launcher` - just not something the suggestion feature could ever surface.

## Fix

The "did you mean" suggestion now also checks for substring matches, not just close typos. If input matches multiple apps, it shows a numbered list to pick from instead of guessing one. Short or very generic input is ignored to avoid listing half the database.

## Examples

```
❯ appman install heroic
============================================================================

                  START OF ALL INSTALLATION PROCESSES

============================================================================

 💀 ERROR: "heroic" does NOT exist in the "AM" database, please check 
 the list, run the "/home/vp/.local/bin/appman -l" command.

 Did you mean "heroic-games-launcher"?
 Install "heroic-games-launcher" instead? (Y/n)

```


```
❯ appman install google
============================================================================

                  START OF ALL INSTALLATION PROCESSES

============================================================================

 💀 ERROR: "google" does NOT exist in the "AM" database, please check 
 the list, run the "/home/vp/.local/bin/appman -l" command.

 Multiple matches found:

   1) google-chrome
   2) google-chrome-beta
   3) google-chrome-dev
   4) google-docs
   5) google-task-tauri
   6) google-tasks-desktop
   7) ungoogled-chromium
   0) None of these
 Select a number (0 to cancel):
```