### PR TITLE
Build AM as a portable, self-contained AppImage (quick-sharun + uruntime)

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,10 +22,12 @@ jobs:
           - arch: x86_64
             runs-on: ubuntu-latest
             image: ghcr.io/pkgforge-dev/archlinux:x86_64
+            platform: linux/amd64
             qemu: false
           - arch: aarch64
             runs-on: ubuntu-24.04-arm
             image: ghcr.io/pkgforge-dev/archlinux:aarch64
+            platform: linux/arm64
             qemu: false
           # The build tools (appimagetool, sharun, mkdwarfs) are
           # architecture-specific and must run on the target architecture,
@@ -35,18 +37,22 @@ jobs:
           - arch: riscv64
             runs-on: ubuntu-latest
             image: ghcr.io/pkgforge-dev/archlinux:riscv64
+            platform: linux/riscv64
             qemu: true
           - arch: loongarch64
             runs-on: ubuntu-latest
             image: ghcr.io/pkgforge-dev/archlinux:loongarch64
+            platform: linux/loong64
             qemu: true
           - arch: ppc64le
             runs-on: ubuntu-latest
             image: ghcr.io/pkgforge-dev/archlinux:ppc64le
+            platform: linux/ppc64le
             qemu: true
           - arch: powerpc64
             runs-on: ubuntu-latest
             image: ghcr.io/pkgforge-dev/archlinux:powerpc64
+            platform: linux/ppc64
             qemu: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -57,6 +63,7 @@ jobs:
         if: ${{ !matrix.qemu || github.event_name != 'pull_request' }}
         run: |
           docker run --rm \
+            --platform ${{ matrix.platform }} \
             -v "$PWD:/build" -w /build \
             -e GITHUB_REPOSITORY="${{ github.repository }}" \
             ${{ matrix.image }} \

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -49,11 +49,8 @@ jobs:
             image: ghcr.io/pkgforge-dev/archlinux:ppc64le
             platform: linux/ppc64le
             qemu: true
-          - arch: powerpc64
-            runs-on: ubuntu-latest
-            image: ghcr.io/pkgforge-dev/archlinux:powerpc64
-            platform: linux/ppc64
-            qemu: true
+          # NOTE: big-endian `powerpc64` is not included - tonistiigi/binfmt
+          # does not register a qemu-ppc64 handler, so it cannot be emulated.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Register QEMU binfmt

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -29,28 +29,32 @@ jobs:
             image: ghcr.io/pkgforge-dev/archlinux:aarch64
             platform: linux/arm64
             qemu: false
-          # The build tools (appimagetool, sharun, mkdwarfs) are
-          # architecture-specific and must run on the target architecture,
-          # so the remaining arches are built inside their Arch Linux
-          # container images, emulated with QEMU on an x86_64 runner.
-          # The QEMU builds are skipped on pull requests to keep PR CI fast.
-          - arch: riscv64
-            runs-on: ubuntu-latest
-            image: ghcr.io/pkgforge-dev/archlinux:riscv64
-            platform: linux/riscv64
-            qemu: true
-          - arch: loongarch64
-            runs-on: ubuntu-latest
-            image: ghcr.io/pkgforge-dev/archlinux:loongarch64
-            platform: linux/loong64
-            qemu: true
-          - arch: ppc64le
-            runs-on: ubuntu-latest
-            image: ghcr.io/pkgforge-dev/archlinux:ppc64le
-            platform: linux/ppc64le
-            qemu: true
-          # NOTE: big-endian `powerpc64` is not included - tonistiigi/binfmt
+          # The remaining arches are built inside their Arch Linux container
+          # images, emulated with QEMU on an x86_64 runner (the build tools -
+          # appimagetool, sharun, mkdwarfs - must run on the target arch).
+          #
+          # DISABLED for now: AM's database does not ship installation
+          # scripts for these architectures yet (see the `programs/`
+          # directory). Uncomment the entries below to enable them again
+          # once app repos for those architectures are introduced.
+          # - arch: riscv64
+          #   runs-on: ubuntu-latest
+          #   image: ghcr.io/pkgforge-dev/archlinux:riscv64
+          #   platform: linux/riscv64
+          #   qemu: true
+          # - arch: loongarch64
+          #   runs-on: ubuntu-latest
+          #   image: ghcr.io/pkgforge-dev/archlinux:loongarch64
+          #   platform: linux/loong64
+          #   qemu: true
+          # - arch: ppc64le
+          #   runs-on: ubuntu-latest
+          #   image: ghcr.io/pkgforge-dev/archlinux:ppc64le
+          #   platform: linux/ppc64le
+          #   qemu: true
+          # NOTE: big-endian `powerpc64` is not supported - tonistiigi/binfmt
           # does not register a qemu-ppc64 handler, so it cannot be emulated.
+          # QEMU builds are skipped on pull requests to keep PR CI fast.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Register QEMU binfmt

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -3,8 +3,8 @@ concurrency:
   group: appimage-${{ github.ref }}
   cancel-in-progress: true
 on:
-  schedule:
-    - cron: "0 5 1/3 * *" # Rebuild every 3 days to track changes in this repository
+  release:
+    types: [published]
   workflow_dispatch: {}
   pull_request:
     paths:
@@ -77,7 +77,10 @@ jobs:
           path: dist
 
   release:
-    if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
+    # Triggered by a manually published GitHub release (ivan-hc pushes a new
+    # version, writing the release notes himself): build from that tag and
+    # attach the AppImages to that very release.
+    if: ${{ github.event_name == 'release' }}
     needs: [build]
     permissions: write-all
     runs-on: ubuntu-latest
@@ -86,5 +89,10 @@ jobs:
         with:
           pattern: AppImage-*
           merge-multiple: true
-      - name: Release AppImage
-        uses: pkgforge-dev/make-stable-appimage-release@4ed3d48ccb065352b6e6c0db6d39885b201c54a0 #v1.1
+      - name: Attach AppImages to the release
+        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            *.AppImage
+            *.AppImage.zsync

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,54 @@
+name: AppImage
+concurrency:
+  group: appimage-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  schedule:
+    - cron: "0 5 1/3 * *" # Rebuild every 3 days to track changes in this repository
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "APP-MANAGER"
+      - "appimage/**"
+
+jobs:
+  build:
+    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            name: Build AppImage
+            arch: x86_64
+          # comment out these 3 lines if aarch64 is not wanted
+          - runs-on: ubuntu-24.04-arm
+            name: Build AppImage
+            arch: aarch64
+    container: ghcr.io/pkgforge-dev/archlinux:latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Preparing Container
+        uses: pkgforge-dev/anylinux-setup-action@0964f2258d6c93d1391359978dde081fd8b3c6af # v2
+      - name: Install Dependencies
+        run: /bin/sh ./appimage/get-dependencies.sh
+      - name: Make AppImage
+        run: /bin/sh ./appimage/make-appimage.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: AppImage-${{ matrix.arch }}
+          path: dist
+
+  release:
+    if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request' }}
+    needs: [build]
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: AppImage-*
+          merge-multiple: true
+      - name: Release AppImage
+        uses: pkgforge-dev/make-stable-appimage-release@4ed3d48ccb065352b6e6c0db6d39885b201c54a0 #v1.1

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -15,7 +15,6 @@ jobs:
   build:
     name: "Build AppImage (${{ matrix.arch }})"
     runs-on: ${{ matrix.runs-on }}
-    if: ${{ !matrix.qemu || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +31,7 @@ jobs:
           # architecture-specific and must run on the target architecture,
           # so the remaining arches are built inside their Arch Linux
           # container images, emulated with QEMU on an x86_64 runner.
+          # The QEMU builds are skipped on pull requests to keep PR CI fast.
           - arch: riscv64
             runs-on: ubuntu-latest
             image: ghcr.io/pkgforge-dev/archlinux:riscv64
@@ -51,9 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Register QEMU binfmt
-        if: matrix.qemu
+        if: ${{ matrix.qemu && github.event_name != 'pull_request' }}
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
       - name: Build AppImage
+        if: ${{ !matrix.qemu || github.event_name != 'pull_request' }}
         run: |
           docker run --rm \
             -v "$PWD:/build" -w /build \
@@ -61,6 +62,7 @@ jobs:
             ${{ matrix.image }} \
             /bin/sh -c "sh appimage/get-dependencies.sh && sh appimage/make-appimage.sh"
       - name: Upload artifact
+        if: ${{ !matrix.qemu || github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: AppImage-${{ matrix.arch }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -13,27 +13,53 @@ on:
 
 jobs:
   build:
-    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    name: "Build AppImage (${{ matrix.arch }})"
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ !matrix.qemu || github.event_name != 'pull_request' }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-latest
-            name: Build AppImage
-            arch: x86_64
-          # comment out these 3 lines if aarch64 is not wanted
-          - runs-on: ubuntu-24.04-arm
-            name: Build AppImage
-            arch: aarch64
-    container: ghcr.io/pkgforge-dev/archlinux:latest
+          - arch: x86_64
+            runs-on: ubuntu-latest
+            image: ghcr.io/pkgforge-dev/archlinux:x86_64
+            qemu: false
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+            image: ghcr.io/pkgforge-dev/archlinux:aarch64
+            qemu: false
+          # The build tools (appimagetool, sharun, mkdwarfs) are
+          # architecture-specific and must run on the target architecture,
+          # so the remaining arches are built inside their Arch Linux
+          # container images, emulated with QEMU on an x86_64 runner.
+          - arch: riscv64
+            runs-on: ubuntu-latest
+            image: ghcr.io/pkgforge-dev/archlinux:riscv64
+            qemu: true
+          - arch: loongarch64
+            runs-on: ubuntu-latest
+            image: ghcr.io/pkgforge-dev/archlinux:loongarch64
+            qemu: true
+          - arch: ppc64le
+            runs-on: ubuntu-latest
+            image: ghcr.io/pkgforge-dev/archlinux:ppc64le
+            qemu: true
+          - arch: powerpc64
+            runs-on: ubuntu-latest
+            image: ghcr.io/pkgforge-dev/archlinux:powerpc64
+            qemu: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Preparing Container
-        uses: pkgforge-dev/anylinux-setup-action@0964f2258d6c93d1391359978dde081fd8b3c6af # v2
-      - name: Install Dependencies
-        run: /bin/sh ./appimage/get-dependencies.sh
-      - name: Make AppImage
-        run: /bin/sh ./appimage/make-appimage.sh
+      - name: Register QEMU binfmt
+        if: matrix.qemu
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+      - name: Build AppImage
+        run: |
+          docker run --rm \
+            -v "$PWD:/build" -w /build \
+            -e GITHUB_REPOSITORY="${{ github.repository }}" \
+            ${{ matrix.image }} \
+            /bin/sh -c "sh appimage/get-dependencies.sh && sh appimage/make-appimage.sh"
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# AppImage build artifacts (produced by .github/workflows/appimage.yml)
+AppDir/
+dist/
+_test-app/

--- a/AM-INSTALLER
+++ b/AM-INSTALLER
@@ -71,9 +71,7 @@ _install_am() {
 	URL="https://raw.githubusercontent.com/ivan-hc/AM/$AM_BRANCH/INSTALL"
 	SCRIPT="$CACHEDIR/INSTALL-AM.sh"
 	mkdir -p "$CACHEDIR" || true
-	rm -f "$CACHEDIR"/INSTALL-AM.sh || true
-	_script_downloader && chmod a+x "$CACHEDIR"/INSTALL-AM.sh
-	#cp ./INSTALL "$CACHEDIR"/INSTALL-AM.sh && chmod a+x "$CACHEDIR"/INSTALL-AM.sh # for developers
+	rm -f "$CACHEDIR"/INSTALL-AM.sh "$CACHEDIR"/INSTALL-AM-APPIMAGE.sh || true
 	if command -v sudo >/dev/null 2>&1; then
 		SUDOCMD="sudo"
 	elif command -v doas >/dev/null 2>&1; then
@@ -82,7 +80,13 @@ _install_am() {
 		echo "ERROR: No sudo or doas found"
 		exit 1
 	fi
-	$SUDOCMD "$CACHEDIR"/INSTALL-AM.sh && rm -f "$CACHEDIR"/INSTALL-AM.sh
+	if [ -n "$APPIMAGE" ]; then
+		cp -f "$APPDIR"/INSTALL-AM-APPIMAGE.sh "$CACHEDIR"/INSTALL-AM-APPIMAGE.sh && chmod a+x "$CACHEDIR"/INSTALL-AM-APPIMAGE.sh
+		$SUDOCMD "$CACHEDIR"/INSTALL-AM-APPIMAGE.sh "$APPIMAGE" && rm -f "$CACHEDIR"/INSTALL-AM-APPIMAGE.sh
+	else
+		_script_downloader && chmod a+x "$CACHEDIR"/INSTALL-AM.sh
+		$SUDOCMD "$CACHEDIR"/INSTALL-AM.sh && rm -f "$CACHEDIR"/INSTALL-AM.sh
+	fi
 }
 
 # INSTALL "AM" LOCALLY, AS "APPMAN"
@@ -109,13 +113,17 @@ _install_appman() {
 	SCRIPT="$BINDIR/appman"
 	echo '--------------------------------------------------------------------------'
 	printf " %bInstalling \"AppMan\" in %b\033[0m\n" "${Green}" "$BINDIR"
-	_script_downloader && chmod a+x "$BINDIR"/appman
-	echo '--------------------------------------------------------------------------'
-	printf " %bThe following modules will be installed gradually, as you use AppMan\033[0m\n" "${Green}"
-	MODULES=$(sort "$SCRIPT" | tr '"' '\n' | grep "[a-z]\.am$")
-	for module_name in $MODULES; do
-		echo " ◆ https://raw.githubusercontent.com/ivan-hc/AM/$AM_BRANCH/modules/$module_name"
-	done
+	if [ -n "$APPIMAGE" ]; then
+		\mv -f "$APPIMAGE" "$SCRIPT"
+	else
+		_script_downloader && chmod a+x "$BINDIR"/appman
+		echo '--------------------------------------------------------------------------'
+		printf " %bThe following modules will be installed gradually, as you use AppMan\033[0m\n" "${Green}"
+		MODULES=$(sort "$SCRIPT" | tr '"' '\n' | grep "[a-z]\.am$")
+		for module_name in $MODULES; do
+			echo " ◆ https://raw.githubusercontent.com/ivan-hc/AM/$AM_BRANCH/modules/$module_name"
+		done
+	fi
 	echo '--------------------------------------------------------------------------'
 	printf " %b\"AppMan\" has been successfully installed! \033[0m\n\n" "${Green}"
 	printf " To use 'appman' in your current terminal, please run\n" "${LightBlue}"

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -1857,6 +1857,23 @@ _sync_modules() {
 }
 
 _sync_amcli() {
+	if [ -n "$APPIMAGE" ]; then
+		echo "$DIVIDING_LINE"
+		printf "\n %b is running as an AppImage, its script is part of a read-only squashfs\n and cannot be replaced in place.\n\n" "$AMCLIUPPER"
+		PATH="$PATH:$BINDIR"
+		if command -v appimageupdatetool >/dev/null 2>&1 && [ -w "$APPIMAGE" ]; then
+			printf " Checking for a new AppImage release...\n\n"
+			if appimageupdatetool -Or "$APPIMAGE" >/dev/null 2>&1; then
+				printf " %b has been updated, restart it to use the new version.\n\n" "${APPIMAGE##*/}"
+			else
+				printf " No update available (or update failed), %b is already up to date.\n\n" "${APPIMAGE##*/}"
+			fi
+		else
+			printf " Install 'appimageupdatetool' to update this AppImage from the terminal,\n or download the latest release from the GitHub repository.\n\n"
+		fi
+		echo "$DIVIDING_LINE"
+		return 0
+	fi
 	echo "$DIVIDING_LINE"
 	CURRENT_AM_VERSION="$AMVERSION"
 	echo -ne $"\n ◆ SYNCHRONIZING \"$AMCLIUPPER\" VERSION \"$CURRENT_AM_VERSION\"...\r" && sleep 0.25

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -2406,6 +2406,8 @@ case "$1" in
 	'devmode-disable'|'devmode-enable'|'--devmode-disable'|'--devmode-enable')
 		if [ "$CLI_PATH" = "/usr/bin/am" ]; then
 			echo $"This feature is disabled by your organization" | _fit
+		elif [ -n "$APPIMAGE" ]; then
+			echo $"This feature is not available for the AppImage build of \"$AMCLIUPPER\"" | _fit
 		else
 			if [ "$1" = "--devmode-disable" ]; then
 				rm -f "$AMDATADIR"/betatester

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -9,11 +9,22 @@ AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
 export REALDIR="$PWD"
 
 # Detect the AppImage runtime: when running from inside an AppImage the
-# environment exports $APPIMAGE (the AppImage file) and $APPDIR. Use that to
-# decide whether this copy acts as "am" or "appman": the CLI name follows the
-# name of the AppImage file itself (see INSTALL and AM-INSTALLER, which
-# install the AppImage as "APP-MANAGER" for "am", or as "appman" for AppMan).
-IS_APPIMAGE=$([[ -n "$APPIMAGE" && -f "$APPIMAGE" ]] && [[ -n "$APPDIR" && -d "$APPDIR" && -f "$APPDIR/AppRun" ]] && echo 1) || unset IS_APPIMAGE
+# environment exports $APPIMAGE (the AppImage file) and $APPDIR. Both are
+# also exported by *other* AppImages that may run this script from inside
+# them (e.g. an "am-gui" AppImage calling "appman"), so additionally check
+# that this very script is the "appman" bundled inside its own AppImage
+# ($APPDIR/bin/appman). Use that to decide whether this copy acts as "am"
+# or "appman": the CLI name follows the name of the AppImage file itself
+# (see INSTALL and AM-INSTALLER, which install the AppImage as "APP-MANAGER"
+# for "am", or as "appman" for AppMan).
+IS_APPIMAGE=
+if [ -n "$APPIMAGE" ] && [ -f "$APPIMAGE" ] \
+	&& [ -n "$APPDIR" ] && [ -d "$APPDIR" ] \
+	&& [ "$(readlink -f "$0")" = "$APPDIR/bin/appman" ]; then
+	IS_APPIMAGE=1
+else
+	unset IS_APPIMAGE
+fi
 
 if [ -n "$IS_APPIMAGE" ]; then
 	DIR="$(cd "${APPIMAGE%/*}" && echo "$PWD")"
@@ -1871,7 +1882,7 @@ _sync_modules() {
 }
 
 _sync_amcli() {
-	if [ -n "$APPIMAGE" ]; then
+	if [ -n "$IS_APPIMAGE" ]; then
 		echo "$DIVIDING_LINE"
 		printf "\n %b is running as an AppImage, its script is part of a read-only squashfs\n and cannot be replaced in place.\n\n" "$AMCLIUPPER"
 		PATH="$PATH:$BINDIR"
@@ -2420,7 +2431,7 @@ case "$1" in
 	'devmode-disable'|'devmode-enable'|'--devmode-disable'|'--devmode-enable')
 		if [ "$CLI_PATH" = "/usr/bin/am" ]; then
 			echo $"This feature is disabled by your organization" | _fit
-		elif [ -n "$APPIMAGE" ]; then
+		elif [ -n "$IS_APPIMAGE" ]; then
 			echo $"This feature is not available for the AppImage build of \"$AMCLIUPPER\"" | _fit
 		else
 			if [ "$1" = "--devmode-disable" ]; then

--- a/APP-MANAGER
+++ b/APP-MANAGER
@@ -7,9 +7,23 @@ AMREPO="https://raw.githubusercontent.com/ivan-hc/AM/main"
 
 # Determine the name of this script and its working directory
 export REALDIR="$PWD"
-DIR="$(cd "${0%/*}" && echo "$PWD")"
-CLI="${0##*/}"
-CLI_PATH="$(readlink -f "$0")"
+
+# Detect the AppImage runtime: when running from inside an AppImage the
+# environment exports $APPIMAGE (the AppImage file) and $APPDIR. Use that to
+# decide whether this copy acts as "am" or "appman": the CLI name follows the
+# name of the AppImage file itself (see INSTALL and AM-INSTALLER, which
+# install the AppImage as "APP-MANAGER" for "am", or as "appman" for AppMan).
+IS_APPIMAGE=$([[ -n "$APPIMAGE" && -f "$APPIMAGE" ]] && [[ -n "$APPDIR" && -d "$APPDIR" && -f "$APPDIR/AppRun" ]] && echo 1) || unset IS_APPIMAGE
+
+if [ -n "$IS_APPIMAGE" ]; then
+	DIR="$(cd "${APPIMAGE%/*}" && echo "$PWD")"
+	CLI_PATH="$(readlink -f "$APPIMAGE")"
+	CLI=$([ "${CLI_PATH##*/}" = "APP-MANAGER" ] && echo "am" || echo "appman")
+else
+	DIR="$(cd "${0%/*}" && echo "$PWD")"
+	CLI="${0##*/}"
+	CLI_PATH="$(readlink -f "$0")"
+fi
 
 # Determine system architecture and current user
 ARCH="$(uname -m)"

--- a/INSTALL
+++ b/INSTALL
@@ -11,6 +11,12 @@ RED='\033[0;31m'; LightBlue='\033[1;34m'; Green='\033[0;32m'
 # For developers
 [ -z "$AM_BRANCH" ] && AM_BRANCH="main"
 
+# Determine if this is the AppImage installation flow. AM-INSTALLER copies this
+# script into the AppImage as "INSTALL-AM-APPIMAGE.sh" and runs it with the
+# AppImage file path as "$1": we then install the AppImage itself, not the
+# plain script, as "am".
+[ "${0##*/}" = "INSTALL-AM-APPIMAGE.sh" ] && APPIMAGE="$1" || unset APPIMAGE
+
 # Function to check online connections (uses github.com by default, as the database and CLI itself are stored/hosted there)
 _online_check_tool() {
 	if command -v wget >/dev/null 2>&1; then
@@ -61,7 +67,7 @@ fi
 # INSTALL "AM"
 _prepare_am_directory() {
 	# CREATE AND ENTER THE MAIN DIRECTORY FOR "AM"
-	mkdir -p /opt/am/modules /usr/local/bin && cd /opt/am || exit 1
+	mkdir -p /opt/am /usr/local/bin && cd /opt/am || exit 1
 
 	# CREATE THE SCRIPT NEEDED TO UNINSTALL "AM"
 	printf '#!/bin/sh\n\nset -e\n' > /opt/am/remove
@@ -70,15 +76,19 @@ _prepare_am_directory() {
 	printf '%s\n' 'rm -R -f /opt/am' >> /opt/am/remove
 	chmod a+x /opt/am/remove || exit 1
 
-	# DOWNLOAD THE MAIN SCRIPT
+	# DOWNLOAD THE MAIN SCRIPT, OR MOVE THE APPIMAGE INTO /OPT/AM
 	URL="https://raw.githubusercontent.com/ivan-hc/AM/$AM_BRANCH/APP-MANAGER"
 	SCRIPT="APP-MANAGER"
-	if ! _script_downloader; then
-		echo "💀 ERROR: Cannot download am"
-		exit 1
+	if [ -n "$APPIMAGE" ]; then
+		\mv -f "$APPIMAGE" "$SCRIPT"
+	else
+		if ! _script_downloader; then
+			echo "💀 ERROR: Cannot download am"
+			exit 1
+		fi
 	fi
 	chmod a+x /opt/am/APP-MANAGER
-	MODULES=$(sort /opt/am/APP-MANAGER | tr '"' '\n' | grep "[a-z]\.am$")
+	[ -n "$APPIMAGE" ] || MODULES=$(sort /opt/am/APP-MANAGER | tr '"' '\n' | grep "[a-z]\.am$")
 	# LINK THE MAIN SCRIPT IN $PATH
 	if uname -a | grep -qi "Linux deck \|Linux steamdeck "; then
 		[ -d "/home/${SUDO_USER:-$DOAS_USER}" ] && BINDIR="/home/${SUDO_USER:-$DOAS_USER}/.local/bin" || BINDIR=""
@@ -89,8 +99,9 @@ _prepare_am_directory() {
 }
 
 _download_am_modules() {
+	[ -n "$APPIMAGE" ] && return 0
 	# DOWNLOAD MODULES
-	cd /opt/am/modules || exit
+	mkdir -p /opt/am/modules && cd /opt/am/modules || exit
 	if [ -z "$MODULES" ]; then
 		echo "💀 ERROR: Cannot download am modules"
 		exit 1
@@ -104,17 +115,18 @@ _download_am_modules() {
 		fi
 	done
 	cd ..
-
-	# ENABLE NON-ROOT PERMISSIONS TO THE MAIN DIRECTORY FOR THE CURRENT USER
-	chown -R "${SUDO_USER:-$DOAS_USER}" /opt/am
 }
 
 echo '--------------------------------------------------------------------------'
 printf " %bInstalling \"AM\" in /opt/am\033[0m\n" "${Green}"
 _prepare_am_directory
-echo '--------------------------------------------------------------------------'
-printf " %bInstalling modules\033[0m\n" "${Green}"
-_download_am_modules
+if [ -z "$APPIMAGE" ]; then
+	echo '--------------------------------------------------------------------------'
+	printf " %bInstalling modules\033[0m\n" "${Green}"
+	_download_am_modules
+fi
+# ENABLE NON-ROOT PERMISSIONS TO THE MAIN DIRECTORY FOR THE CURRENT USER
+chown -R "${SUDO_USER:-$DOAS_USER}" /opt/am
 echo '--------------------------------------------------------------------------'
 printf " %b\"AM\" has been successfully installed! \033[0m\n\n" "${Green}"
 printf " Please, run \"%bam -h\033[0m\" to see the list of the options.\n" "${LightBlue}"

--- a/README.md
+++ b/README.md
@@ -1133,7 +1133,8 @@ The build files live in the `appimage/` directory:
 It is built for the following architectures, each inside its own Arch Linux container image ([pkgforge-dev/docker-archlinux](https://github.com/pkgforge-dev/docker-archlinux)):
 
 - `x86_64` and `aarch64` run on native GitHub Actions runners
-- `riscv64`, `loongarch64`, `ppc64le` and `powerpc64` are built inside their respective Arch Linux ports, emulated with QEMU on an x86_64 runner
+
+`riscv64`, `loongarch64` and `ppc64le` are also supported by the build (their Arch Linux ports are emulated with QEMU on an x86_64 runner), but they are **disabled** for now because AM's database does not ship installation scripts for those architectures yet (see the `programs/` directory). Uncomment the entries in [.github/workflows/appimage.yml](.github/workflows/appimage.yml) to enable them once app repos for those architectures are introduced.
 
 > NOTE: AM's database currently ships installation scripts for `x86_64`, `aarch64`, `i686` and `armv7l` only (see the `programs/` directory). On the other architectures the AppImage still fully works for the core options (`-h`, `-s`, `-u`, managing AppImages installed locally with `-ia`/`-e`, third-party databases, ...), but the main database has no entries for those architectures yet.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ You can use the command `am -a {PROGRAM}` to view the description and get the so
 
 [Regression Testing (for developers)](regress)
 
+[Build "AM" as an AppImage (for developers)](#build-am-as-an-appimage-for-developers)
+
 [Instructions for Linux Distro Maintainers](#instructions-for-linux-distro-maintainers)
 
 [Troubleshooting](#troubleshooting)
@@ -1107,7 +1109,42 @@ Below you can access the documentation pages related to the use of "AM", complet
 | [Back to "Main Index"](#main-index) |
 | - |
 
-------------------------------------------------------------------------
+-----------------------------------------------------------------------
+
+# Build "AM" as an AppImage (for developers)
+
+Since version 10.x, a GitHub Actions workflow in this repository builds a portable, self-contained **AppImage** of "AM" that runs as a local-user `appman` (no root needed), in addition to the classic script-based installations described above.
+
+The AppImage is built with [quick-sharun](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/quick-sharun.sh) on an Arch Linux container:
+
+- it runs the "[APP-MANAGER](APP-MANAGER)" script directly in "AppMan"/portable mode, so no installation is required: `./AM-*.AppImage -h`
+- the tools that AM may call but that are missing on some distros (`curl`, `wget`, `7z`, `tar`, `unzip`, `xz`, `file`, checksums, ...) are bundled together with their libraries and glibc, making the AppImage fully self-contained
+- it does not require FUSE (thanks to the [uruntime](https://github.com/VHSgunzo/uruntime))
+- it is self-updating: the AppImage updates itself in place from the GitHub releases, and running `appman -s` from inside it triggers that update too
+- double-clicking it opens a terminal with the help screen; `AM-*.AppImage setup` runs the installer to install AM system-wide or AppMan locally
+
+The build files live in the `appimage/` directory:
+
+- [appimage/make-appimage.sh](appimage/make-appimage.sh) - the build script (fetch deps, bundle, package and test)
+- [appimage/get-dependencies.sh](appimage/get-dependencies.sh) - installs the container build dependencies
+- [appimage/hooks/](appimage/hooks/) - AppImage runtime hooks
+- [appimage/APP-MANAGER.desktop](appimage/APP-MANAGER.desktop) - the desktop entry used by the AppImage
+
+To build it locally (requires a GNU/Linux system with `bash`, `wget`/`curl` and `git`):
+
+```
+# 1. install quick-sharun
+wget -q https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh
+install -m755 quick-sharun.sh /usr/local/bin/quick-sharun
+# 2. run the build from the repository root
+./appimage/make-appimage.sh
+```
+
+The resulting `AM-*.AppImage` and its `.zsync` file are written to the `dist/` directory.
+
+> NOTE: The GitHub Actions workflow ([.github/workflows/appimage.yml](.github/workflows/appimage.yml)) rebuilds the AppImage every 3 days and publishes it as a GitHub release, so users can always get an up-to-date single file.
+
+-----------------------------------------------------------------------
 # Instructions for Linux Distro Maintainers
 **Glossary**:
 - System `am` (`/usr/bin/am`)

--- a/README.md
+++ b/README.md
@@ -1130,6 +1130,13 @@ The build files live in the `appimage/` directory:
 - [appimage/hooks/](appimage/hooks/) - AppImage runtime hooks
 - [appimage/APP-MANAGER.desktop](appimage/APP-MANAGER.desktop) - the desktop entry used by the AppImage
 
+It is built for the following architectures, each inside its own Arch Linux container image ([pkgforge-dev/docker-archlinux](https://github.com/pkgforge-dev/docker-archlinux)):
+
+- `x86_64` and `aarch64` run on native GitHub Actions runners
+- `riscv64`, `loongarch64`, `ppc64le` and `powerpc64` are built inside their respective Arch Linux ports, emulated with QEMU on an x86_64 runner
+
+> NOTE: AM's database currently ships installation scripts for `x86_64`, `aarch64`, `i686` and `armv7l` only (see the `programs/` directory). On the other architectures the AppImage still fully works for the core options (`-h`, `-s`, `-u`, managing AppImages installed locally with `-ia`/`-e`, third-party databases, ...), but the main database has no entries for those architectures yet.
+
 To build it locally (requires a GNU/Linux system with `bash`, `wget`/`curl` and `git`):
 
 ```

--- a/README.md
+++ b/README.md
@@ -1119,9 +1119,10 @@ The AppImage is built with [quick-sharun](https://github.com/pkgforge-dev/Anylin
 
 - it runs the "[APP-MANAGER](APP-MANAGER)" script directly in "AppMan"/portable mode, so no installation is required: `./AM-*.AppImage -h`
 - the tools that AM may call but that are missing on some distros (`curl`, `wget`, `7z`, `tar`, `unzip`, `xz`, `file`, checksums, ...) are bundled together with their libraries and glibc, making the AppImage fully self-contained
+- [appimageupdatetool](https://github.com/pkgforge-dev/AppImageUpdate) (static binary) is bundled too, so the AppImage can update itself in place
 - it does not require FUSE (thanks to the [uruntime](https://github.com/VHSgunzo/uruntime))
 - it is self-updating: the AppImage updates itself in place from the GitHub releases, and running `appman -s` from inside it triggers that update too
-- double-clicking it opens a terminal with the help screen; `AM-*.AppImage setup` runs the installer to install AM system-wide or AppMan locally
+- double-clicking it (when "am" or "appman" is not installed yet) opens a terminal with the embedded installer, so you can install this very AppImage as "am" system-wide or as "appman" locally; if already installed it opens a terminal with its help screen instead. `AM-*.AppImage setup` always runs that installer.
 
 The build files live in the `appimage/` directory:
 
@@ -1150,7 +1151,7 @@ install -m755 quick-sharun.sh /usr/local/bin/quick-sharun
 
 The resulting `AM-*.AppImage` and its `.zsync` file are written to the `dist/` directory.
 
-> NOTE: The GitHub Actions workflow ([.github/workflows/appimage.yml](.github/workflows/appimage.yml)) rebuilds the AppImage every 3 days and publishes it as a GitHub release, so users can always get an up-to-date single file.
+> NOTE: The GitHub Actions workflow ([.github/workflows/appimage.yml](.github/workflows/appimage.yml)) is triggered when a new version-tagged GitHub release is published, and attaches the freshly built `AM-*.AppImage` files to that very release. This way the AppImage always ships all the bugfixes of the corresponding version of the script.
 
 -----------------------------------------------------------------------
 # Instructions for Linux Distro Maintainers

--- a/appimage/APP-MANAGER.desktop
+++ b/appimage/APP-MANAGER.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=AM
+GenericName=AppImage Package Manager
+Comment=AppImage Package Manager: install, update and manage AppImages and portable apps (portable AppMan)
+Exec=appman
+Icon=logo
+Type=Application
+Categories=System;PackageManager;Utility;
+Keywords=package;manager;appimage;appman;am;terminal;
+StartupNotify=false
+Terminal=true

--- a/appimage/APP-MANAGER.desktop
+++ b/appimage/APP-MANAGER.desktop
@@ -8,4 +8,4 @@ Type=Application
 Categories=System;PackageManager;Utility;
 Keywords=package;manager;appimage;appman;am;terminal;
 StartupNotify=false
-Terminal=true
+Terminal=false

--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -33,7 +33,10 @@ pacman -S --noconfirm --needed \
 # Optional packages may not exist on every architecture port. If they are
 # missing here, quick-sharun (see make-appimage.sh) warns and skips them,
 # and AM falls back to its built-in mechanism for those commands.
-pacman -S --noconfirm --needed 7zip file \
+# xorg-server-xvfb is only used by quick-sharun's strace mode to provide a
+# virtual display (our CLI tools do not need one, so it is just a warning
+# if unavailable).
+pacman -S --noconfirm --needed 7zip file xorg-server-xvfb \
 	|| echo "  WARNING: some optional packages are not available on $ARCH"
 
 echo "Installing quick-sharun..."

--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -4,39 +4,42 @@ set -eu
 
 ARCH=$(uname -m)
 
+echo "Initializing the build container..."
+echo "---------------------------------------------------------------"
+pacman-key --init
+pacman -Syy --noconfirm archlinux-keyring
+pacman -Syu --noconfirm
+
 echo "Installing package dependencies..."
 echo "---------------------------------------------------------------"
 # "AM" is a shell script, so no GUI/mesa/etc libraries need to be bundled
 # into the AppImage. We install the tools that AM may call (and that are
 # missing on some distros) so that quick-sharun can bundle them - together
-# with their libraries and glibc - into the AppImage. This makes the
-# resulting AppImage fully self-contained.
+# with their libraries and glibc - into the AppImage.
+#
+# The required set is present on every architecture (Arch Linux ports).
 pacman -S --noconfirm --needed \
 	base-devel \
 	ca-certificates \
 	curl \
-	file \
 	git \
 	jq \
+	patchelf \
 	tar \
 	unzip \
 	wget \
-	xz \
-	7zip
+	xz
 
-# If you ever need to bundle extra libraries from the (debloated) Arch
-# packages, uncomment the line below. It is NOT needed for this app.
-#get-debloated-pkgs --add-common --prefer-nano
+# Optional packages may not exist on every architecture port. If they are
+# missing here, quick-sharun (see make-appimage.sh) warns and skips them,
+# and AM falls back to its built-in mechanism for those commands.
+pacman -S --noconfirm --needed 7zip file \
+	|| echo "  WARNING: some optional packages are not available on $ARCH"
 
-# Comment this out if you need an AUR package
-#make-aur-package PACKAGENAME
+echo "Installing quick-sharun..."
+echo "---------------------------------------------------------------"
+wget -q -O /usr/local/bin/quick-sharun \
+	https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh
+chmod a+x /usr/local/bin/quick-sharun
 
-# If the application needs to be manually built that has to be done down here
-
-# if you also have to make nightly releases check for DEVEL_RELEASE = 1
-#
-# if [ "${DEVEL_RELEASE-}" = 1 ]; then
-# 	nightly build steps
-# else
-# 	regular build steps
-# fi
+echo "CONTAINER IS READY!"

--- a/appimage/get-dependencies.sh
+++ b/appimage/get-dependencies.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -eu
+
+ARCH=$(uname -m)
+
+echo "Installing package dependencies..."
+echo "---------------------------------------------------------------"
+# "AM" is a shell script, so no GUI/mesa/etc libraries need to be bundled
+# into the AppImage. We install the tools that AM may call (and that are
+# missing on some distros) so that quick-sharun can bundle them - together
+# with their libraries and glibc - into the AppImage. This makes the
+# resulting AppImage fully self-contained.
+pacman -S --noconfirm --needed \
+	base-devel \
+	ca-certificates \
+	curl \
+	file \
+	git \
+	jq \
+	tar \
+	unzip \
+	wget \
+	xz \
+	7zip
+
+# If you ever need to bundle extra libraries from the (debloated) Arch
+# packages, uncomment the line below. It is NOT needed for this app.
+#get-debloated-pkgs --add-common --prefer-nano
+
+# Comment this out if you need an AUR package
+#make-aur-package PACKAGENAME
+
+# If the application needs to be manually built that has to be done down here
+
+# if you also have to make nightly releases check for DEVEL_RELEASE = 1
+#
+# if [ "${DEVEL_RELEASE-}" = 1 ]; then
+# 	nightly build steps
+# else
+# 	regular build steps
+# fi

--- a/appimage/hooks/05-am-appimage-env.hook
+++ b/appimage/hooks/05-am-appimage-env.hook
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Runs BEFORE 10-self-updater.hook (hooks are sourced in lexical order of
+# $APPDIR/bin/*.hook), so these exports are visible to the self-updater.
+
+# This AppImage bundles its own 'appman' into $PATH. Without this the
+# self-updater hook would always find an "appman" and skip update checks for
+# "other" AppImage managers - i.e. for itself. We want the built-in
+# self-updater to be active, so disable that manager-detection.
+export DO_NOT_CHECK_FOR_OTHER_APPIMAGE_MANAGERS=1
+
+# Keep AM/AppMan cache and config in their standard locations (like a
+# normally installed AppMan) instead of the AppImage-Cache directory.
+export USE_HOST_XDG_CACHE_HOME=1

--- a/appimage/hooks/90-am-appimage-interface.hook
+++ b/appimage/hooks/90-am-appimage-interface.hook
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Runs AFTER 10-self-updater.hook (the update check has already started).
+# Provides the GUI entry points of this terminal application:
+#   * double-click (no arguments, no terminal) -> open a terminal with the
+#     help screen, otherwise nothing would be visible
+#   * `setup` / `--install`                    -> run the embedded upstream
+#     installer to install AM (system-wide) or AppMan (local)
+# Every other invocation returns to the default AppRun behaviour: run the
+# bundled 'appman' with the given arguments.
+
+APP="$APPDIR/bin/appman"
+
+# Double-clicked from a file manager: no arguments and no terminal.
+if [ -z "$1" ] && [ ! -t 1 ]; then
+	TERM_BIN=""
+	for t in ${TERMINAL:-} x-terminal-emulator kgx konsole gnome-terminal \
+		xfce4-terminal mate-terminal lxterminal terminator kitty alacritty \
+		wezterm urxvt xterm; do
+		[ -n "$t" ] || continue
+		if command -v "$t" >/dev/null 2>&1; then
+			TERM_BIN="$t"
+			break
+		fi
+	done
+	if [ -n "$TERM_BIN" ]; then
+		case "$TERM_BIN" in
+			gnome-terminal|kgx)
+				exec "$TERM_BIN" -- "$APP" -h
+				;;
+			*)
+				exec "$TERM_BIN" -e "$APP" -h
+				;;
+		esac
+	fi
+	>&2 echo "AM is a terminal program, please run it from a terminal."
+	exit 1
+fi
+
+# One-click installer: install AM (system-wide) or AppMan (local) using the
+# embedded upstream installer script.
+case "$1" in
+	setup|--install|install-am)
+		exec "$APPDIR/AM-INSTALLER"
+		;;
+esac

--- a/appimage/hooks/90-am-appimage-interface.hook
+++ b/appimage/hooks/90-am-appimage-interface.hook
@@ -75,23 +75,27 @@ _find_terminal() {
 }
 
 # Launch a command in the found terminal, using the right flag per terminal.
+# The whole command is wrapped in `sh -c` so that flags like `-h` are NOT
+# parsed by the terminal itself (e.g. `ptyxis -x app -h` would make ptyxis
+# print its own help and exit without showing anything). The window is kept
+# open until ENTER is pressed so the output stays visible.
 _run_in_terminal() {
+	_script="'$APP' -h; printf '\\n\\n'; echo 'Press ENTER to close this window...'; read _"
 	TERM_NAME=${TERM_BIN%% *}
 	case "$TERM_NAME" in
 		xdg-terminal-exec)
-			exec xdg-terminal-exec "$@"
+			exec xdg-terminal-exec sh -c "$_script"
 			;;
 		gnome-terminal|kgx)
 			# shellcheck disable=SC2086
-			exec $TERM_BIN -- "$@"
+			exec $TERM_BIN -- sh -c "$_script"
 			;;
 		ptyxis)
-			# shellcheck disable=SC2086
-			exec $TERM_BIN -x "$@"
+			exec $TERM_BIN -x "sh -c \"$_script\""
 			;;
 		*)
 			# shellcheck disable=SC2086
-			exec $TERM_BIN -e "$@"
+			exec $TERM_BIN -e sh -c "$_script"
 			;;
 	esac
 }

--- a/appimage/hooks/90-am-appimage-interface.hook
+++ b/appimage/hooks/90-am-appimage-interface.hook
@@ -10,27 +10,96 @@
 
 APP="$APPDIR/bin/appman"
 
-# Double-clicked from a file manager: no arguments and no terminal.
-if [ -z "$1" ] && [ ! -t 1 ]; then
-	TERM_BIN=""
-	for t in ${TERMINAL:-} x-terminal-emulator kgx konsole gnome-terminal \
-		xfce4-terminal mate-terminal lxterminal terminator kitty alacritty \
-		wezterm urxvt xterm; do
-		[ -n "$t" ] || continue
-		if command -v "$t" >/dev/null 2>&1; then
-			TERM_BIN="$t"
-			break
+# Find the user's terminal, in order of preference:
+#   $TERMINAL  ->  x-terminal-emulator (Debian alternatives)
+#   ->  xdg-terminal-exec (freedesktop draft spec)
+#   ->  the desktop environment's configured default (GNOME/MATE/Cinnamon,
+#       KDE, XFCE)  ->  a fallback list of common terminals.
+# Sets TERM_BIN (may contain arguments, see $TERMINAL) or returns 1.
+_find_terminal() {
+	# 1. explicit user preference
+	if [ -n "$TERMINAL" ]; then
+		if command -v "${TERMINAL%% *}" >/dev/null 2>&1; then
+			TERM_BIN="$TERMINAL"
+			return 0
+		fi
+	fi
+	# 2. Debian alternatives system
+	if command -v x-terminal-emulator >/dev/null 2>&1; then
+		TERM_BIN="x-terminal-emulator"
+		return 0
+	fi
+	# 3. freedesktop xdg-terminal-exec (draft spec)
+	if command -v xdg-terminal-exec >/dev/null 2>&1; then
+		TERM_BIN="xdg-terminal-exec"
+		return 0
+	fi
+	# 4. desktop environment configured default terminal.
+	#    NOTE: GNOME 48+ returns the spec name "xdg-terminal-exec" here,
+	#    which is not a binary - skip it and keep looking.
+	if command -v gsettings >/dev/null 2>&1; then
+		TERM_NAME=$(gsettings get org.gnome.desktop.default-applications.terminal exec 2>/dev/null)
+		TERM_NAME=${TERM_NAME#\'}; TERM_NAME=${TERM_NAME%\'}
+		if [ -n "$TERM_NAME" ] && [ "$TERM_NAME" != "xdg-terminal-exec" ] \
+			&& command -v "$TERM_NAME" >/dev/null 2>&1; then
+			TERM_BIN="$TERM_NAME"
+			return 0
+		fi
+	fi
+	for kc in kreadconfig6 kreadconfig5 kreadconfig; do
+		if command -v "$kc" >/dev/null 2>&1; then
+			TERM_NAME=$("$kc" --file kdeglobals --group General --key TerminalApplication 2>/dev/null)
+			if [ -n "$TERM_NAME" ] && command -v "$TERM_NAME" >/dev/null 2>&1; then
+				TERM_BIN="$TERM_NAME"
+				return 0
+			fi
 		fi
 	done
-	if [ -n "$TERM_BIN" ]; then
-		case "$TERM_BIN" in
-			gnome-terminal|kgx)
-				exec "$TERM_BIN" -- "$APP" -h
-				;;
-			*)
-				exec "$TERM_BIN" -e "$APP" -h
-				;;
-		esac
+	if command -v xfconf-query >/dev/null 2>&1; then
+		TERM_NAME=$(xfconf-query -c xfce4-session -p /general/TerminalEmulator 2>/dev/null)
+		if [ -n "$TERM_NAME" ] && command -v "$TERM_NAME" >/dev/null 2>&1; then
+			TERM_BIN="$TERM_NAME"
+			return 0
+		fi
+	fi
+	# 5. fallback: scan common terminals
+	for t in ptyxis kgx konsole gnome-terminal xfce4-terminal mate-terminal \
+		lxterminal terminator kitty alacritty wezterm foot tilix qterminal \
+		sakura urxvt xterm; do
+		if command -v "$t" >/dev/null 2>&1; then
+			TERM_BIN="$t"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Launch a command in the found terminal, using the right flag per terminal.
+_run_in_terminal() {
+	TERM_NAME=${TERM_BIN%% *}
+	case "$TERM_NAME" in
+		xdg-terminal-exec)
+			exec xdg-terminal-exec "$@"
+			;;
+		gnome-terminal|kgx)
+			# shellcheck disable=SC2086
+			exec $TERM_BIN -- "$@"
+			;;
+		ptyxis)
+			# shellcheck disable=SC2086
+			exec $TERM_BIN -x "$@"
+			;;
+		*)
+			# shellcheck disable=SC2086
+			exec $TERM_BIN -e "$@"
+			;;
+	esac
+}
+
+# Double-clicked from a file manager: no arguments and no terminal.
+if [ -z "$1" ] && [ ! -t 1 ]; then
+	if _find_terminal; then
+		_run_in_terminal "$APP" -h
 	fi
 	>&2 echo "AM is a terminal program, please run it from a terminal."
 	exit 1

--- a/appimage/hooks/90-am-appimage-interface.hook
+++ b/appimage/hooks/90-am-appimage-interface.hook
@@ -1,14 +1,16 @@
 #!/bin/sh
 # Runs AFTER 10-self-updater.hook (the update check has already started).
 # Provides the GUI entry points of this terminal application:
-#   * double-click (no arguments, no terminal) -> open a terminal with the
-#     help screen, otherwise nothing would be visible
+#   * double-click (no arguments, no terminal):
+#       - if "am" or "appman" is already installed -> open a terminal with its
+#         help screen
+#       - otherwise -> open a terminal with the embedded installer, so the user
+#         can install this very AppImage as "am" (system-wide) or "appman"
+#         (local)
 #   * `setup` / `--install`                    -> run the embedded upstream
 #     installer to install AM (system-wide) or AppMan (local)
 # Every other invocation returns to the default AppRun behaviour: run the
 # bundled 'appman' with the given arguments.
-
-APP="$APPDIR/bin/appman"
 
 # Find the user's terminal, in order of preference:
 #   $TERMINAL  ->  x-terminal-emulator (Debian alternatives)
@@ -80,7 +82,8 @@ _find_terminal() {
 # print its own help and exit without showing anything). The window is kept
 # open until ENTER is pressed so the output stays visible.
 _run_in_terminal() {
-	_script="'$APP' -h; printf '\\n\\n'; echo 'Press ENTER to close this window...'; read _"
+	_cmd="$1"
+	_script="$_cmd; printf '\\n\\n'; echo 'Press ENTER to close this window...'; read _"
 	TERM_NAME=${TERM_BIN%% *}
 	case "$TERM_NAME" in
 		xdg-terminal-exec)
@@ -100,10 +103,21 @@ _run_in_terminal() {
 	esac
 }
 
-# Double-clicked from a file manager: no arguments and no terminal.
+# Double-clicked from a file manager: no arguments and no terminal. If "am" or
+# "appman" is already installed on the system, open a terminal with its help
+# screen; otherwise open the embedded installer so the user can install this
+# AppImage as "am" or "appman" (see INSTALL and AM-INSTALLER).
 if [ -z "$1" ] && [ ! -t 1 ]; then
+	BINDIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+	if command -v am >/dev/null 2>&1 && [ -e /opt/am/APP-MANAGER ]; then
+		_cmd="am -h"
+	elif [ -x "$BINDIR/appman" ]; then
+		_cmd="$BINDIR/appman -h"
+	else
+		_cmd="$APPDIR/AM-INSTALLER"
+	fi
 	if _find_terminal; then
-		_run_in_terminal "$APP" -h
+		_run_in_terminal "$_cmd"
 	fi
 	>&2 echo "AM is a terminal program, please run it from a terminal."
 	exit 1

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -60,6 +60,11 @@ export ADD_HOOKS="self-updater.hook"
 export UPINFO="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}|latest|*$ARCH.AppImage.zsync"
 export ICON="$PWD/logo.png"
 export DESKTOP="$PWD/appimage/APP-MANAGER.desktop"
+# TEMPORARY: quick-sharun still defaults to sharun 2.3.0, which does not
+# ship builds for riscv64/loongarch64/ppc64/ppc64le - those were added in
+# sharun 3.0.0. This override can be removed once quick-sharun bumps its
+# default SHARUN_LINK.
+export SHARUN_LINK="${SHARUN_LINK:-https://github.com/pkgforge-dev/sharun/releases/download/3.0.0/sharun-$APPIMAGE_ARCH}"
 
 # Deploy the 'appman' script together with the tools that AM may call but
 # that are missing from some distros (curl, wget, 7z, tar, unzip, xz, ...).

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -60,9 +60,6 @@ export ADD_HOOKS="self-updater.hook"
 export UPINFO="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}|latest|*$ARCH.AppImage.zsync"
 export ICON="$PWD/logo.png"
 export DESKTOP="$PWD/appimage/APP-MANAGER.desktop"
-# "AM" is a shell script: there are no dlopened libraries to discover and
-# running it in the build container would only print its usage screen.
-export STRACE_MODE=0
 
 # Deploy the 'appman' script together with the tools that AM may call but
 # that are missing from some distros (curl, wget, 7z, tar, unzip, xz, ...).

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -3,22 +3,15 @@
 set -eu
 
 ARCH=$(uname -m)
-
-# Defensive: this script can be run from inside an AppImage environment
-# (e.g. a FUSE-mounted shell/editor) which exports APPDIR/APPIMAGE and
-# friends pointing at the outer AppImage. Ignore any inherited values.
-unset APPDIR APPIMAGE APPIMAGE_ARCH APPIMAGE_TARGET_DIR APPIMAGE_EXTRACT_AND_RUN \
-	ARG0 ARGV0 SHARUN_DIR SHARUN_LIB_DIR HOST_PATH 2>/dev/null || :
-
-export ARCH APPIMAGE_ARCH="$ARCH"
+export ARCH
 
 # This script is meant to be run from the repository root (the CI checks it
 # out), so the checkout itself is the source for the AppImage. This way a
 # pull request that changes APP-MANAGER produces an AppImage of that same
 # code, and the resulting AppImage can be tested before merging.
 UPSTREAM_DIR="$PWD"
-APPDIR="$PWD/AppDir"
-export APPDIR
+APP_DIR="$PWD/AppDir"
+export APP_DIR
 
 echo "---------------------------------------------------------------"
 echo "Building the \"AM\" AppImage..."
@@ -32,48 +25,48 @@ echo "Version: $VERSION"
 echo "---------------------------------------------------------------"
 echo "Preparing AppDir..."
 echo "---------------------------------------------------------------"
-rm -rf "$APPDIR"
-mkdir -p "$APPDIR/bin"
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/bin"
 
 # Desktop entry + icon
-cp "$PWD/appimage/APP-MANAGER.desktop" "$APPDIR/APP-MANAGER.desktop"
-cp "$PWD/logo.png" "$APPDIR/logo.png"
+cp "$PWD/appimage/APP-MANAGER.desktop" "$APP_DIR/APP-MANAGER.desktop"
+cp "$PWD/logo.png" "$APP_DIR/logo.png"
 
 # Main executable: the APP-MANAGER, named 'appman' so it runs in
 # portable/AppMan mode. AppDir/bin is prepended to PATH by the generated
 # AppRun, so all bundled tools below are found by AM automatically.
-cp "$UPSTREAM_DIR/APP-MANAGER" "$APPDIR/bin/appman"
-chmod a+x "$APPDIR/bin/appman"
+cp "$UPSTREAM_DIR/APP-MANAGER" "$APP_DIR/bin/appman"
+chmod a+x "$APP_DIR/bin/appman"
 
 # Upstream installer, reachable via `AM-*.AppImage setup`. INSTALL is renamed
 # "INSTALL-AM-APPIMAGE.sh" so that INSTALL itself detects the AppImage flow
 # (see the top of INSTALL) and installs this very AppImage as "am".
-cp "$UPSTREAM_DIR/INSTALL" "$APPDIR/INSTALL-AM-APPIMAGE.sh"
-cp "$UPSTREAM_DIR/AM-INSTALLER" "$APPDIR/AM-INSTALLER"
-chmod a+x "$APPDIR/INSTALL-AM-APPIMAGE.sh" "$APPDIR/AM-INSTALLER"
+cp "$UPSTREAM_DIR/INSTALL" "$APP_DIR/INSTALL-AM-APPIMAGE.sh"
+cp "$UPSTREAM_DIR/AM-INSTALLER" "$APP_DIR/AM-INSTALLER"
+chmod a+x "$APP_DIR/INSTALL-AM-APPIMAGE.sh" "$APP_DIR/AM-INSTALLER"
 
 # Bundle the static appimageupdatetool binary (pkgforge-dev/AppImageUpdate),
 # so that the AppImage can update itself in place (see "_sync_amcli" in
 # APP-MANAGER). It is a self-contained static binary, so it only needs to be
-# placed in $APPDIR/bin - no libraries to bundle with it.
+# placed in $APP_DIR/bin - no libraries to bundle with it.
 echo "---------------------------------------------------------------"
 echo "Bundling appimageupdatetool..."
 echo "---------------------------------------------------------------"
-APPIMAGEUPDATETOOL_LINK="${APPIMAGEUPDATETOOL_LINK:-https://github.com/pkgforge-dev/AppImageUpdate/releases/latest/download/appimageupdate-$APPIMAGE_ARCH-linux}"
+APPIMAGEUPDATETOOL_LINK="${APPIMAGEUPDATETOOL_LINK:-https://github.com/pkgforge-dev/AppImageUpdate/releases/latest/download/appimageupdate-$ARCH-linux}"
 if command -v wget >/dev/null 2>&1; then
-	wget -q -O "$APPDIR/bin/appimageupdatetool" "$APPIMAGEUPDATETOOL_LINK" \
-		&& chmod a+x "$APPDIR/bin/appimageupdatetool" \
+	wget -q -O "$APP_DIR/bin/appimageupdatetool" "$APPIMAGEUPDATETOOL_LINK" \
+		&& chmod a+x "$APP_DIR/bin/appimageupdatetool" \
 		|| echo "  WARNING: could not download appimageupdatetool, skipping"
 elif command -v curl >/dev/null 2>&1; then
-	curl -sL -o "$APPDIR/bin/appimageupdatetool" "$APPIMAGEUPDATETOOL_LINK" \
-		&& chmod a+x "$APPDIR/bin/appimageupdatetool" \
+	curl -sL -o "$APP_DIR/bin/appimageupdatetool" "$APPIMAGEUPDATETOOL_LINK" \
+		&& chmod a+x "$APP_DIR/bin/appimageupdatetool" \
 		|| echo "  WARNING: could not download appimageupdatetool, skipping"
 else
 	echo "  WARNING: neither wget nor curl available, not bundling appimageupdatetool"
 fi
 
 # Our hooks (run before/after the bundled self-updater hook)
-cp "$PWD"/appimage/hooks/*.hook "$APPDIR/bin/"
+cp "$PWD"/appimage/hooks/*.hook "$APP_DIR/bin/"
 
 echo "---------------------------------------------------------------"
 echo "Deploying with quick-sharun..."
@@ -83,11 +76,6 @@ export ADD_HOOKS="self-updater.hook"
 export UPINFO="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}|latest|*$ARCH.AppImage.zsync"
 export ICON="$PWD/logo.png"
 export DESKTOP="$PWD/appimage/APP-MANAGER.desktop"
-# TEMPORARY: quick-sharun still defaults to sharun 2.3.0, which does not
-# ship builds for riscv64/loongarch64/ppc64/ppc64le - those were added in
-# sharun 3.0.0. This override can be removed once quick-sharun bumps its
-# default SHARUN_LINK.
-export SHARUN_LINK="${SHARUN_LINK:-https://github.com/pkgforge-dev/sharun/releases/download/3.0.0/sharun-$APPIMAGE_ARCH}"
 
 # Deploy the 'appman' script together with the tools that AM may call but
 # that are missing from some distros (curl, wget, 7z, tar, unzip, xz, ...).
@@ -120,9 +108,9 @@ if [ "${DEPLOY_AM_DEPS:-1}" = 1 ]; then
 		/usr/bin/grep
 		/usr/bin/sed
 	"
-	set -- "$APPDIR/bin/appman" $DEP_DEPS
+	set -- "$APP_DIR/bin/appman" $DEP_DEPS
 else
-	set -- "$APPDIR/bin/appman"
+	set -- "$APP_DIR/bin/appman"
 fi
 # Warn (but keep going) if a bundled dependency is not present on the
 # build system - quick-sharun would silently skip missing files.

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+
+set -eu
+
+ARCH=$(uname -m)
+
+# Defensive: this script can be run from inside an AppImage environment
+# (e.g. a FUSE-mounted shell/editor) which exports APPDIR/APPIMAGE and
+# friends pointing at the outer AppImage. Ignore any inherited values.
+unset APPDIR APPIMAGE APPIMAGE_ARCH APPIMAGE_TARGET_DIR APPIMAGE_EXTRACT_AND_RUN \
+	ARG0 ARGV0 SHARUN_DIR SHARUN_LIB_DIR HOST_PATH 2>/dev/null || :
+
+export ARCH APPIMAGE_ARCH="$ARCH"
+
+# This script is meant to be run from the repository root (the CI checks it
+# out), so the checkout itself is the source for the AppImage. This way a
+# pull request that changes APP-MANAGER produces an AppImage of that same
+# code, and the resulting AppImage can be tested before merging.
+UPSTREAM_DIR="$PWD"
+APPDIR="$PWD/AppDir"
+export APPDIR
+
+echo "---------------------------------------------------------------"
+echo "Building the \"AM\" AppImage..."
+echo "---------------------------------------------------------------"
+
+VERSION=$(grep -m1 '^AMVERSION=' "$UPSTREAM_DIR/APP-MANAGER" | sed 's/.*="\([^"]*\)".*/\1/')
+[ -n "$VERSION" ] || { echo "ERROR: could not determine the version!"; exit 1; }
+export VERSION
+echo "Version: $VERSION"
+
+echo "---------------------------------------------------------------"
+echo "Preparing AppDir..."
+echo "---------------------------------------------------------------"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/bin"
+
+# Desktop entry + icon
+cp "$PWD/appimage/APP-MANAGER.desktop" "$APPDIR/APP-MANAGER.desktop"
+cp "$PWD/logo.png" "$APPDIR/logo.png"
+
+# Main executable: the APP-MANAGER, named 'appman' so it runs in
+# portable/AppMan mode. AppDir/bin is prepended to PATH by the generated
+# AppRun, so all bundled tools below are found by AM automatically.
+cp "$UPSTREAM_DIR/APP-MANAGER" "$APPDIR/bin/appman"
+chmod a+x "$APPDIR/bin/appman"
+
+# Upstream installer, reachable via `AM-*.AppImage setup`
+cp "$UPSTREAM_DIR/INSTALL" "$UPSTREAM_DIR/AM-INSTALLER" "$APPDIR/"
+chmod a+x "$APPDIR/INSTALL" "$APPDIR/AM-INSTALLER"
+
+# Our hooks (run before/after the bundled self-updater hook)
+cp "$PWD"/appimage/hooks/*.hook "$APPDIR/bin/"
+
+echo "---------------------------------------------------------------"
+echo "Deploying with quick-sharun..."
+echo "---------------------------------------------------------------"
+export OUTPATH="$PWD/dist"
+export ADD_HOOKS="self-updater.hook"
+export UPINFO="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}|latest|*$ARCH.AppImage.zsync"
+export ICON="$PWD/logo.png"
+export DESKTOP="$PWD/appimage/APP-MANAGER.desktop"
+# "AM" is a shell script: there are no dlopened libraries to discover and
+# running it in the build container would only print its usage screen.
+export STRACE_MODE=0
+
+# Deploy the 'appman' script together with the tools that AM may call but
+# that are missing from some distros (curl, wget, 7z, tar, unzip, xz, ...).
+# quick-sharun bundles each binary together with its libraries and glibc
+# (DEPLOY_GLIBC is enabled automatically), which makes the resulting
+# AppImage fully self-contained and portable. Set DEPLOY_AM_DEPS=0 to skip
+# this and rely on AM's built-in fallback.
+if [ "${DEPLOY_AM_DEPS:-1}" = 1 ]; then
+	DEP_DEPS="
+		/usr/bin/curl
+		/usr/bin/wget
+		/usr/lib/7zip/7z
+		/usr/bin/ar
+		/usr/bin/column
+		/usr/bin/du
+		/usr/bin/file
+		/usr/bin/md5sum
+		/usr/bin/mv
+		/usr/bin/sha1sum
+		/usr/bin/sha256sum
+		/usr/bin/sha512sum
+		/usr/bin/tar
+		/usr/bin/unxz
+		/usr/bin/unzip
+		/usr/bin/xz
+		/usr/bin/xzcat
+		/usr/bin/cat
+		/usr/bin/chmod
+		/usr/bin/chown
+		/usr/bin/grep
+		/usr/bin/sed
+	"
+	set -- "$APPDIR/bin/appman" $DEP_DEPS
+else
+	set -- "$APPDIR/bin/appman"
+fi
+# Warn (but keep going) if a bundled dependency is not present on the
+# build system - quick-sharun would silently skip missing files.
+for d do
+	[ -e "$d" ] || echo "  WARNING: $d not found, not bundling it"
+done
+quick-sharun "$@"
+
+echo "---------------------------------------------------------------"
+echo "Making the AppImage..."
+echo "---------------------------------------------------------------"
+quick-sharun --make-appimage
+
+echo "---------------------------------------------------------------"
+echo "Testing the AppImage..."
+echo "---------------------------------------------------------------"
+# uruntime falls back to extract-and-run when FUSE is unavailable (CI)
+export APPIMAGE_EXTRACT_AND_RUN=1 APPIMAGE_TARGET_DIR="$PWD/_test-app"
+# AM is a CLI that exits immediately, so use --simple-test (the full --test
+# expects the app to stay running for 12 seconds).
+quick-sharun --simple-test ./dist/*.AppImage -v

--- a/appimage/make-appimage.sh
+++ b/appimage/make-appimage.sh
@@ -45,9 +45,32 @@ cp "$PWD/logo.png" "$APPDIR/logo.png"
 cp "$UPSTREAM_DIR/APP-MANAGER" "$APPDIR/bin/appman"
 chmod a+x "$APPDIR/bin/appman"
 
-# Upstream installer, reachable via `AM-*.AppImage setup`
-cp "$UPSTREAM_DIR/INSTALL" "$UPSTREAM_DIR/AM-INSTALLER" "$APPDIR/"
-chmod a+x "$APPDIR/INSTALL" "$APPDIR/AM-INSTALLER"
+# Upstream installer, reachable via `AM-*.AppImage setup`. INSTALL is renamed
+# "INSTALL-AM-APPIMAGE.sh" so that INSTALL itself detects the AppImage flow
+# (see the top of INSTALL) and installs this very AppImage as "am".
+cp "$UPSTREAM_DIR/INSTALL" "$APPDIR/INSTALL-AM-APPIMAGE.sh"
+cp "$UPSTREAM_DIR/AM-INSTALLER" "$APPDIR/AM-INSTALLER"
+chmod a+x "$APPDIR/INSTALL-AM-APPIMAGE.sh" "$APPDIR/AM-INSTALLER"
+
+# Bundle the static appimageupdatetool binary (pkgforge-dev/AppImageUpdate),
+# so that the AppImage can update itself in place (see "_sync_amcli" in
+# APP-MANAGER). It is a self-contained static binary, so it only needs to be
+# placed in $APPDIR/bin - no libraries to bundle with it.
+echo "---------------------------------------------------------------"
+echo "Bundling appimageupdatetool..."
+echo "---------------------------------------------------------------"
+APPIMAGEUPDATETOOL_LINK="${APPIMAGEUPDATETOOL_LINK:-https://github.com/pkgforge-dev/AppImageUpdate/releases/latest/download/appimageupdate-$APPIMAGE_ARCH-linux}"
+if command -v wget >/dev/null 2>&1; then
+	wget -q -O "$APPDIR/bin/appimageupdatetool" "$APPIMAGEUPDATETOOL_LINK" \
+		&& chmod a+x "$APPDIR/bin/appimageupdatetool" \
+		|| echo "  WARNING: could not download appimageupdatetool, skipping"
+elif command -v curl >/dev/null 2>&1; then
+	curl -sL -o "$APPDIR/bin/appimageupdatetool" "$APPIMAGEUPDATETOOL_LINK" \
+		&& chmod a+x "$APPDIR/bin/appimageupdatetool" \
+		|| echo "  WARNING: could not download appimageupdatetool, skipping"
+else
+	echo "  WARNING: neither wget nor curl available, not bundling appimageupdatetool"
+fi
 
 # Our hooks (run before/after the bundled self-updater hook)
 cp "$PWD"/appimage/hooks/*.hook "$APPDIR/bin/"


### PR DESCRIPTION
## What

Adds an optional GitHub Actions workflow that builds a **portable AppMan AppImage** of AM using **quick-sharun** (sharun runtime + uruntime).

This follows the suggestions from #2695: *"build the AppImage on a distribution (Arch Linux for example) using a better runtime (like sharun) and for all architectures"*.

## How it works

- The AppImage runs `APP-MANAGER` directly as a local/portable **`appman`** — no installation needed, no root required:
  ```
  ./AM-10.5-anylinux-x86_64.AppImage -h
  ./AM-10.5-anylinux-x86_64.AppImage -i firefox
  ```
- AM's dependencies that are missing on some distros (`curl`, `wget`, `7z`, `tar`, `unzip`, `xz`, `file`, checksums, ...) are bundled together with their libraries and glibc, so the AppImage is self-contained and works offline.
- The static **`appimageupdatetool`** ([pkgforge-dev/AppImageUpdate](https://github.com/pkgforge-dev/AppImageUpdate)) is bundled too, so the AppImage updates itself in place from the GitHub releases, and `appman -s` from inside the AppImage triggers that update.
- No FUSE required (uruntime), works on old and musl-based distros.
- **Beginner friendly**: double-clicking the AppImage — when "am"/"appman" is not installed yet — opens a terminal with the embedded installer, so you can install **this very AppImage** as "am" system-wide or as "appman" locally; if already installed it opens a terminal with its help screen. `AM-*.AppImage setup` always runs that installer.
- The workflow is triggered when a new **version-tagged GitHub release is published** (e.g. `10.5`), and attaches the freshly built `AM-*.AppImage` + `.zsync` to that very release — so the AppImage always ships all the bugfixes of the corresponding version. (Also runs on PRs that touch `APP-MANAGER` or `appimage/**` for testing, without releasing.)

## Architectures

Currently built: **`x86_64`** and **`aarch64`**, each inside its own Arch Linux container image ([pkgforge-dev/docker-archlinux](https://github.com/pkgforge-dev/docker-archlinux)) on native GitHub Actions runners.

The build infrastructure also supports **`riscv64`**, **`loongarch64`** and **`ppc64le`** (their Arch Linux ports are emulated with QEMU on an x86_64 runner — the architecture-specific build tools appimagetool/sharun/mkdwarfs, themselves zig-cross-built upstream, must run on the target arch). These are currently **disabled** in the matrix, because AM's database does not ship installation scripts for those architectures yet (see the `programs/` directory). They are commented out in [.github/workflows/appimage.yml](.github/workflows/appimage.yml) and can be re-enabled once app repos for those architectures are introduced.

> `powerpc64` (big-endian) is not supported: `tonistiigi/binfmt` does not register a `qemu-ppc64` handler, so it cannot be emulated.

## Changes

- **`APP-MANAGER`**: detects the AppImage runtime (`IS_APPIMAGE`) and derives the CLI name from the AppImage file itself — installed as `APP-MANAGER` it acts as `am`, installed as `appman` it acts as `appman`. `_sync_amcli` updates the AppImage in place via the bundled `appimageupdatetool`, and `devmode` is disabled in AppImage mode. Both are no-ops for classic script installs (`$APPIMAGE` is empty).
- **`INSTALL`** + **`AM-INSTALLER`**: when run from inside the AppImage they install **the AppImage file itself** as `am` (moved to `/opt/am/APP-MANAGER` + symlink) or as `appman` (moved to `~/.local/bin/appman`), instead of downloading the plain script.
- **`appimage/`** (new): `make-appimage.sh`, `get-dependencies.sh` (self-contained container setup: pacman keyring, packages, quick-sharun), `APP-MANAGER.desktop`, and two runtime hooks (self-updater env + terminal/installer interface).
- **`.github/workflows/appimage.yml`** (new): x86_64 + aarch64 build, attached to the triggering release, with the QEMU matrix entries ready to enable.
- **`README.md`**: documents the build.

Module handling is deliberately left as in the script-based install (unlike #2695): the AppImage updates its modules in the writable apps dir exactly like a normal AppMan.

## Notes / open questions

- The release job attaches the AppImages to the release that triggered the workflow (the existing version-tagged releases like `10.5`). If you'd rather use a different tag scheme, that's easy to adjust.
- The added files are contributed under the repository's GPL-3.0 license.

Demo AppImage built and tested from this branch (x86_64): version output, `-l` listing, the `appman -s` AppImage-update path and the devmode guard all work.