### PR TITLE
Added support for aborting AM commands that are incompatible with -y

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -28,6 +28,12 @@ _read() {
 		# If variable name is 'choice', default to '1'
 		elif [[ "$var_name" == "choice" ]]; then
 			results="1"
+		# If variable name is 'yn_abort', default to 'n' to abort the AM command
+		elif [[ "$var_name" == "yn_abort" ]]; then
+			results="n"
+		# If variable name is 'choice_abort', default to '0' to abort the AM command
+		elif [[ "$var_name" == "choice_abort" ]]; then
+			results="0"
 		fi
 	else
 		read -r -ep "$prompt" results

--- a/modules/install.am
+++ b/modules/install.am
@@ -540,9 +540,9 @@ _install_3rd_party_app() {
 			fi
 		elif [ -n "$DID_YOU_MEAN" ]; then
 			if [ -n "$DID_YOU_MEAN_FLAG" ]; then
-				read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
+				_read $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn_abort
 			else
-				read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+				_read $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn_abort
 			fi
 			echo ""
 			if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
@@ -686,7 +686,7 @@ _did_you_mean() {
 
 _select_did_you_mean_candidate() {
 	local choice
-	read -r -p $" Type a number and press ENTER: " choice
+	_read $" Type a number and press ENTER: " choice_abort
 	echo ""
 	case "$choice" in
 		''|*[!0-9]*) return 1 ;;
@@ -1148,9 +1148,9 @@ case "$1" in
 					fi
 				elif [ -n "$DID_YOU_MEAN" ]; then
 					if [ -n "$DID_YOU_MEAN_FLAG" ]; then
-						read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
+						_read $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn_abort
 					else
-						read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
+						_read $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn_abort
 					fi
 					echo ""
 					if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then

--- a/modules/install.am
+++ b/modules/install.am
@@ -545,7 +545,7 @@ _install_3rd_party_app() {
 				_read $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn_abort
 			fi
 			echo ""
-			if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+			if ! echo "$yn_abort" | grep -i '^n' >/dev/null 2>&1; then
 				arg="$DID_YOU_MEAN"
 				FLAGS="$FLAGS --$DID_YOU_MEAN_FLAG"
 				_install_3rd_party_app
@@ -685,16 +685,16 @@ _did_you_mean() {
 }
 
 _select_did_you_mean_candidate() {
-	local choice
+	local choice_abort
 	_read $" Type a number and press ENTER: " choice_abort
 	echo ""
-	case "$choice" in
+	case "$choice_abort" in
 		''|*[!0-9]*) return 1 ;;
 	esac
-	[ "$choice" -eq 0 ] && return 1
-	[ "$choice" -lt 1 ] || [ "$choice" -gt "${#DID_YOU_MEAN_CANDIDATES[@]}" ] && return 1
-	DID_YOU_MEAN="${DID_YOU_MEAN_CANDIDATES[$((choice-1))]}"
-	DID_YOU_MEAN_FLAG="${DID_YOU_MEAN_CANDIDATE_FLAGS[$((choice-1))]}"
+	[ "$choice_abort" -eq 0 ] && return 1
+	[ "$choice_abort" -lt 1 ] || [ "$choice_abort" -gt "${#DID_YOU_MEAN_CANDIDATES[@]}" ] && return 1
+	DID_YOU_MEAN="${DID_YOU_MEAN_CANDIDATES[$((choice_abort-1))]}"
+	DID_YOU_MEAN_FLAG="${DID_YOU_MEAN_CANDIDATE_FLAGS[$((choice_abort-1))]}"
 	return 0
 }
 
@@ -1153,7 +1153,7 @@ case "$1" in
 						_read $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn_abort
 					fi
 					echo ""
-					if ! echo "$yn" | grep -i '^n' >/dev/null 2>&1; then
+					if ! echo "$yn_abort" | grep -i '^n' >/dev/null 2>&1; then
 						arg="$DID_YOU_MEAN"
 						_not_an_appimage_message || continue
 						if [ -n "$DID_YOU_MEAN_FLAG" ]; then


### PR DESCRIPTION
Three read operations remain from making AM a fully non-interactive user experience with -y in install.am:
1. read -r -p $" Install \"$DID_YOU_MEAN\" with --$DID_YOU_MEAN_FLAG flag? (Y/n) " yn
2. read -r -p $" Install \"$DID_YOU_MEAN\" instead? (Y/n) " yn
3. read -r -p $" Type a number and press ENTER: " choice

Methodology:
1. If the read variable is is named yn_abort or choice_abort, the _read wrapper function will auto select "N" or "0" instead. This will force AM to abort the command.
2. Simple modifications to _read:
```
....
# If variable name is 'yn_abort', default to 'n' to abort the AM command
elif [[ "$var_name" == "yn_abort" ]]; then
	results="n"
# If variable name is 'choice_abort', default to '0' to abort the AM command
elif [[ "$var_name" == "choice_abort" ]]; then
	results="0"
....
```

To test, try to install an app that doesnt exist to trigger fuzzy matching: `am -y -i fccp`
```
 💀 ERROR: "fccp" does NOT exist in the "AM" database, please check
 the list, run the "am -l" command.

 Did you mean "fcp"?
```

AM will not stop and prompt, instead it will just abort and return the user to the CLI.

This behavior matches with how `apt-get -y` works when commands should not receieve a "Y".

All regression tests are fully passing.