### PR TITLE
did-you-mean: match app names case-insensitively

### DIFF
--- a/modules/install.am
+++ b/modules/install.am
@@ -612,7 +612,7 @@ _levenshtein() {
 }
 
 _did_you_mean() {
-	local input="$1" only_flag="$2"
+	local input="${1,,}" only_flag="$2"
 	local names match="" match_flag="" input_len=${#input} first_char="${input:0:1}" best_dist=3 diff dist
 	local -a sub_names=() sub_flags=()
 	DID_YOU_MEAN=""
@@ -621,17 +621,18 @@ _did_you_mean() {
 	DID_YOU_MEAN_CANDIDATE_FLAGS=()
 
 	_did_you_mean_search() {
-		local list="$1"
+		local list="$1" name_orig
 		[ ! -f "$list" ] && return
 		[ "$best_dist" -eq 0 ] && return
 		names=$(grep "^◆ " "$list" | sed 's/^◆ //;s/ :.*$//')
-		while IFS= read -r name; do
-			[ -z "$name" ] && continue
-			[ "$name" = "$input" ] && [ -n "$2" ] && best_dist=0 && match=$name && match_flag="$2" && return
+		while IFS= read -r name_orig; do
+			[ -z "$name_orig" ] && continue
+			local name="${name_orig,,}"
+			[ "$name" = "$input" ] && [ -n "$2" ] && best_dist=0 && match=$name_orig && match_flag="$2" && return
 			if [ "$input_len" -ge 4 ]; then
 				case "$name" in
 					*"$input"*)
-						sub_names+=("$name")
+						sub_names+=("$name_orig")
 						sub_flags+=("$2")
 						continue
 						;;
@@ -644,7 +645,7 @@ _did_you_mean() {
 			dist=$(_levenshtein "$input" "$name")
 			if [ "$dist" -lt "$best_dist" ]; then
 				best_dist=$dist
-				match=$name
+				match=$name_orig
 				match_flag="$2"
 			fi
 		done <<< "$names"

--- a/regress/test-am-fuzzy-suggest.sh
+++ b/regress/test-am-fuzzy-suggest.sh
@@ -402,6 +402,56 @@ EOF
 }
 
 ################################################################################
+# _did_you_mean case-insensitivity tests
+################################################################################
+
+_test_did_you_mean_case_insensitive() {
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' RETURN
+
+	cat > "$tmpdir/${ARCH}-apps" <<'EOF'
+◆ sayonara : music player
+◆ heroic-games-launcher : Native GOG, Epic and Amazon Games client
+EOF
+
+	local saved_amdatadir="$AMDATADIR"
+	local saved_tp="$third_party_lists"
+	AMDATADIR="$tmpdir"
+	third_party_lists=""
+
+	printf "\n=== _did_you_mean case-insensitivity tests ===\n"
+	local out
+
+	# Exact match, differing only by case → dist 0, no candidate list.
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	out=$(_did_you_mean "Sayonara")
+	_assert_contains "Sayonara → suggests sayonara" "$out" "sayonara"
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	_did_you_mean "Sayonara" > /dev/null
+	_assert_eq "Sayonara → DID_YOU_MEAN=sayonara" "$DID_YOU_MEAN" "sayonara"
+	_assert_eq "Sayonara → no candidate list" "${#DID_YOU_MEAN_CANDIDATES[@]}" "0"
+
+	# All-uppercase input, same exact-match behavior.
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	_did_you_mean "SAYONARA" > /dev/null
+	_assert_eq "SAYONARA → DID_YOU_MEAN=sayonara" "$DID_YOU_MEAN" "sayonara"
+
+	# Substring match, differing only by case (input len >= 4).
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	_did_you_mean "HEROIC" > /dev/null
+	_assert_eq "HEROIC → DID_YOU_MEAN=heroic-games-launcher" "$DID_YOU_MEAN" "heroic-games-launcher"
+
+	# Mixed-case substring, match found via the substring pass.
+	DID_YOU_MEAN="" DID_YOU_MEAN_CANDIDATES=()
+	_did_you_mean "HeRoIc" > /dev/null
+	_assert_eq "HeRoIc → DID_YOU_MEAN=heroic-games-launcher" "$DID_YOU_MEAN" "heroic-games-launcher"
+
+	AMDATADIR="$saved_amdatadir"
+	third_party_lists="$saved_tp"
+}
+
+################################################################################
 # _select_did_you_mean_candidate unit tests
 ################################################################################
 
@@ -455,6 +505,7 @@ _test_levenshtein
 _test_did_you_mean
 _test_did_you_mean_tp
 _test_did_you_mean_substring
+_test_did_you_mean_case_insensitive
 _test_select_did_you_mean_candidate
 
 printf "\n=== Results: \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m ===\n\n" "$PASS" "$FAIL"


### PR DESCRIPTION
`appman install Sayonara` failed even though "sayonara" exists because the lookup compared case exactly. Users (me🙂) don't expect app-name search to care about case.

```
❯ appman install Sayonara
============================================================================

                  START OF ALL INSTALLATION PROCESSES

============================================================================

 💀 ERROR: "Sayonara" does NOT exist in the "AM" database, please check 
 the list, run the "/home/vp/.local/bin/appman -l" command.
____________________________________________________________________________
============================================================================

                  END OF ALL INSTALLATION PROCESSES

============================================================================
```

"Did you mean" suggestions now ignore letter case. Typing `Sayonara` now matches `sayonara` in the database, same for substring matches like `HEROIC` - `heroic-games-launcher`.
