### PR TITLE
Removed android-messages-desktop from obsolete-apps list

### DIFF
--- a/programs/obsolete-apps
+++ b/programs/obsolete-apps
@@ -17,7 +17,6 @@ altitude 2024
 alvr 2022
 amusiz 2021
 anavis 2022
-android-messages-desktop 2019
 animos 2023
 aniship 2023
 ant-downloader 2019


### PR DESCRIPTION
This can be removed since my last [pull request](https://github.com/ivan-hc/AM/pull/2672) transitioned the install script to the newer fork by OrangeDrangon.