### PR TITLE
Update the version variable for fdroidcl

### DIFF
--- a/programs/x86_64/fdroidcl
+++ b/programs/x86_64/fdroidcl
@@ -12,7 +12,7 @@ printf "#!/bin/sh\nset -e\nrm -f /usr/local/bin/$APP\nrm -R -f /opt/$APP" > ../r
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/Hoverth/fdroidcl/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/Hoverth/fdroidcl/releases/latest | grep -o 'browser_download_url": "[^"]*linux_amd64[^"]*"' | grep -v '\.gz' | sed 's/.*"\(https[^"]*\)".*/\1/' | head -1)
 wget "$version" || exit 1
 [ -e ./*7z ] && 7z x ./*7z && rm -f ./*7z
 [ -e ./*tar.* ] && tar fx ./*tar.* && rm -f ./*tar.*
@@ -33,7 +33,7 @@ set -u
 APP=fdroidcl
 SITE="Hoverth/fdroidcl"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/Hoverth/fdroidcl/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/Hoverth/fdroidcl/releases/latest | grep -o 'browser_download_url": "[^"]*linux_amd64[^"]*"' | grep -v '\.gz' | sed 's/.*"\(https[^"]*\)".*/\1/' | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if [ "$version" != "$version0" ]; then
 	mkdir "/opt/$APP/tmp" && cd "/opt/$APP/tmp" || exit 1


### PR DESCRIPTION
With the previous string manipulation it was getting the release URL and
then downloading the JSON instad of the asset. Now it looks for the
`browser_download_url` of `linux_amd64` and downloads that.
