### PR TITLE
New feature: am -a will now list the latest available version for an app

### DIFF
--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -2237,7 +2237,7 @@ case "$1" in
 		exit 0
 		;;
 	# EXTERNAL OPTIONS / MODULES
-	'about'|'-a'|\
+	'about'|'-a'|'-av'|\
 	'files'|'-f'|'-fi'|\
 	'list'|'-l'|\
 	'query'|'-q'|'search')

--- a/modules/database.am
+++ b/modules/database.am
@@ -154,7 +154,7 @@ _about() {
 			echo ""
 			echo $" Disk usage: $disk_usage MB"
 			echo $" Installed version: $app_version"
-		else
+		elif [ $online_version_check == 1 ]; then
 			# Else, grep version+curl variable from install script, eval it to get the download URL, then extract version number from it
 			arg_script=$(_use_online_reading_tool "$APPSDB/$arg" 2>/dev/null)
 			eval $(echo "$arg_script" | grep "version=" | head -n 1 ) 2>/dev/null
@@ -850,7 +850,7 @@ _find_no_order() {
 ################################################################################
 
 case "$1" in
-	'-a'|'about')
+	'-a'|'-av'|'about')
 		[ -z "$2" ] && echo $" USAGE: $AMCLI $1 [ARGUMENT]" && exit 1
 		_online_check
 		_completion_lists
@@ -860,6 +860,7 @@ case "$1" in
 		echo "$DIVIDING_LINE"
 		rm -f "$AMCACHEDIR"/version-args && _check_version
 		entries="$(echo "$@" | cut -f2- -d ' ')" # Removes first argument
+		online_version_check=$( [ "$1" = "-av" ] && echo 1 || echo 0 )
 		for arg in $entries; do
 			_about "$arg"
 			echo "$DIVIDING_LINE"

--- a/modules/database.am
+++ b/modules/database.am
@@ -147,12 +147,19 @@ _about() {
 		printf " PACKAGE: %b%b\033[0m\n" "${Green}" "$arg"
 		_about_status
 		if echo "$app_status" | grep -q "^installed"; then
+			# If installed, print disk usage and app version
 			disk_usage=$(du -sm "$argpath" 2>/dev/null | cut -f1)
 			[ -z "$disk_usage" ] && disk_usage=$(du -sm "$metaargpath" | cut -f1)
 			app_version=$(grep -w " ◆ $appname	|" "$AMCACHEDIR"/version-args 2>/dev/null | sed 's:.*|	::' | sed 's/\([✖✓🔒]\)/ \1/g')
 			echo ""
 			echo $" Disk usage: $disk_usage MB"
 			echo $" Installed version: $app_version"
+		else
+			# Else, grep version+curl variable from install script, eval it to get the download URL, then extract version number from it
+			arg_script=$(_use_online_reading_tool "$APPSDB/$arg" 2>/dev/null)
+			eval $(echo "$arg_script" | grep "version=" | head -n 1 ) 2>/dev/null
+			version=$(echo $version | _check_version_filters)
+			printf $" VERSION: %b\n" "$version"
 		fi
 		_about_description
 	else


### PR DESCRIPTION
New feature: am -a will now list the latest available version for any app that is not yet installed. Fixes #1832.

Example: `am -a firefox`
```
 PACKAGE: firefox
 STATUS: not installed
 VERSION: 154.0

 Firefox is a powerful, extensible web browser with support for modern web application technologies.

 This is the Stable release.

 This script provides both the official portable build with automatic updates and the AppImage.

 SCREENSHOTS:
 https://user-images.githubusercontent.com/88724353/235563850-61d359ff-53ac-43a6-ab1d-33297dc4df73.jpg

 SITES:
 https://www.firefox.com

 SOURCES:
 https://github.com/ivan-hc/Firefox-appimage
```
