### PR TITLE
Fixed bash regex substring matching for --assume-yes + housekeeping

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -646,13 +646,13 @@ if [ "$ARCH" = aarch64 ] || [ "$ARCH" = x86_64 ]; then
 			if [ -d "$CACHEDIR"/AMCACHEPATH/"$name" ] || [ -L "$CACHEDIR"/AMCACHEPATH/"$name" ] || ! head -c 4 "$CACHEDIR"/AMCACHEPATH/"$name" 2>/dev/null | grep -q $'\x7fELF' || [ ! -f "$CACHEDIR"/AMCACHEPATH/"$name" ]; then
 				rm -Rf "$CACHEDIR"/AMCACHEPATH/"$name"
 				case $name in
-  					'column'|'du'|'mv')
-  						if ! "$name" --version 2>/dev/null; then
-  							_collect_fallback_dependencies
-  						fi
-  						;;
-  				esac
-  			fi
+					'column'|'du'|'mv')
+						if ! "$name" --version 2>/dev/null; then
+							_collect_fallback_dependencies
+						fi
+						;;
+				esac
+			fi
 		fi
 	done
 	if [ -n "$fallback_binaries_needed" ] && [ ! -f "$AMDATADIR"/disable-dependencies-prompt ]; then
@@ -702,15 +702,15 @@ if [ "$ARCH" = aarch64 ] || [ "$ARCH" = x86_64 ]; then
 		if command -v "$name" >/dev/null 2>&1; then
 			if uname | grep -q BSD; then
 				case $name in
-  					'column'|'du'|'mv')
-  						if "$name" --version >/dev/null 2>&1; then
-  							rm -Rf "$CACHEDIR"/AMCACHEPATH/"$name"
-  						fi
-  						;;
-  					*)
-  						rm -Rf "$CACHEDIR"/AMCACHEPATH/"$name"
-  						;;
-  				esac
+					'column'|'du'|'mv')
+						if "$name" --version >/dev/null 2>&1; then
+							rm -Rf "$CACHEDIR"/AMCACHEPATH/"$name"
+						fi
+						;;
+					*)
+						rm -Rf "$CACHEDIR"/AMCACHEPATH/"$name"
+						;;
+				esac
 			else
 				if [ -f "$CACHEDIR"/AMCACHEPATH/"$name" ]; then
 					rm -Rf "$CACHEDIR"/AMCACHEPATH/"$name"
@@ -2163,12 +2163,12 @@ _use_update() {
 }
 
 _use_force_latest() {
-  	_online_check
-  	_determine_args
+	_online_check
+	_determine_args
 	ENTRIES="$(echo "$@" | cut -f2- -d ' ')"
-  	for arg in $ENTRIES; do
-	  	_determine_argpath
-	  	if [ ! -d "$argpath" ]; then
+	for arg in $ENTRIES; do
+		_determine_argpath
+		if [ ! -d "$argpath" ]; then
 			echo $" ERROR: \"$arg\" is not installed, see \"-f\""
 		elif [ ! -f "$argpath"/AM-updater ]; then
 			echo $" ERROR: \"$AMCLI\" cannot manage updates for \"$arg\""

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -2214,9 +2214,9 @@ _use_module() {
 }
 
 # Parse for global switches and remove them
-if [[ "$1" =~ (-y|--assume-yes) ]]; then
+if [[ "$1" == "-y" || "$1" == "--assume-yes" ]]; then
 	default_yes=true
-    shift
+	shift
 fi
 
 # Parse main command

--- a/modules/database.am
+++ b/modules/database.am
@@ -186,7 +186,7 @@ _column() {
 }
 
 _column_spaces() {
-	 sed 's/[✖✓🔒]/_&/g' | _column | sed 's/_\([✖✓🔒]\)/ \1/g'
+	sed 's/[✖✓🔒]/_&/g' | _column | sed 's/_\([✖✓🔒]\)/ \1/g'
 }
 
 # HEAD OF THE TABLE

--- a/modules/management.am
+++ b/modules/management.am
@@ -308,9 +308,9 @@ _launcher_handle_launcher() {
 }
 
 _launcher_appimage_integration() {
- 	if grep -Eaoq -m 1 "appimage-extract" "$arg" || file "$arg" | grep -q 'static'; then
- 		rm -Rf AMLAUNCHER_DIR
- 		mkdir -p AMLAUNCHER_DIR && cp -r "$arg" AMLAUNCHER_DIR/AppImage && cd ./AMLAUNCHER_DIR || exit 1
+	if grep -Eaoq -m 1 "appimage-extract" "$arg" || file "$arg" | grep -q 'static'; then
+		rm -Rf AMLAUNCHER_DIR
+		mkdir -p AMLAUNCHER_DIR && cp -r "$arg" AMLAUNCHER_DIR/AppImage && cd ./AMLAUNCHER_DIR || exit 1
 		exec 3< <(./AppImage --appimage-mount)
 		read -r MOUNT_POINT <&3
 		APP_PID=$!

--- a/modules/template.am
+++ b/modules/template.am
@@ -468,7 +468,7 @@ for arg in $ARGS; do
 				echo "$DIVIDING_LINE"
 				read -r -p " Set a binary name or leave blank if it is \"$arg\": " binaryname
 				if [ -n "$binaryname" ]; then
-					 sed -i "s/\* \"\$APP\" /\* $binaryname /g" ./am-scripts/"$MAIN_ARCH"/"$arg"
+					sed -i "s/\* \"\$APP\" /\* $binaryname /g" ./am-scripts/"$MAIN_ARCH"/"$arg"
 				fi
 			fi
 			# END OF THIS FUNCTION


### PR DESCRIPTION
Two fixes:
1. Fixed bash regex substring matching for `--assume-yes`:
  - **Problem**: Old code triggers even if we half type assume-yes (eg. `am --assume-y -f`), and does not show "ERROR: unknown option". This is because Bash regex =~ does substring matching by default (it does not require the whole string to match unless you use anchors).
  - **Old code**: `if [[ "$1" =~ (-y|--assume-yes) ]]`
  - **Fixed code**: `if [[ "$1" == "-y" || "$1" == "--assume-yes" ]]`

2. Some housekeeping work to remove empty spaces where tabs are supposed to be.

