### PR TITLE
Updated version information for Enth-Auth

### DIFF
--- a/programs/x86_64/ente-auth
+++ b/programs/x86_64/ente-auth
@@ -12,7 +12,7 @@ printf '\n%s' "rm -f /usr/local/share/applications/$APP-AM.desktop" >> ../remove
 chmod a+x ../remove || exit 1
 
 # DOWNLOAD AND PREPARE THE APP, $version is also used for updates
-version=$(curl -Ls https://api.github.com/repos/ente-io/ente/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ente-io/ente/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*/auth.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 wget "$version" || exit 1
 # Keep this space in sync with other installation scripts
 # Use tar fx ./*tar* here for example in this line in case a compressed file is downloaded.
@@ -33,7 +33,7 @@ set -u
 APP=ente-auth
 SITE="ente-io/ente"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/ente-io/ente/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep "ente-auth" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ente-io/ente/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*/auth.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1

--- a/programs/x86_64/ente-auth
+++ b/programs/x86_64/ente-auth
@@ -33,7 +33,7 @@ set -u
 APP=ente-auth
 SITE="ente-io/ente"
 version0=$(cat "/opt/$APP/version")
-version=$(curl -Ls https://api.github.com/repos/ente-io/ente/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
+version=$(curl -Ls https://api.github.com/repos/ente-io/ente/releases | sed 's/[()",{} ]/\n/g' | grep -oi "https.*mage$" | grep "ente-auth" | grep -vi "i386\|i686\|aarch64\|arm64\|armv7l" | head -1)
 [ -n "$version" ] || { echo "Error getting link"; exit 1; }
 if command -v appimageupdatetool >/dev/null 2>&1; then
 	cd "/opt/$APP" || exit 1


### PR DESCRIPTION
- gets Ente-Auth link, and not whatever the latest app in Ente's repo is, at https://github.com/ente/ente/releases