### PR TITLE
Add MetaClean installation script

### DIFF
--- a/programs/x86_64-apps
+++ b/programs/x86_64-apps
@@ -1775,6 +1775,7 @@
 ◆ meshlab : Processor and editor of large 3D triangular meshes.
 ◆ meshmill : The world's greatest open source 3D CAM software, maybe one day.
 ◆ meta-grabber : A tool to grab metadata for tv shows and rename files on PC.
+◆ metaclean : Offline desktop app for removing sensitive metadata from files.
 ◆ mgba : Game Boy Advance Emulator.
 ◆ mgba-enhanced : Unofficial, Game Boy Advance Emulator.
 ◆ micropad : µPad is an open digital note taking app.

--- a/programs/x86_64/metaclean
+++ b/programs/x86_64/metaclean
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+# AM INSTALL SCRIPT VERSION 3.6
+set -u
+APP=metaclean
+SITE="Moresyl/metaclean"
+
+# CREATE DIRECTORIES AND ADD REMOVER
+[ -n "$APP" ] && mkdir -p "/opt/$APP/tmp" "/opt/$APP/icons" && cd "/opt/$APP/tmp" || exit 1
+printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../remove
+printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
+chmod a+x ../remove || exit 1
+
+# DOWNLOAD AND PREPARE THE APP, $version is also used for updates
+version=$(curl -Ls https://api.github.com/repos/Moresyl/metaclean/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*MetaClean_.*_amd64.AppImage$" | head -1)
+wget "$version" || exit 1
+cd ..
+mv ./tmp/*mage ./"$APP"
+rm -R -f ./tmp || exit 1
+echo "$version" > ./version
+chmod a+x ./"$APP" || exit 1
+
+# LINK TO PATH
+ln -s "/opt/$APP/$APP" "/usr/local/bin/$APP"
+
+# SCRIPT TO UPDATE THE PROGRAM
+cat >> ./AM-updater << 'EOF'
+#!/bin/sh
+set -u
+APP=metaclean
+SITE="Moresyl/metaclean"
+version0=$(cat "/opt/$APP/version")
+version=$(curl -Ls https://api.github.com/repos/Moresyl/metaclean/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*MetaClean_.*_amd64.AppImage$" | head -1)
+[ -n "$version" ] || { echo "Error getting link"; exit 1; }
+if command -v appimageupdatetool >/dev/null 2>&1; then
+	cd "/opt/$APP" || exit 1
+	appimageupdatetool -Or ./"$APP" && chmod a+x ./"$APP" && echo "$version" > ./version && exit 0
+fi
+if [ "$version" != "$version0" ]; then
+	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1
+	notify-send "A new version of $APP is available, please wait"
+	wget "$version" || exit 1
+	cd ..
+	mv --backup=t ./tmp/*mage ./"$APP"
+	chmod a+x ./"$APP" || exit 1
+	echo "$version" > ./version
+	rm -R -f ./*zs-old ./*.part ./tmp ./*~
+	notify-send "$APP is updated!"
+else
+	echo "Update not needed!"
+fi
+EOF
+chmod a+x ./AM-updater || exit 1
+
+# LAUNCHER & ICON
+./"$APP" --appimage-extract '*.desktop' 1>/dev/null
+./"$APP" --appimage-extract .DirIcon 1>/dev/null && mv ./squashfs-root/.DirIcon ./DirIcon
+COUNT=0
+while [ "$COUNT" -lt 10 ]; do
+	for f in squashfs-root/*.desktop; do
+		FILE="$f"
+		if [ -L "$f" ]; then
+			LINKPATH="$(readlink "$f" | sed 's|^\./||' 2>/dev/null)"
+			./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null
+			FILE="./squashfs-root/$LINKPATH"
+		fi
+		if grep -qi '^NoDisplay=true$' "$FILE" 2>/dev/null; then mv "$FILE" ./"$APP"-handler-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-handler-AM.desktop" >> ./remove
+		else [ ! -f ./"$APP"-AM.desktop ] && mv "$FILE" ./"$APP"-AM.desktop || mv "$FILE" ./"$APP"-"$COUNT"-AM.desktop && printf '\n%s' "rm -f /usr/local/share/applications/$APP-$COUNT-AM.desktop" >> ./remove
+		fi
+	done
+	if [ -L ./DirIcon ]; then
+		LINKPATH="$(readlink ./DirIcon | sed 's|^\./||' 2>/dev/null)"
+		./"$APP" --appimage-extract "$LINKPATH" 1>/dev/null && mv ./squashfs-root/"$LINKPATH" ./DirIcon
+	fi
+	[ ! -L ./"$APP"-AM.desktop ] && [ ! -L ./DirIcon ] && break
+	COUNT=$((COUNT + 1))
+done
+for f in ./*-AM.desktop; do [ "$f" != ./"$APP"-AM.desktop ] && [ -f "$f" ] && [ "$(sort ./"$APP"-AM.desktop)" = "$(sort "$f")" ] && rm -f "$f"; done
+sed -i "s#Exec=[^ ]*#Exec=$APP#g; s#Icon=.*#Icon=/opt/$APP/icons/$APP#g; s# --no-sandbox##g" ./*-AM.desktop
+mv ./*-AM.desktop /usr/local/share/applications/ && mv ./DirIcon ./icons/"$APP" 1>/dev/null
+rm -R -f ./squashfs-root


### PR DESCRIPTION
Adds MetaClean to the x86_64 application catalog using the official amd64 AppImage from GitHub Releases.

Validation:
- resolved the current official release asset and verified SHA-256
- passed `bash -n`
- installed the real AppImage in WSL and verified the executable, symlink, desktop entry, and icon
- verified the no-op updater path and complete removal

Disclosure: I maintain MetaClean.